### PR TITLE
chore: add debug parser workflow

### DIFF
--- a/.github/workflows/debug-parser.yml
+++ b/.github/workflows/debug-parser.yml
@@ -1,0 +1,27 @@
+name: Debug Parser
+on:
+  workflow_dispatch: {}
+
+jobs:
+  show:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Clojure CLI
+        uses: DeLaGuardo/setup-clojure@13.4
+        with:
+          cli: latest
+
+      - name: Show import_csv.clj head
+        run: sed -n '1,120p' src/vgm/import_csv.clj || true
+
+      - name: Print source of vgm.import-csv/parse-csv
+        run: |
+          clojure -Srepro -e "(require '[vgm.import-csv :as ic] 'clojure.repl) (clojure.repl/source ic/parse-csv)"


### PR DESCRIPTION
## Summary
- debug parser by printing import-csv head and parse-csv source in workflow

## Testing
- `test -f .github/workflows/debug-parser.yml`
- `clojure -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae93cba87c832481a95e66d3d2f057