### PR TITLE
feat: import tracks from CSV

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -39,3 +39,4 @@ python -m http.server -d public 4444
 - Release workflow added
 - Versioned cache + version label
 - QA-3: EDN schema validation
+- CSV import pipeline

--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ clojure -M -m vgm.cli export
 clojure -M -m vgm.cli export --format csv > out.csv
 ```
 
+## Contributing data
+
+Provide a CSV file with the header `title,game,composer,year`:
+
+```csv
+title,game,composer,year
+Megalovania,UNDERTALE,Toby Fox,2015
+```
+
+Then merge it into the dataset:
+
+```bash
+clojure -M -m vgm.cli import-csv new_tracks.csv resources/data/tracks.edn
+```
+
 ## 概要
 
 * `resources/data/tracks.edn` を読み込み

--- a/src/vgm/cli.clj
+++ b/src/vgm/cli.clj
@@ -1,7 +1,10 @@
 (ns vgm.cli
   (:gen-class)
   (:require [vgm.core :as core]
-            [vgm.export :as export]))
+            [vgm.export :as export]
+            [vgm.import-csv :as ic]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]))
 
 (defn- parse-opts [args]
   (loop [m {} args args]
@@ -13,7 +16,8 @@
 
 (defn -main [& args]
   (let [[cmd & opts] args]
-    (if (= cmd "export")
+    (case cmd
+      "export"
       (let [{:keys [n format]} (parse-opts opts)
             n (or (some-> n Integer/parseInt) 30)
             format (keyword (or format "plain"))
@@ -22,5 +26,15 @@
                   :csv (export/to-csv items)
                   (export/to-plain items))]
         (println out))
+
+      "import-csv"
+      (let [[in out] opts
+            new (map ic/normalize-track (ic/parse-csv in))
+            existing (if (.exists (io/file out))
+                       (edn/read-string (slurp out))
+                       [])
+            merged (ic/merge-unique existing new)]
+        (ic/write-edn out merged))
+
       (let [n (or (some-> cmd Integer/parseInt) 5)]
         (core/run-quiz! n)))))

--- a/src/vgm/import_csv.clj
+++ b/src/vgm/import_csv.clj
@@ -1,0 +1,40 @@
+(ns vgm.import-csv
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(defn parse-csv [path]
+  (with-open [r (io/reader path)]
+    (let [lines (line-seq r)
+          headers (->> (first lines)
+                        (str/split #",")
+                        (map str/trim)
+                        (map keyword))
+          rows (rest lines)]
+      (map (fn [line]
+             (->> (str/split line #",")
+                  (map str/trim)
+                  (zipmap headers)))
+           rows))))
+
+(defn normalize-track [m]
+  (let [nfkc (fn [s]
+               (some-> s
+                       (java.text.Normalizer/normalize java.text.Normalizer$Form/NFKC)
+                       str/trim
+                       str/lower-case))
+        year-int (fn [y]
+                   (some-> y nfkc Integer/parseInt))]
+    (-> m
+        (update :title nfkc)
+        (update :game nfkc)
+        (update :composer nfkc)
+        (update :year year-int))))
+
+(defn merge-unique [existing new]
+  (let [kfn (juxt :title :game :composer :year)
+        seen (set (map kfn existing))
+        fresh (remove #(contains? seen (kfn %)) new)]
+    (vec (concat existing fresh))))
+
+(defn write-edn [out-path items]
+  (spit out-path (pr-str items)))


### PR DESCRIPTION
## Summary
- add import_csv utilities for parsing and normalizing track CSVs
- extend CLI with `import-csv` command and document contribution workflow
- note CSV import pipeline in project status

## Testing
- ⚠️ `clojure -M:test` (command not found)
- ⚠️ `apt-get update` (repository signatures missing)
- ⚠️ `apt-get install -y clojure` (package not found)


------
https://chatgpt.com/codex/tasks/task_e_68ae6b340cc0832482a9d239b455a558