### PR TITLE
chore: share CLJC core skeleton

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,7 +1,7 @@
 # Project Status
 
 ## Current Step
-6b - IndexedDB history
+7b - CLJC core skeleton
 
 ## Next Step
 7a - Aliases on web
@@ -14,6 +14,7 @@
 - Step 5: Minimal web quiz playable
 - Step 6a: Add stable track IDs
 - Step 6b: IndexedDB history
+- Step 7b: CLJC core skeleton
 - GitHub Actions CI
 - CI stabilized (cache 403 fixed)
 

--- a/src/vgm/core.clj
+++ b/src/vgm/core.clj
@@ -1,9 +1,8 @@
 (ns vgm.core
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
-            [clojure.string :as str]
-            [malli.core :as m])
-  (:import (java.text Normalizer Normalizer$Form)))
+            [vgm.core-shared :as shared]
+            [malli.core :as m]))
 
 
 ;; ----- スキーマ ------------------------------------------------------------
@@ -35,12 +34,6 @@
 ;; --- 同義語辞書の読み込み＆正規化 ----------------------------------------
 
 
-(defn- nfkc [^CharSequence s]
-(Normalizer/normalize (str s) Normalizer$Form/NFKC))
-
-
-(defn base-normalize [s]
-(-> s (or "") nfkc str/trim str/lower-case))
 
 
 (defn load-aliases []
@@ -49,15 +42,15 @@
 (edn/read (java.io.PushbackReader. r)))))
 
 
-(defn- invert-aliases
-"{:game {canon #{a1 a2}} ...} → {normalized-alias canon, ...}"
-[aliases]
-(into {}
-(for [[_cat m] aliases
-[canon vs] m
-:let [canon* (base-normalize canon)]
-v (conj vs canon)]
-[(base-normalize v) canon*])))
+ (defn- invert-aliases
+  "{:game {canon #{a1 a2}} ...} → {normalized-alias canon, ...}"
+  [aliases]
+  (into {}
+    (for [[_cat m] aliases
+          [canon vs] m
+          :let [canon* (shared/normalize canon)]
+          v (conj vs canon)]
+      [(shared/normalize v) canon*])))
 
 
 (defonce ^:private !alias-map (atom nil))
@@ -69,9 +62,7 @@ v (conj vs canon)]
 
 
 (defn canonical [s]
-(let [b (base-normalize s)
-amap (ensure-alias-map)]
-(get amap b b)))
+  (shared/canonical (ensure-alias-map) s))
 
 
 ;; ----- 問題生成 ------------------------------------------------------------
@@ -81,7 +72,7 @@ amap (ensure-alias-map)]
 
 
 (defn normalize [s]
-  (base-normalize s))
+  (shared/normalize s))
 
 
 (defn make-question

--- a/src/vgm/core_shared.cljc
+++ b/src/vgm/core_shared.cljc
@@ -1,0 +1,16 @@
+(ns vgm.core-shared
+  (:require [clojure.string :as str]))
+
+(defn normalize
+  "Normalize a string using NFKC, trim, and lower-case."
+  [s]
+  (let [s (str (or s ""))
+        s #?(:clj  (java.text.Normalizer/normalize s java.text.Normalizer$Form/NFKC)
+               :cljs (.normalize s "NFKC"))]
+    (-> s str/trim str/lower-case)))
+
+(defn canonical
+  "Return canonical form of `s` using normalized alias map `aliases`."
+  [aliases s]
+  (let [norm (normalize s)]
+    (get aliases norm norm)))

--- a/test/vgm/core_shared_test.clj
+++ b/test/vgm/core_shared_test.clj
@@ -1,0 +1,9 @@
+(ns vgm.core-shared-test
+  (:require [clojure.test :refer :all]
+            [vgm.core-shared :as sut]))
+
+(deftest normalize-basic
+  (is (= "hello" (sut/normalize "  HeLLo  "))))
+
+(deftest canonical-basic
+  (is (= "world" (sut/canonical {"hello" "world"} "HELLO"))))


### PR DESCRIPTION
## Summary
- add `vgm.core-shared` with pure `normalize` and `canonical` fns
- refactor `vgm.core` to delegate normalization/canonicalization
- add minimal unit tests and update project status

## Testing
- `test -f src/vgm/core_shared.cljc`
- `grep -iq "defn canonical" src/vgm/core_shared.cljc`
- `test -d test`
- `test -f PROJECT_STATUS.md`


------
https://chatgpt.com/codex/tasks/task_e_68adbb4053848324b5e29b6d7afdd797