### PR TITLE
chore: fail CI on merge conflict markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,11 @@ jobs:
       - name: clj-kondo
         run: clj-kondo --lint src test build.clj || clj-kondo --version
 
+      - name: Check for unresolved merge conflict markers
+        run: |
+          if git grep -nE '^(<<<<<<<|=======$|>>>>>>> )' -- ':!public/build/*' ':!dist/*' ; then
+            echo "Unresolved merge conflict markers found"; exit 1; fi
+
       - name: Build dataset/publish
         run: |
           clojure -T:build clean || true


### PR DESCRIPTION
## Summary
- add CI step to detect unresolved merge conflict markers

## Testing
- `test -f .github/workflows/ci.yml`
- `grep -q "Unresolved merge conflict markers" .github/workflows/ci.yml`
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae762dae2083249d65dc6d455a5330