### PR TITLE
Show message when dataset load fails

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -110,6 +110,11 @@ async function loadDataset() {
     document.getElementById('start-btn').disabled = false;
   } catch (err) {
     console.error('Failed to load dataset', err);
+    const msg = document.getElementById('dataset-error');
+    if (msg) {
+      msg.textContent = 'データが読み込めませんでした。時間をおいて再度お試しください。';
+      msg.style.display = 'block';
+    }
   }
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
   <div id="start-view">
     <label>Questions: <input id="count" type="number" min="1" value="5" /></label>
     <button id="start-btn" disabled>Start</button>
+    <div id="dataset-error" style="display:none;color:red;"></div>
     <button id="history-btn">History</button>
   </div>
 


### PR DESCRIPTION
## Summary
- Display dataset loading failure notice in the UI
- Add placeholder element for dataset load errors on start view

## Testing
- `sh scripts/validate_sandbox.sh web`
- `sh scripts/validate_sandbox.sh build`
- `clojure -M:test` *(fails: command not found; attempted to install but repository access was forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5b71e0908324a6af3f1459310c3a