### PR TITLE
chore: add auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,25 @@
+name: Auto-Enable PR Auto-Merge
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable:
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository && (
+        startsWith(github.event.pull_request.head.ref, 'codex/') ||
+        startsWith(github.event.pull_request.head.ref, 'bot/') ||
+        contains(join(github.event.pull_request.labels.*.name), 'automerge')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash


### PR DESCRIPTION
## Summary
- enable automatic squash merge for qualifying PRs

## Testing
- `test -f .github/workflows/auto-merge.yml`
- `rg -q "pull_request_target" .github/workflows/auto-merge.yml && echo found`
- `rg -q "enable-pull-request-automerge@v3" .github/workflows/auto-merge.yml && echo found`
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed.)*


------
https://chatgpt.com/codex/tasks/task_e_68ae7de0d27c83248e8e7430531fa312