### PR TITLE
Add versioned cache and app version label

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -38,4 +38,5 @@ python -m http.server -d public 4444
 - Pages: publish app under /app
 - Release workflow added
 - 2025-08-27: PWA update toast
+- Versioned cache + version label
 

--- a/build.clj
+++ b/build.clj
@@ -97,4 +97,11 @@
   (spit (io/file "public/build/dataset.json")
         (slurp (io/file "build/dataset.json")))
   ;; 4) aliases があれば JSON も出力
-  (edn->json-file "resources/data/aliases.edn" "public/build/aliases.json"))
+  (edn->json-file "resources/data/aliases.edn" "public/build/aliases.json")
+  ;; 5) version.json
+  (let [sha (System/getenv "GITHUB_SHA")
+        commit (if (and sha (<= 7 (count sha))) (subs sha 0 7) "dev")
+        ver {:commit commit
+             :generated_at (str (java.time.Instant/now))}]
+    (spit (io/file "public/build/version.json")
+          (json/write-str ver))))

--- a/public/app.js
+++ b/public/app.js
@@ -4,6 +4,7 @@ let current = 0;
 let score = 0;
 let awaitingNext = false;
 const aliases = {};
+window.__APP_VERSION__ = 'dev';
 
 const DB_NAME = 'vgm-quiz';
 const STORE = 'plays';
@@ -134,6 +135,21 @@ async function loadAliases() {
   }
 }
 
+async function loadVersion() {
+  try {
+    const res = await fetch('./build/version.json');
+    const data = await res.json();
+    window.__APP_VERSION__ = data.commit || 'dev';
+  } catch (err) {
+    console.warn('Failed to load version', err);
+  }
+  const el = document.createElement('div');
+  el.id = 'app-version';
+  el.style.marginTop = '1em';
+  el.textContent = `Version: ${window.__APP_VERSION__}`;
+  document.body.appendChild(el);
+}
+
 function startQuiz() {
   const countInput = document.getElementById('count');
   let n = parseInt(countInput.value, 10);
@@ -251,43 +267,45 @@ document.getElementById('clear-history-btn').addEventListener('click', clearHist
 loadDataset();
 loadAliases();
 
-if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('sw.js').then(registration => {
-    function showUpdateBanner() {
-      if (document.getElementById('sw-update')) return;
-      const banner = document.createElement('div');
-      banner.id = 'sw-update';
-      banner.style.position = 'fixed';
-      banner.style.bottom = '0';
-      banner.style.left = '0';
-      banner.style.right = '0';
-      banner.style.background = '#333';
-      banner.style.color = '#fff';
-      banner.style.padding = '8px';
-      banner.style.textAlign = 'center';
-      const btn = document.createElement('button');
-      btn.textContent = '更新があります。リロードしますか？';
-      btn.addEventListener('click', () => {
-        registration.waiting?.postMessage({ type: 'SKIP_WAITING' });
-        location.reload();
-      });
-      banner.appendChild(btn);
-      document.body.appendChild(banner);
-    }
-
-    if (registration.waiting) {
-      showUpdateBanner();
-    }
-    registration.addEventListener('updatefound', () => {
-      const newWorker = registration.installing;
-      if (newWorker) {
-        newWorker.addEventListener('statechange', () => {
-          if (registration.waiting) {
-            showUpdateBanner();
-          }
+loadVersion().then(() => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register(`sw.js?v=${encodeURIComponent(window.__APP_VERSION__ || 'dev')}`).then(registration => {
+      function showUpdateBanner() {
+        if (document.getElementById('sw-update')) return;
+        const banner = document.createElement('div');
+        banner.id = 'sw-update';
+        banner.style.position = 'fixed';
+        banner.style.bottom = '0';
+        banner.style.left = '0';
+        banner.style.right = '0';
+        banner.style.background = '#333';
+        banner.style.color = '#fff';
+        banner.style.padding = '8px';
+        banner.style.textAlign = 'center';
+        const btn = document.createElement('button');
+        btn.textContent = '更新があります。リロードしますか？';
+        btn.addEventListener('click', () => {
+          registration.waiting?.postMessage({ type: 'SKIP_WAITING' });
+          location.reload();
         });
+        banner.appendChild(btn);
+        document.body.appendChild(banner);
       }
+
+      if (registration.waiting) {
+        showUpdateBanner();
+      }
+      registration.addEventListener('updatefound', () => {
+        const newWorker = registration.installing;
+        if (newWorker) {
+          newWorker.addEventListener('statechange', () => {
+            if (registration.waiting) {
+              showUpdateBanner();
+            }
+          });
+        }
+      });
+      navigator.serviceWorker.addEventListener('controllerchange', showUpdateBanner);
     });
-    navigator.serviceWorker.addEventListener('controllerchange', showUpdateBanner);
-  });
-}
+  }
+});

--- a/public/build/version.json
+++ b/public/build/version.json
@@ -1,0 +1,1 @@
+{"commit":"dev","generated_at":"2025-01-01T00:00:00Z"}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,5 @@
-const CACHE_NAME = 'pwa-cache-v1';
+self.__APP_VERSION__ = new URL(self.location).searchParams.get('v');
+const CACHE_NAME = 'vgm-quiz-' + (self.__APP_VERSION__ || 'dev');
 const CORE_ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- generate `public/build/version.json` during publish with commit hash and timestamp
- load app version at startup and display it while registering service worker with versioned URL
- prefix service worker cache with app version to bust cache

## Testing
- `test -f public/build/version.json || true`
- `grep -q "version.json" public/app.js`
- `grep -q "vgm-quiz-" public/sw.js`
- `test -f PROJECT_STATUS.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae68a665588324a68fcb8fc9ff3153