### PR TITLE
feat: autofetch stats and schedule

### DIFF
--- a/.github/workflows/autofetch.yml
+++ b/.github/workflows/autofetch.yml
@@ -2,12 +2,16 @@ name: Auto-fetch
 
 on:
   schedule:
-    - cron: "30 19 * * 1"
+    - cron: "30 18 * * *"
   workflow_dispatch:
     inputs:
       dry_run:
         type: boolean
         default: false
+
+concurrency:
+  group: "autofetch"
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -52,6 +56,16 @@ jobs:
         run: clojure -M -e "(require 'vgm.autofetch 'vgm.cli 'vgm.ingest 'vgm.import-csv)"
       - name: Run autofetch
         run: clojure -M -m vgm.autofetch
+      - name: Run stats
+        run: |
+          YEAR=$(clojure -M -m vgm.stats added-by-year || echo "Stats unavailable")
+          echo "YEAR<<'EOF'" >> $GITHUB_ENV
+          echo "$YEAR" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          COMP=$(clojure -M -m vgm.stats added-by-composer || echo "Stats unavailable")
+          echo "COMP<<'EOF'" >> $GITHUB_ENV
+          echo "$COMP" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
       - name: Ingest candidates
         run: clojure -M -m vgm.cli ingest
       - name: Create PR
@@ -67,10 +81,11 @@ jobs:
             - Please review stats below. CI will validate schema and IDs.
 
             ### Stats (preview)
-            ```
-            $ clojure -M -m vgm.stats added-by-year
-            $ clojure -M -m vgm.stats added-by-composer
-            ```
+            #### Added by year
+            ${{ env.YEAR }}
+
+            #### Added by composer
+            ${{ env.COMP }}
           labels: data, bot
           delete-branch: true
       - name: Enable auto-merge (squash)

--- a/src/vgm/stats.clj
+++ b/src/vgm/stats.clj
@@ -1,26 +1,46 @@
 (ns vgm.stats
   (:gen-class)
   (:require [vgm.core :as core]
+            [vgm.ingest :as ingest]
             [clojure.string :as str]))
 
-(defn- table [headers rows]
-  (println (str "|" (str/join "|" headers) "|"))
-  (println (str "|" (str/join "|" (repeat (count headers) "-")) "|"))
-  (doseq [r rows]
-    (println (str "|" (str/join "|" r) "|"))))
+(defn- table
+  "Render a markdown table given headers and rows.
+  Returns a string with newline separators."
+  [headers rows]
+  (let [header (str "|" (str/join "|" headers) "|")
+        sep    (str "|" (str/join "|" (repeat (count headers) "---")) "|")
+        body   (map #(str "|" (str/join "|" %) "|") rows)]
+    (str/join "\n" (concat [header sep] body))))
+
+(defn- newly-added
+  "Return tracks that are present in candidates but not already in
+  `resources/data/tracks.edn`."
+  []
+  (let [kfn      (juxt :title :game :composer :year)
+        existing (set (map kfn (core/load-tracks)))]
+    (->> (ingest/read-candidates "resources/candidates")
+         (remove #(contains? existing (kfn %)))
+         distinct)))
 
 (defn added-by-year []
-  (let [tracks (core/load-tracks)
-        grouped (->> tracks (group-by :year) (map (fn [[y ts]] [y (count ts)])) (sort-by first))]
-    (table ["year" "count"] grouped)))
+  (let [grouped (->> (newly-added)
+                     (group-by :year)
+                     (map (fn [[y ts]] [y (count ts)]))
+                     (sort-by first))]
+    (println (table ["year" "count"] grouped))))
 
 (defn added-by-composer []
-  (let [tracks (core/load-tracks)
-        grouped (->> tracks (group-by :composer) (map (fn [[c ts]] [c (count ts)])) (sort-by first))]
-    (table ["composer" "count"] grouped)))
+  (let [grouped (->> (newly-added)
+                     (group-by :composer)
+                     (map (fn [[c ts]] [c (count ts)]))
+                     (sort-by second >)
+                     (take 10))]
+    (println (table ["composer" "count"] grouped))))
 
 (defn -main [& [cmd]]
   (case cmd
     "added-by-year" (added-by-year)
     "added-by-composer" (added-by-composer)
     (println "Unknown command")))
+


### PR DESCRIPTION
## Summary
- aggregate new candidate tracks via `vgm.stats` with year and composer tables
- embed stats output and nightly schedule in autofetch workflow

## Testing
- `clojure -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb69bddbc83249be7702c4e10040e