### PR TITLE
feat: add autofetch workflow

### DIFF
--- a/.github/workflows/autofetch.yml
+++ b/.github/workflows/autofetch.yml
@@ -1,0 +1,48 @@
+name: Auto-fetch
+
+on:
+  schedule:
+    - cron: "30 19 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: false
+
+jobs:
+  autofetch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+      - name: Setup Clojure CLI
+        uses: DeLaGuardo/setup-clojure@13.4
+        with:
+          cli: latest
+      - name: Fetch candidates
+        run: clojure -M -m vgm.autofetch
+      - name: Ingest candidates
+        run: clojure -M -m vgm.cli ingest
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: "bot/ingest-${{ github.run_id }}"
+          title: "Data ingest: ${{ github.event_name == 'workflow_dispatch' && 'manual' || 'scheduled' }} run"
+          commit-message: "chore(data): ingest candidates + normalize + dedupe"
+          body: |
+            ### Summary
+            - Ingested candidates and merged into `resources/data/tracks.edn`
+            - Please review stats below. CI will validate schema and IDs.
+
+            ### Stats (preview)
+            ```
+            $ clojure -M -m vgm.stats added-by-year
+            $ clojure -M -m vgm.stats added-by-composer
+            ```
+          labels: data, bot
+          delete-branch: true

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -40,3 +40,4 @@ python -m http.server -d public 4444
 - Versioned cache + version label
 - QA-3: EDN schema validation
 - CSV import pipeline
+- autofetch workflow

--- a/resources/feeds/sample.csv
+++ b/resources/feeds/sample.csv
@@ -1,0 +1,3 @@
+title,game,composer,year
+Song A,Game A,Composer A,2000
+Song B,Game B,Composer B,2001

--- a/src/vgm/autofetch.clj
+++ b/src/vgm/autofetch.clj
@@ -1,0 +1,16 @@
+(ns vgm.autofetch
+  (:gen-class)
+  (:require [vgm.import-csv :as ic]
+            [clojure.java.io :as io])
+  (:import [java.time LocalDate]
+           [java.time.format DateTimeFormatter]))
+
+(defn- today []
+  (.format (LocalDate/now) (DateTimeFormatter/ofPattern "yyyyMMdd")))
+
+(defn -main [& _]
+  (let [feed "resources/feeds/sample.csv"
+        out (format "resources/candidates/autofetch-%s.edn" (today))
+        candidates (map ic/normalize-track (ic/parse-csv feed))]
+    (io/make-parents out)
+    (ic/write-edn out (vec candidates))))

--- a/src/vgm/cli.clj
+++ b/src/vgm/cli.clj
@@ -4,7 +4,8 @@
             [vgm.export :as export]
             [vgm.import-csv :as ic]
             [clojure.edn :as edn]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
 
 (defn- parse-opts [args]
   (loop [m {} args args]
@@ -30,6 +31,22 @@
       "import-csv"
       (let [[in out] opts
             new (map ic/normalize-track (ic/parse-csv in))
+            existing (if (.exists (io/file out))
+                       (edn/read-string (slurp out))
+                       [])
+            merged (ic/merge-unique existing new)]
+        (ic/write-edn out merged))
+
+      "ingest"
+      (let [cand-dir (io/file "resources/candidates")
+            files (->> (file-seq cand-dir)
+                       (filter #(.isFile %))
+                       (filter #(str/ends-with? (.getName %) ".edn")))
+            new (->> files
+                     (mapcat (fn [f]
+                               (map ic/normalize-track
+                                    (edn/read-string (slurp f))))))
+            out "resources/data/tracks.edn"
             existing (if (.exists (io/file out))
                        (edn/read-string (slurp out))
                        [])

--- a/src/vgm/cli.clj
+++ b/src/vgm/cli.clj
@@ -3,6 +3,7 @@
   (:require [vgm.core :as core]
             [vgm.export :as export]
             [vgm.import-csv :as ic]
+            [vgm.ingest :as ingest]
             [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str]))
@@ -38,20 +39,17 @@
         (ic/write-edn out merged))
 
       "ingest"
-      (let [cand-dir (io/file "resources/candidates")
-            files (->> (file-seq cand-dir)
-                       (filter #(.isFile %))
-                       (filter #(str/ends-with? (.getName %) ".edn")))
-            new (->> files
-                     (mapcat (fn [f]
-                               (map ic/normalize-track
-                                    (edn/read-string (slurp f))))))
-            out "resources/data/tracks.edn"
-            existing (if (.exists (io/file out))
-                       (edn/read-string (slurp out))
-                       [])
-            merged (ic/merge-unique existing new)]
-        (ic/write-edn out merged))
+      (let [existing   (if (.exists (io/file "resources/data/tracks.edn"))
+                         (edn/read-string (slurp "resources/data/tracks.edn"))
+                         [])
+            candidates (->> (ingest/read-candidates "resources/candidates")
+                            (map ingest/normalize-track))
+            merged     (ingest/merge-unique existing candidates)
+            sorted     (ingest/sort-tracks merged)]
+        (ingest/rewrite-tracks! sorted)
+        (println (format "Ingested %d candidates, wrote %d total tracks"
+                         (count candidates) (count sorted))))
 
+      ;; default: run quiz with N questions
       (let [n (or (some-> cmd Integer/parseInt) 5)]
         (core/run-quiz! n)))))

--- a/src/vgm/stats.clj
+++ b/src/vgm/stats.clj
@@ -1,0 +1,26 @@
+(ns vgm.stats
+  (:gen-class)
+  (:require [vgm.core :as core]
+            [clojure.string :as str]))
+
+(defn- table [headers rows]
+  (println (str "|" (str/join "|" headers) "|"))
+  (println (str "|" (str/join "|" (repeat (count headers) "-")) "|"))
+  (doseq [r rows]
+    (println (str "|" (str/join "|" r) "|"))))
+
+(defn added-by-year []
+  (let [tracks (core/load-tracks)
+        grouped (->> tracks (group-by :year) (map (fn [[y ts]] [y (count ts)])) (sort-by first))]
+    (table ["year" "count"] grouped)))
+
+(defn added-by-composer []
+  (let [tracks (core/load-tracks)
+        grouped (->> tracks (group-by :composer) (map (fn [[c ts]] [c (count ts)])) (sort-by first))]
+    (table ["composer" "count"] grouped)))
+
+(defn -main [& [cmd]]
+  (case cmd
+    "added-by-year" (added-by-year)
+    "added-by-composer" (added-by-composer)
+    (println "Unknown command")))


### PR DESCRIPTION
## Summary
- add scheduled autofetch GitHub Action
- stub autofetch script reading CSV feeds
- provide stats CLI for year/composer distributions

## Testing
- `clojure -M -m vgm.autofetch` *(fails: command not found)*
- `clojure -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6ee399e08324aef28df9c614d381