### PR TITLE
Minimal playable web quiz (JS)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,13 +1,110 @@
-async function load() {
+let tracks = [];
+let questions = [];
+let current = 0;
+let score = 0;
+let awaitingNext = false;
+
+function showView(id) {
+  document.getElementById('start-view').style.display = id === 'start-view' ? 'block' : 'none';
+  document.getElementById('question-view').style.display = id === 'question-view' ? 'block' : 'none';
+  document.getElementById('result-view').style.display = id === 'result-view' ? 'block' : 'none';
+}
+
+function norm(str) {
+  return str.normalize('NFKC').trim().toLowerCase();
+}
+
+async function loadDataset() {
   try {
     const res = await fetch('./build/dataset.json');
     const data = await res.json();
-    const info = document.getElementById('info');
-    info.textContent = `dataset_version: ${data.dataset_version}, tracks: ${data.tracks.length}`;
+    tracks = data.tracks;
+    document.getElementById('start-btn').disabled = false;
   } catch (err) {
     console.error('Failed to load dataset', err);
   }
 }
 
-load();
+function startQuiz() {
+  const countInput = document.getElementById('count');
+  let n = parseInt(countInput.value, 10);
+  if (!n || n < 1) n = 1;
+  n = Math.min(n, tracks.length);
+  const shuffled = [...tracks].sort(() => Math.random() - 0.5).slice(0, n);
+  const types = ['title-game', 'game-composer', 'title-composer'];
+  questions = shuffled.map(track => ({ track, type: types[Math.floor(Math.random() * types.length)] }));
+  current = 0;
+  score = 0;
+  showQuestion();
+}
 
+function showQuestion() {
+  awaitingNext = false;
+  showView('question-view');
+  const q = questions[current];
+  const prompt = document.getElementById('prompt');
+  const answer = document.getElementById('answer');
+  const submit = document.getElementById('submit-btn');
+  const feedback = document.getElementById('feedback');
+  answer.value = '';
+  feedback.textContent = '';
+  submit.textContent = 'Submit';
+  switch (q.type) {
+    case 'title-game':
+      prompt.textContent = `Which game is the track "${q.track.title}" from?`;
+      q.expected = q.track.game;
+      break;
+    case 'game-composer':
+      prompt.textContent = `Who composed the music for "${q.track.game}"?`;
+      q.expected = q.track.composer;
+      break;
+    case 'title-composer':
+      prompt.textContent = `Who composed the track "${q.track.title}"?`;
+      q.expected = q.track.composer;
+      break;
+  }
+}
+
+function submitAnswer() {
+  if (awaitingNext) {
+    nextQuestion();
+    return;
+  }
+  const q = questions[current];
+  const userAns = norm(document.getElementById('answer').value);
+  const expected = norm(q.expected);
+  const feedback = document.getElementById('feedback');
+  if (userAns === expected) {
+    score++;
+    feedback.textContent = 'Correct!';
+  } else {
+    feedback.textContent = `Incorrect. Correct: ${q.expected}`;
+  }
+  const submit = document.getElementById('submit-btn');
+  submit.textContent = current === questions.length - 1 ? 'Finish' : 'Next';
+  awaitingNext = true;
+}
+
+function nextQuestion() {
+  current++;
+  if (current >= questions.length) {
+    showResult();
+  } else {
+    showQuestion();
+  }
+}
+
+function showResult() {
+  showView('result-view');
+  document.getElementById('final-score').textContent = `Score: ${score}/${questions.length}`;
+}
+
+function restart() {
+  showView('start-view');
+}
+
+document.getElementById('start-btn').addEventListener('click', startQuiz);
+document.getElementById('submit-btn').addEventListener('click', submitAnswer);
+document.getElementById('restart-btn').addEventListener('click', restart);
+
+loadDataset();

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,24 @@
 </head>
 <body>
   <h1>VGM Quiz</h1>
-  <div id="info"></div>
+
+  <div id="start-view">
+    <label>Questions: <input id="count" type="number" min="1" value="5" /></label>
+    <button id="start-btn" disabled>Start</button>
+  </div>
+
+  <div id="question-view" style="display:none">
+    <div id="prompt"></div>
+    <input id="answer" type="text" autocomplete="off" />
+    <button id="submit-btn">Submit</button>
+    <div id="feedback"></div>
+  </div>
+
+  <div id="result-view" style="display:none">
+    <div id="final-score"></div>
+    <button id="restart-btn">Restart</button>
+  </div>
+
   <script src="app.js"></script>
   <script>
     if ('serviceWorker' in navigator) {
@@ -16,4 +33,3 @@
   </script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- Implement a three-view UI for starting, answering, and reviewing quiz results
- Add quiz logic to fetch the dataset, randomize tracks and question types, normalize answers, and tally score

## Testing
- `test -f public/index.html`
- `test -f public/app.js`
- `grep -q serviceWorker public/index.html`
- `grep -q manifest.webmanifest public/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68ad968c0b788324beb56cd51e481319