### PR TITLE
chore: publish app in pages

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -35,4 +35,5 @@ python -m http.server -d public 4444
 - Enable public code snapshot via GitHub Pages
 - 12: export for みんはや
 - 11: web pipeline applied
+- Pages: publish app under /app
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Index page displays dataset version and track count.
 
 Latest code snapshot: (see GitHub Pages URL after first deploy)
 
+Play the app: https://<owner>.github.io/<repo>/app/
+
 ## Codex sandbox validation
 
 Run a small script to verify required files without network access:

--- a/scripts/snapshot.sh
+++ b/scripts/snapshot.sh
@@ -46,3 +46,6 @@ commit=$(git rev-parse --short HEAD 2>/dev/null || echo "")
   printf '</ul>\n'
   printf '</body></html>\n'
 } > "$OUT/index.html"
+
+mkdir -p "$OUT/app"
+cp -r public/* "$OUT/app/"


### PR DESCRIPTION
## Summary
- copy web app to snapshot site so Pages hosts it under `/app`
- link to the playable app in README
- log publishing the app in project activity

## Testing
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: 403 for repos)*
- `apt-get install -y clojure` *(fails: package not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ae505e8e4883248f59600cf3955a96