### PR TITLE
feat: add deterministic track IDs

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,11 +1,10 @@
 # Project Status
 
 ## Current Step
-5 - Minimal web quiz playable
+6a - Add stable track IDs
 
 ## Next Step
-- 6a - Add stable track IDs
-- 6b - IndexedDB history
+6b - IndexedDB history
 
 ## Implemented
 - Step 1: Initial CLI prototype
@@ -13,9 +12,9 @@
 - Step 3: Quiz generation and scoring
 - Step 4: Web build pipeline
 - Step 5: Minimal web quiz playable
+- Step 6a: Add stable track IDs
 
 ## Open Tasks
-- Add stable track IDs
 - Implement IndexedDB history
 
 ## How to Run

--- a/build.clj
+++ b/build.clj
@@ -3,7 +3,8 @@
             [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.data.json :as json])
-  (:import (java.io PushbackReader)))
+  (:import (java.io PushbackReader)
+           (java.util UUID)))
 
 (defn clean [_]
   (b/delete {:path "build"}))
@@ -15,16 +16,27 @@
   (with-open [r (io/reader f)]
     (edn/read (PushbackReader. r))))
 
+(defn- ensure-track-id [track]
+  (if (:track/id track)
+    track
+    (let [s (str (:title track) "|" (:game track) "|" (:composer track) "|" (:year track))]
+      (assoc track :track/id
+             (str (UUID/nameUUIDFromBytes (.getBytes s "UTF-8")))))))
+
 (defn dataset [_]
   (ensure-dir "build")                       ;; ← ここで作成
   (let [files  (->> (file-seq (io/file "resources/data"))
                     (filter #(-> % .getName (.endsWith ".edn"))))
         items  (->> files (map read-edn-file) (mapcat identity) vec)
+        tracks (mapv ensure-track-id items)
         out    {:dataset_version 1
                 :generated_at (str (java.time.Instant/now))
-                :tracks items}]
+                :tracks tracks}]
     (spit (io/file "build/dataset.json")
-          (json/write-str out))))
+          (json/write-str out :key-fn (fn [k]
+                                       (if-let [ns (namespace k)]
+                                         (str ns "/" (name k))
+                                         (name k))))))
 
 (defn publish [_]
   (dataset nil)


### PR DESCRIPTION
## Summary
- generate deterministic track IDs using name-based UUIDs
- include track IDs in exported JSON
- document completion of step 6a and advance to step 6b

## Testing
- `grep -q "track/id" build.clj`
- `grep -q "publish" build.clj`
- `test -f PROJECT_STATUS.md`
- `grep -q "Next Step" PROJECT_STATUS.md`


------
https://chatgpt.com/codex/tasks/task_e_68ad9e879084832492d08d004f3a9925