### PR TITLE
chore: build dataset before Pages snapshot

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,8 +18,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+
+      - name: Setup Clojure CLI
+        uses: DeLaGuardo/setup-clojure@13.4
+        with:
+          cli: latest
+
+      - name: Build dataset for Pages
+        run: |
+          clojure -T:build clean || true
+          clojure -T:build publish
+
       - name: Build snapshot site
         run: bash scripts/snapshot.sh
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- set up Java and Clojure CLI in Pages workflow
- build dataset before running snapshot.sh to publish dataset.json

## Testing
- `test -f .github/workflows/pages.yml`
- `grep -q "clojure -T:build publish" .github/workflows/pages.yml`
- `grep -q "DeLaGuardo/setup-clojure" .github/workflows/pages.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ae58e6a2f483249dc0ab9b64e1bbe6