### PR TITLE
chore: run tests before autofetch

### DIFF
--- a/.github/workflows/autofetch.yml
+++ b/.github/workflows/autofetch.yml
@@ -28,7 +28,9 @@ jobs:
         uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest
-      - name: Fetch candidates
+      - name: Run tests
+        run: clojure -M:test
+      - name: Run autofetch
         run: clojure -M -m vgm.autofetch
       - name: Ingest candidates
         run: clojure -M -m vgm.cli ingest


### PR DESCRIPTION
## Summary
- run tests before autofetch to catch parser regressions

## Testing
- `rg "clojure -M:test" .github/workflows/autofetch.yml`
- `clojure -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae92c4b18883248b061ac67a3954dc