### PR TITLE
chore: configure Pages workflow for reliable deploys

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,7 @@
 name: Pages
-
 on:
   push:
-    branches: ["main"]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:
@@ -10,17 +9,29 @@ permissions:
   pages: write
   id-token: write
 
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: bash scripts/snapshot.sh
-      - uses: actions/upload-pages-artifact@v3
+      - name: Build snapshot site
+        run: bash scripts/snapshot.sh
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
           path: site
+
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- configure GitHub Pages workflow with permissions, concurrency group, and environment metadata

## Testing
- `test -f .github/workflows/pages.yml`
- `grep -q "pages: write" .github/workflows/pages.yml`
- `grep -q "environment:" .github/workflows/pages.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ae3f40b1cc832498d003d68a8f7ded