### PR TITLE
chore: fix Kaocha reporter configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ clojure -M -m vgm.cli # 既定: 5問
 clojure -M -m vgm.cli 3 # 3問
 ```
 
+Kaocha is configured via `tests.edn`.
+
 ### みんはや向けエクスポート
 
 ```bash

--- a/tests.edn
+++ b/tests.edn
@@ -4,4 +4,7 @@
  :randomize? true
  :color? true
  :fail-fast? false
- :reporter [kaocha.report/progress]}
+ :reporter [kaocha.report/documentation]}
+
+# (If you prefer a progress bar, use this instead:)
+# :reporter [kaocha.report.progress/report]

--- a/tests.edn
+++ b/tests.edn
@@ -1,0 +1,7 @@
+#kaocha/v1
+{:tests [{:id :unit
+          :test-paths ["test"]}]
+ :randomize? true
+ :color? true
+ :fail-fast? false
+ :reporter [kaocha.report/progress]}


### PR DESCRIPTION
## Summary
- use slash syntax for Kaocha progress reporter in tests.edn

## Testing
- `test -f tests.edn`
- `grep -q "kaocha.report/progress" tests.edn`
- `clojure -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae45a04c108324b1e19afadad116d3