### PR TITLE
Fix typo in CLI ingest command

### DIFF
--- a/src/vgm/cli.clj
+++ b/src/vgm/cli.clj
@@ -46,7 +46,7 @@
             candidates  (->> (ingest/read-candidates "resources/candidates")
                              (map ingest/normalize-track))
             merged      (ingest/merge-unique existing candidates)
-            sorted      (engest/sort-tracks merged)]
+            sorted      (ingest/sort-tracks merged)]
         (ingest/rewrite-tracks! sorted)
         (println (format "Ingested %d candidates, wrote %d total tracks"
                          (count candidates) (count sorted))))


### PR DESCRIPTION
## Summary
- fix CLI ingest command to call `ingest/sort-tracks` instead of non-existent `engest/sort-tracks`

## Testing
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aea966749c8324889bb29a4016a1e3