### PR TITLE
chore(ci): guard typos and legacy code

### DIFF
--- a/.github/workflows/autofetch.yml
+++ b/.github/workflows/autofetch.yml
@@ -28,10 +28,17 @@ jobs:
         uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest
-      - name: Guard parser implementation (sentinel & no split-based csv)
+      - name: Static guards (typos & legacy)
         run: |
+          set -euo pipefail
+          # ensure data.csv parser is used
           grep -q 'SENTINEL: data.csv-parser v1' src/vgm/import_csv.clj
-          ! grep -R 'string/split.*","' -n src || (echo "Old parser detected"; exit 1)
+          # ban split-based CSV parsing
+          ! git grep -nE 'string/split.+","' -- src || { echo "Legacy CSV parsing detected. Use clojure.data.csv"; exit 1; }
+          # ban typo 'engest/'
+          ! git grep -n "engest/" -- ':!public/build/*' || { echo "Typo 'engest/' found"; exit 1; }
+          # ban old normalizer ref
+          ! git grep -n "ic/normalize-track" -- ':!public/build/*' || { echo "Use ingest/normalize-track instead of ic/normalize-track"; exit 1; }
       - name: Build dataset for tests
         run: |
           clojure -T:build clean || true

--- a/.github/workflows/autofetch.yml
+++ b/.github/workflows/autofetch.yml
@@ -31,14 +31,16 @@ jobs:
       - name: Static guards (typos & legacy)
         run: |
           set -euo pipefail
-          # ensure data.csv parser is used
-          grep -q 'SENTINEL: data.csv-parser v1' src/vgm/import_csv.clj
-          # ban split-based CSV parsing
+          # Directories to scan
+          DIRS="src test resources scripts"
+          # 1) ban typo 'engest/'
+          ! git grep -n "engest/" -- $DIRS || { echo "Typo 'engest/' found"; exit 1; }
+          # 2) ban old normalizer ref
+          ! git grep -n "ic/normalize-track" -- $DIRS || { echo "Use ingest/normalize-track instead of ic/normalize-track"; exit 1; }
+          # 3) ban split-based CSV parsing (must use clojure.data.csv)
           ! git grep -nE 'string/split.+","' -- src || { echo "Legacy CSV parsing detected. Use clojure.data.csv"; exit 1; }
-          # ban typo 'engest/'
-          ! git grep -n "engest/" -- ':!public/build/*' || { echo "Typo 'engest/' found"; exit 1; }
-          # ban old normalizer ref
-          ! git grep -n "ic/normalize-track" -- ':!public/build/*' || { echo "Use ingest/normalize-track instead of ic/normalize-track"; exit 1; }
+          # 4) enforce data.csv version via sentinel
+          grep -q 'SENTINEL: data.csv-parser v1' src/vgm/import_csv.clj || { echo "import_csv.clj is not the data.csv version"; exit 1; }
       - name: Build dataset for tests
         run: |
           clojure -T:build clean || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,13 @@ jobs:
       - name: Static guards (typos & legacy)
         run: |
           set -euo pipefail
+          # Directories to scan
+          DIRS="src test resources scripts"
           # 1) ban typo 'engest/'
-          ! git grep -n "engest/" -- ':!public/build/*' || { echo "Typo 'engest/' found"; exit 1; }
+          ! git grep -n "engest/" -- $DIRS || { echo "Typo 'engest/' found"; exit 1; }
           # 2) ban old normalizer ref
-          ! git grep -n "ic/normalize-track" -- ':!public/build/*' || { echo "Use ingest/normalize-track instead of ic/normalize-track"; exit 1; }
-          # 3) ban split-based CSV parsing (must use data.csv)
+          ! git grep -n "ic/normalize-track" -- $DIRS || { echo "Use ingest/normalize-track instead of ic/normalize-track"; exit 1; }
+          # 3) ban split-based CSV parsing (must use clojure.data.csv)
           ! git grep -nE 'string/split.+","' -- src || { echo "Legacy CSV parsing detected. Use clojure.data.csv"; exit 1; }
           # 4) enforce data.csv version via sentinel
           grep -q 'SENTINEL: data.csv-parser v1' src/vgm/import_csv.clj || { echo "import_csv.clj is not the data.csv version"; exit 1; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,18 @@ jobs:
           if git grep -nE '^(<<<<<<<|=======$|>>>>>>> )' -- ':!public/build/*' ':!dist/*' ; then
             echo "Unresolved merge conflict markers found"; exit 1; fi
 
+      - name: Static guards (typos & legacy)
+        run: |
+          set -euo pipefail
+          # 1) ban typo 'engest/'
+          ! git grep -n "engest/" -- ':!public/build/*' || { echo "Typo 'engest/' found"; exit 1; }
+          # 2) ban old normalizer ref
+          ! git grep -n "ic/normalize-track" -- ':!public/build/*' || { echo "Use ingest/normalize-track instead of ic/normalize-track"; exit 1; }
+          # 3) ban split-based CSV parsing (must use data.csv)
+          ! git grep -nE 'string/split.+","' -- src || { echo "Legacy CSV parsing detected. Use clojure.data.csv"; exit 1; }
+          # 4) enforce data.csv version via sentinel
+          grep -q 'SENTINEL: data.csv-parser v1' src/vgm/import_csv.clj || { echo "import_csv.clj is not the data.csv version"; exit 1; }
+
       - name: Preflight require (vgm.cli)
         run: clojure -M -e "(require 'vgm.cli 'vgm.ingest 'vgm.import-csv)"
 


### PR DESCRIPTION
## Summary
- guard against common typos and legacy code paths during CI
- add equivalent static checks to autofetch workflow

## Testing
- `test -f .github/workflows/ci.yml`
- `rg "Static guards (typos & legacy)" .github/workflows/ci.yml`
- `rg "Static guards (typos & legacy)" .github/workflows/autofetch.yml`
- `rg "engest/" -n src || true`
- `rg "ic/normalize-track" -n src || true`
- `clj-kondo --lint src test build.clj` *(fails: command not found)*
- `curl -sL https://raw.githubusercontent.com/borkdude/clj-kondo/master/script/install-clj-kondo | bash -s -- -d /usr/local/bin` *(fails: no output, likely blocked network)*
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aead6f56488324a809f51d4eb9d38b