### PR TITLE
chore: publish code snapshot via GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,26 @@
+name: Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/snapshot.sh
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/deploy-pages@v4

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -32,3 +32,5 @@ python -m http.server -d public 4444
 - CI: clj-kondo via release binary
 - CI: clj-kondo via setup-clojure
 - 2025-08-26: Fix dataset normalization (:id → :track/id); add guard test
+- Enable public code snapshot via GitHub Pages
+

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ python -m http.server -d public 4444
 
 Index page displays dataset version and track count.
 
+## Snapshot
+
+Latest code snapshot: (see GitHub Pages URL after first deploy)
+
 ## Codex sandbox validation
 
 Run a small script to verify required files without network access:
@@ -39,3 +43,4 @@ Run a small script to verify required files without network access:
 sh scripts/validate_sandbox.sh web
 sh scripts/validate_sandbox.sh build
 ```
+

--- a/scripts/snapshot.sh
+++ b/scripts/snapshot.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -eu
+
+OUT=site
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+files="build.clj deps.edn PROJECT_STATUS.md README.md .github/workflows/ci.yml public/index.html public/app.js public/sw.js public/manifest.webmanifest"
+
+for dir in src test; do
+  if [ -d "$dir" ]; then
+    files="$files $(find "$dir" -type f -name '*.clj' | sort)"
+  fi
+done
+
+included=""
+
+for f in $files; do
+  if [ -f "$f" ]; then
+    included="$included $f"
+    rel=$(printf '%s' "$f" | sed 's#^\.##')
+    html="$OUT/$rel.html"
+    mkdir -p "$(dirname "$html")"
+    {
+      printf '<!DOCTYPE html>\n<html><head><meta charset="utf-8"><title>%s</title></head><body><pre><code>' "$f"
+      sed -e 's/&/&amp;/g; s/</&lt;/g; s/>/&gt;/g' "$f"
+      printf '</code></pre></body></html>\n'
+    } > "$html"
+  fi
+done
+
+commit=$(git rev-parse --short HEAD 2>/dev/null || echo "")
+{
+  printf '<!DOCTYPE html>\n<html><head><meta charset="utf-8"><title>Snapshot</title></head><body>\n'
+  printf '<h1>Code Snapshot</h1>\n'
+  if [ -n "$commit" ]; then
+    printf '<p>Commit: %s</p>\n' "$commit"
+  fi
+  printf '<ul>\n'
+  for f in $included; do
+    rel=$(printf '%s' "$f" | sed 's#^\.##')
+    link="$rel.html"
+    text=$(printf '%s' "$f" | sed 's/&/&amp;/g; s/</&lt;/g; s/>/&gt;/g')
+    printf '<li><a href="%s">%s</a></li>\n' "$link" "$text"
+  done
+  printf '</ul>\n'
+  printf '</body></html>\n'
+} > "$OUT/index.html"


### PR DESCRIPTION
## Summary
- add snapshot script to generate static site of selected files
- publish snapshot on pushes to main via GitHub Pages workflow
- document snapshot link and status update

## Testing
- `test -f scripts/snapshot.sh`
- `test -f .github/workflows/pages.yml`
- `grep -q "upload-pages-artifact" .github/workflows/pages.yml`
- `grep -q "deploy-pages" .github/workflows/pages.yml`
- `test -f PROJECT_STATUS.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae3b146088832495d1e944ea7ac322