### PR TITLE
chore: prepare v1.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build dataset
+        run: |
+          clojure -T:build clean
+          clojure -T:build publish
+      - name: Bundle artifacts
+        run: |
+          mkdir -p dist
+          cp -r public/build dist/
+          cp -r public dist/app
+          tar -czf vgm-quiz-${{ github.ref_name }}.tar.gz dist
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: CHANGELOG.md
+          files: |
+            vgm-quiz-${{ github.ref_name }}.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## v1.0.0 (2025-08-27)
+- PWA(+IndexedDB)
+- Web aliases
+- CLJC pipeline
+- CLI export
+- CI hardening
+- Pages (code + app)

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -36,4 +36,5 @@ python -m http.server -d public 4444
 - 12: export for みんはや
 - 11: web pipeline applied
 - Pages: publish app under /app
+- Release workflow added
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,8 @@ Index page displays dataset version and track count.
 
 ## Snapshot
 
-Latest code snapshot: (see GitHub Pages URL after first deploy)
-
-Play the app: https://<owner>.github.io/<repo>/app/
+- [Code Snapshot](https://<owner>.github.io/<repo>/)
+- [Live App](https://<owner>.github.io/<repo>/app/)
 
 ## Codex sandbox validation
 


### PR DESCRIPTION
## Summary
- add v1.0 changelog with major features
- link Code Snapshot and Live App from README
- add GitHub release workflow and log activity

## Testing
- `test -f CHANGELOG.md`
- `test -f .github/workflows/release.yml`
- `rg "softprops/action-gh-release" .github/workflows/release.yml`
- `test -f PROJECT_STATUS.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae51a4a5248324bbe434bb782031f1