### PR TITLE
chore: add sandbox validator

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -16,6 +16,7 @@
 - Step 6b: IndexedDB history
 - GitHub Actions CI
 - CI stabilized (cache 403 fixed)
+- QA-1
 
 ## Open Tasks
 - Implement aliases on web

--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@ python -m http.server -d public 4444
 ```
 
 Index page displays dataset version and track count.
+
+## Codex sandbox validation
+
+Run a small script to verify required files without network access:
+
+```bash
+sh scripts/validate_sandbox.sh web
+sh scripts/validate_sandbox.sh build
+```

--- a/scripts/validate_sandbox.sh
+++ b/scripts/validate_sandbox.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+mode="$1"
+status=0
+
+pass() {
+  printf 'PASS: %s\n' "$1"
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$1"
+  status=1
+}
+
+optfail() {
+  printf 'FAIL: %s (optional)\n' "$1"
+}
+
+case "$mode" in
+  web)
+    [ -f "public/index.html" ] && pass public/index.html || fail public/index.html
+    [ -f "public/app.js" ] && pass public/app.js || fail public/app.js
+    [ -f "public/sw.js" ] && pass public/sw.js || optfail public/sw.js
+    [ -f "public/manifest.webmanifest" ] && pass public/manifest.webmanifest || optfail public/manifest.webmanifest
+    ;;
+  build)
+    if [ -f "build.clj" ]; then
+      pass build.clj
+      grep -q "dataset_version" build.clj && pass "build.clj: dataset_version" || fail "build.clj: dataset_version"
+      grep -q "publish" build.clj && pass "build.clj: publish" || fail "build.clj: publish"
+      grep -q "track/id" build.clj && pass "build.clj: track/id" || fail "build.clj: track/id"
+    else
+      fail build.clj
+    fi
+    ;;
+  aliases)
+    if [ -f "public/build/aliases.json" ]; then
+      pass public/build/aliases.json
+    else
+      optfail public/build/aliases.json
+    fi
+    if [ -f "public/app.js" ]; then
+      if grep -q "aliases" public/app.js; then
+        pass "public/app.js: aliases"
+      else
+        optfail "public/app.js: aliases"
+      fi
+    else
+      optfail public/app.js
+    fi
+    ;;
+  *)
+    echo "usage: $0 {web|build|aliases}" >&2
+    exit 2
+    ;;
+esac
+
+exit $status


### PR DESCRIPTION
## Summary
- add `scripts/validate_sandbox.sh` to check web and build assets in sandbox
- document sandbox validator usage
- mark QA-1 as implemented

## Testing
- `test -f scripts/validate_sandbox.sh`
- `sh scripts/validate_sandbox.sh web`
- `sh scripts/validate_sandbox.sh build`


------
https://chatgpt.com/codex/tasks/task_e_68adbd929eb08324b55a988cd7395794