### PR TITLE
chore(ci): build dataset before tests

### DIFF
--- a/.github/workflows/autofetch.yml
+++ b/.github/workflows/autofetch.yml
@@ -28,12 +28,17 @@ jobs:
         uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest
-      - name: Run tests
-        run: clojure -M:test
       - name: Guard parser implementation (sentinel & no split-based csv)
         run: |
           grep -q 'SENTINEL: data.csv-parser v1' src/vgm/import_csv.clj
           ! grep -R 'string/split.*","' -n src || (echo "Old parser detected"; exit 1)
+      - name: Build dataset for tests
+        run: |
+          clojure -T:build clean || true
+          clojure -T:build publish
+          test -f public/build/dataset.json
+      - name: Run tests
+        run: clojure -M:test
       - name: Run autofetch
         run: clojure -M -m vgm.autofetch
       - name: Ingest candidates


### PR DESCRIPTION
## Summary
- run tools.build publish before tests so dataset is available

## Testing
- `rg "clojure -T:build publish" .github/workflows/autofetch.yml`
- `rg "test -f public/build/dataset.json" .github/workflows/autofetch.yml`
- `clojure -T:build clean || true` *(fails: command not found)*
- `clojure -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9d235d788324be171ca21039916e