### PR TITLE
chore: add preflight require step to autofetch workflow

### DIFF
--- a/.github/workflows/autofetch.yml
+++ b/.github/workflows/autofetch.yml
@@ -39,6 +39,8 @@ jobs:
           test -f public/build/dataset.json
       - name: Run tests
         run: clojure -M:test
+      - name: Preflight require (autofetch)
+        run: clojure -M -e "(require 'vgm.autofetch 'vgm.ingest 'vgm.import-csv)"
       - name: Run autofetch
         run: clojure -M -m vgm.autofetch
       - name: Ingest candidates


### PR DESCRIPTION
## Summary
- run prereq require to fail fast if vgm.autofetch or deps fail to load

## Testing
- `clojure -M:test` *(fails: command not found)*
- `sudo apt-get update` *(fails: 403  Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68aea1cccd5c8324a6efbeea74ed7898