### PR TITLE
chore: add candidates folder and strip meta keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ clojure -M -m vgm.cli export --format csv > out.csv
 
 ## Contributing data
 
+Candidates go to `resources/candidates/*.edn` (map/vector of tracks). `:meta/*` allowed.
+
 Provide a CSV file with the header `title,game,composer,year`:
 
 ```csv

--- a/build.clj
+++ b/build.clj
@@ -38,6 +38,9 @@
     (:id m) (-> (assoc :track/id (:id m))
                 (dissoc :id))))
 
+(defn- strip-meta [m]
+  (apply dissoc m (for [k (keys m) :when (= "meta" (namespace k))] k)))
+
 (defn- normalize-track [m0]
   (let [m (-> m0
               migrate-id
@@ -50,7 +53,8 @@
               (update :composer str))]
     (-> m
         (assoc :track/id (stable-id m))
-        (dissoc :id))))
+        (dissoc :id)
+        strip-meta)))
 
 (defn- normalize-items [items]
   (->> items (map normalize-track) vec))


### PR DESCRIPTION
## Summary
- add resources/candidates folder for track proposals
- drop :meta/* keys when normalizing tracks before writing JSON
- document candidates folder in README

## Testing
- `clojure -M:test` *(fails: command not found)*
- `test -d resources/candidates`
- `grep -n "meta" build.clj`
- `test -f README.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae6ec781f483248abb3fd4c4d9a06b