### PR TITLE
feat: export questions for minhaya

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -33,4 +33,5 @@ python -m http.server -d public 4444
 - CI: clj-kondo via setup-clojure
 - 2025-08-26: Fix dataset normalization (:id → :track/id); add guard test
 - Enable public code snapshot via GitHub Pages
+- 12: export for みんはや
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ clojure -M -m vgm.cli # 既定: 5問
 clojure -M -m vgm.cli 3 # 3問
 ```
 
+### みんはや向けエクスポート
+
+```bash
+# 既定: 30問、タブ区切り
+clojure -M -m vgm.cli export
+# CSV 形式
+clojure -M -m vgm.cli export --format csv > out.csv
+```
+
 ## 概要
 
 * `resources/data/tracks.edn` を読み込み

--- a/src/vgm/cli.clj
+++ b/src/vgm/cli.clj
@@ -1,8 +1,26 @@
 (ns vgm.cli
   (:gen-class)
-  (:require [vgm.core :as core]))
+  (:require [vgm.core :as core]
+            [vgm.export :as export]))
 
+(defn- parse-opts [args]
+  (loop [m {} args args]
+    (if (seq args)
+      (let [[k v & more] args
+            k* (keyword (subs k 2))]
+        (recur (assoc m k* v) more))
+      m)))
 
-(defn -main [& [n]]
-  (let [n (or (some-> n Integer/parseInt) 5)]
-    (core/run-quiz! n)))
+(defn -main [& args]
+  (let [[cmd & opts] args]
+    (if (= cmd "export")
+      (let [{:keys [n format]} (parse-opts opts)
+            n (or (some-> n Integer/parseInt) 30)
+            format (keyword (or format "plain"))
+            items (export/build-questions n)
+            out (case format
+                  :csv (export/to-csv items)
+                  (export/to-plain items))]
+        (println out))
+      (let [n (or (some-> cmd Integer/parseInt) 5)]
+        (core/run-quiz! n)))))

--- a/src/vgm/export.clj
+++ b/src/vgm/export.clj
@@ -1,0 +1,39 @@
+(ns vgm.export
+  "Export questions for みんはや freematch."
+  (:require [clojure.string :as str]
+            [vgm.core :as core]
+            [vgm.question-pipeline :as qp]))
+
+(defn build-questions
+  "Generate N questions using the existing pipeline."
+  [n]
+  (let [tracks (core/load-tracks)
+        _ (assert (core/valid-dataset? tracks) "Invalid dataset")
+        {:keys [items]} (qp/pick-questions tracks
+                                           {:n n
+                                            :distinct-by [:title :game :composer]
+                                            :spread-by :year-bucket
+                                            :qtypes [:title->game :game->composer :title->composer]})]
+    (->> items
+         (map (fn [{:keys [track qtype]}]
+                (core/make-question qtype track)))
+         vec)))
+
+(defn to-plain
+  "Return plain text with one question per line: prompt\tanswer."
+  [items]
+  (->> items
+       (map (fn [{:keys [prompt answer]}]
+              (str prompt "\t" answer)))
+       (str/join "\n")))
+
+(defn- escape-csv [s]
+  (str "\"" (str/replace s #"\"" "\"\"") "\""))
+
+(defn to-csv
+  "Return CSV with header question,answer."
+  [items]
+  (let [rows (map (fn [{:keys [prompt answer]}]
+                    (str (escape-csv prompt) "," (escape-csv answer)))
+                  items)]
+    (str "question,answer\n" (str/join "\n" rows))))


### PR DESCRIPTION
## Summary
- add minhaya export module with plain text and CSV formats
- expose `export` subcommand for CLI
- document export usage and project status entry

## Testing
- `test -f src/vgm/export.clj`
- `grep -n "to-csv" src/vgm/export.clj`
- `grep -n "export" src/vgm/cli.clj`
- `test -f PROJECT_STATUS.md`
- `clojure -M:test` *(fails: command not found)*
- `curl -fLO https://download.clojure.org/install/linux-install-1.11.1.1165.sh` *(fails: 403)*


------
https://chatgpt.com/codex/tasks/task_e_68ae42de7df08324bf8991f667330ca8