### PR TITLE
feat(pwa): notify on service worker updates

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -37,4 +37,5 @@ python -m http.server -d public 4444
 - 11: web pipeline applied
 - Pages: publish app under /app
 - Release workflow added
+- 2025-08-27: PWA update toast
 

--- a/public/app.js
+++ b/public/app.js
@@ -245,3 +245,44 @@ document.getElementById('clear-history-btn').addEventListener('click', clearHist
 
 loadDataset();
 loadAliases();
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('sw.js').then(registration => {
+    function showUpdateBanner() {
+      if (document.getElementById('sw-update')) return;
+      const banner = document.createElement('div');
+      banner.id = 'sw-update';
+      banner.style.position = 'fixed';
+      banner.style.bottom = '0';
+      banner.style.left = '0';
+      banner.style.right = '0';
+      banner.style.background = '#333';
+      banner.style.color = '#fff';
+      banner.style.padding = '8px';
+      banner.style.textAlign = 'center';
+      const btn = document.createElement('button');
+      btn.textContent = '更新があります。リロードしますか？';
+      btn.addEventListener('click', () => {
+        registration.waiting?.postMessage({ type: 'SKIP_WAITING' });
+        location.reload();
+      });
+      banner.appendChild(btn);
+      document.body.appendChild(banner);
+    }
+
+    if (registration.waiting) {
+      showUpdateBanner();
+    }
+    registration.addEventListener('updatefound', () => {
+      const newWorker = registration.installing;
+      if (newWorker) {
+        newWorker.addEventListener('statechange', () => {
+          if (registration.waiting) {
+            showUpdateBanner();
+          }
+        });
+      }
+    });
+    navigator.serviceWorker.addEventListener('controllerchange', showUpdateBanner);
+  });
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -24,3 +24,9 @@ self.addEventListener('fetch', event => {
   );
 });
 
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+


### PR DESCRIPTION
## Summary
- show a reload banner when a new service worker is waiting or takes control
- allow the new worker to activate immediately via SKIP_WAITING
- log the update in project status

## Testing
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*
- `rg "SKIP_WAITING" public/sw.js`
- `rg "controllerchange" public/app.js`
- `test -f PROJECT_STATUS.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae5313fe78832494861bc8fdb4bd04