### PR TITLE
Add minimal PWA skeleton with dataset publish task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 
 # Build outputs (later steps)
 /build/
+/public/build/

--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ clojure -M -m vgm.cli 3 # 3問
 * `resources/data/tracks.edn` を読み込み
 * 簡単な問題をランダム生成（作曲者/作品など）
 * 正解・不正解の判定とスコア表示
+
+## Web Preview
+
+```bash
+clojure -T:build publish
+python -m http.server -d public 4444
+# or: npx serve public
+```
+
+Index page displays dataset version and track count.

--- a/build.clj
+++ b/build.clj
@@ -25,3 +25,9 @@
                 :tracks items}]
     (spit (io/file "build/dataset.json")
           (json/write-str out))))
+
+(defn publish [_]
+  (dataset nil)
+  (ensure-dir "public/build")
+  (io/copy (io/file "build/dataset.json")
+           (io/file "public/build/dataset.json")))

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,13 @@
+async function load() {
+  try {
+    const res = await fetch('./build/dataset.json');
+    const data = await res.json();
+    const info = document.getElementById('info');
+    info.textContent = `dataset_version: ${data.dataset_version}, tracks: ${data.tracks.length}`;
+  } catch (err) {
+    console.error('Failed to load dataset', err);
+  }
+}
+
+load();
+

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>VGM Quiz</title>
+  <link rel="manifest" href="manifest.webmanifest" />
+</head>
+<body>
+  <h1>VGM Quiz</h1>
+  <div id="info"></div>
+  <script src="app.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('sw.js');
+    }
+  </script>
+</body>
+</html>
+

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,9 @@
+{
+  "name": "VGM Quiz",
+  "short_name": "VGM Quiz",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff"
+}
+

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,26 @@
+const CACHE_NAME = 'pwa-cache-v1';
+const CORE_ASSETS = [
+  './',
+  './index.html',
+  './app.js',
+  './manifest.webmanifest'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(CORE_ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      const fetchPromise = fetch(event.request).then(response => {
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, response.clone()));
+        return response;
+      });
+      return cached || fetchPromise;
+    })
+  );
+});
+


### PR DESCRIPTION
## Summary
- serve static web assets under `public/` with a simple PWA setup
- add `publish` build task to copy generated dataset to `public/build/`
- document building and previewing the web app

## Testing
- `clojure -T:build publish` *(fails: command not found)*
- `[ -f public/build/dataset.json ]` *(fails: missing)*
- `grep -q serviceWorker public/index.html && echo found || echo notfound`
- `grep -q manifest.webmanifest public/index.html && echo found || echo notfound`


------
https://chatgpt.com/codex/tasks/task_e_68ad880deeb083248ae5aeaf8c279aa9