### PR TITLE
Add ingest CLI for merging track candidates

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -40,3 +40,4 @@ python -m http.server -d public 4444
 - Versioned cache + version label
 - QA-3: EDN schema validation
 - CSV import pipeline
+- Ingest pipeline added

--- a/src/vgm/cli.clj
+++ b/src/vgm/cli.clj
@@ -3,6 +3,7 @@
   (:require [vgm.core :as core]
             [vgm.export :as export]
             [vgm.import-csv :as ic]
+            [vgm.ingest :as ingest]
             [clojure.edn :as edn]
             [clojure.java.io :as io]))
 
@@ -35,6 +36,16 @@
                        [])
             merged (ic/merge-unique existing new)]
         (ic/write-edn out merged))
+
+      "ingest"
+      (let [existing (if (.exists (io/file "resources/data/tracks.edn"))
+                       (edn/read-string (slurp "resources/data/tracks.edn"))
+                       [])
+            candidates (->> (ingest/read-candidates "resources/candidates")
+                            (map ingest/normalize-track))
+            merged (ingest/merge-unique existing candidates)
+            sorted (ingest/sort-tracks merged)]
+        (ingest/rewrite-tracks! sorted))
 
       (let [n (or (some-> cmd Integer/parseInt) 5)]
         (core/run-quiz! n)))))

--- a/src/vgm/ingest.clj
+++ b/src/vgm/ingest.clj
@@ -1,0 +1,47 @@
+(ns vgm.ingest
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.pprint :as pp]))
+
+(defn read-candidates [dir]
+  (let [files (->> (io/file dir)
+                   file-seq
+                   (filter #(.isFile %))
+                   (filter #(str/ends-with? (.getName %) ".edn")))]
+    (mapcat (fn [f]
+              (let [data (edn/read-string (slurp f))]
+                (cond
+                  (vector? data) data
+                  (map? data) (:items data)
+                  :else [])))
+            files)))
+
+(defn normalize-track [m]
+  (let [nfkc (fn [s]
+               (some-> s
+                       (java.text.Normalizer/normalize java.text.Normalizer$Form/NFKC)
+                       str/trim
+                       str/lower-case))
+        year-int (fn [y]
+                   (some-> y nfkc Integer/parseInt))]
+    (-> m
+        (update :title nfkc)
+        (update :game nfkc)
+        (update :composer nfkc)
+        (update :year year-int))))
+
+(defn merge-unique [existing new]
+  (let [kfn (juxt :title :game :composer :year)
+        seen (set (map kfn existing))
+        fresh (remove #(contains? seen (kfn %)) new)]
+    (vec (concat existing fresh))))
+
+(defn sort-tracks [xs]
+  (sort-by (juxt :game :year :title :composer) xs))
+
+(defn rewrite-tracks! [xs]
+  (with-open [w (io/writer "resources/data/tracks.edn")]
+    (binding [*print-namespace-maps* false]
+      (pp/pprint xs w)))
+)

--- a/test/vgm/ingest_test.clj
+++ b/test/vgm/ingest_test.clj
@@ -1,0 +1,32 @@
+(ns vgm.ingest-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [vgm.ingest :as sut]))
+
+(deftest normalize-track-test
+  (let [m {:title " Ｔｅｓｔ "
+           :game " ｹﾞｰﾑ "
+           :composer "ＣｏｍＰoSeR "
+           :year "２０００"}
+        r (sut/normalize-track m)]
+    (is (= {:title "test"
+            :game "ゲーム"
+            :composer "composer"
+            :year 2000}
+           r))))
+
+(deftest merge-unique-test
+  (let [existing [{:title "t" :game "g" :composer "c" :year 2000}]
+        new [{:title "t" :game "g" :composer "c" :year 2000}
+             {:title "u" :game "g" :composer "c" :year 2001}]
+        merged (sut/merge-unique existing new)]
+    (is (= 2 (count merged)))
+    (is (= 1 (count (filter #(= "t" (:title %)) merged))))))
+
+(deftest sort-tracks-stable-test
+  (let [a {:title "a" :game "g" :composer "c" :year 2000}
+        b {:title "a" :game "g" :composer "c" :year 2000}
+        xs [a b]
+        s1 (sut/sort-tracks xs)
+        s2 (sut/sort-tracks s1)]
+    (is (= s1 s2))
+    (is (= [a b] s1))))


### PR DESCRIPTION
## Summary
- add ingest namespace with candidate reading, normalization, dedupe, sorting, and rewrite helpers
- expose new `ingest` subcommand in CLI to merge candidate tracks into dataset
- document workflow in project status and add tests for normalization, merging, and stable sorting

## Testing
- `clojure -M:test` *(fails: command not found)*
- `test -f src/vgm/ingest.clj`
- `grep -q "merge-unique" src/vgm/ingest.clj`
- `grep -q "ingest" src/vgm/cli.clj`
- `test -f test/vgm/ingest_test.clj`
- `test -f PROJECT_STATUS.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae6ed0f4288324af8722433bee43b8