### PR TITLE
chore: enable auto-merge for autofetch PRs

### DIFF
--- a/.github/workflows/autofetch.yml
+++ b/.github/workflows/autofetch.yml
@@ -9,6 +9,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   autofetch:
     runs-on: ubuntu-latest
@@ -29,6 +33,7 @@ jobs:
       - name: Ingest candidates
         run: clojure -M -m vgm.cli ingest
       - name: Create PR
+        id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
           branch: "bot/ingest-${{ github.run_id }}"
@@ -46,3 +51,10 @@ jobs:
             ```
           labels: data, bot
           delete-branch: true
+      - name: Enable auto-merge (squash)
+        if: steps.cpr.outputs.pull-request-number != ''
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash


### PR DESCRIPTION
## Summary
- allow workflow to update contents and pull requests
- enable auto-merge on auto-generated PRs

## Testing
- `test -f .github/workflows/autofetch.yml`
- `grep -q "enable-pull-request-automerge@v3" .github/workflows/autofetch.yml`
- `grep -q "id: cpr" .github/workflows/autofetch.yml`
- `grep -q "permissions:" .github/workflows/autofetch.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ae7d0c3df88324ab3845b3ca48d106