### PR TITLE
feat: add web quiz loop

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -171,10 +171,14 @@ function showQuestion() {
   const prompt = document.getElementById('prompt');
   const answer = document.getElementById('answer');
   const submit = document.getElementById('submit-btn');
+  const next = document.getElementById('next-btn');
   const feedback = document.getElementById('feedback');
+  const scoreBar = document.getElementById('score-bar');
   answer.value = '';
   feedback.textContent = '';
-  submit.textContent = 'Submit';
+  submit.disabled = false;
+  next.style.display = 'none';
+  scoreBar.textContent = `Score: ${score}/${questions.length}`;
   switch (q.type) {
     case 'title-game':
       prompt.textContent = `Which game is the track "${q.track.title}" from?`;
@@ -192,16 +196,13 @@ function showQuestion() {
 }
 
 function submitAnswer() {
-  if (awaitingNext) {
-    nextQuestion();
-    return;
-  }
   const q = questions[current];
   const promptText = document.getElementById('prompt').textContent;
   const rawInput = document.getElementById('answer').value;
   const userAns = canonical(rawInput);
   const expected = canonical(q.expected);
   const feedback = document.getElementById('feedback');
+  const scoreBar = document.getElementById('score-bar');
   const correct = userAns === expected;
   if (correct) {
     score++;
@@ -210,14 +211,17 @@ function submitAnswer() {
     feedback.textContent = `Incorrect. Correct: ${q.expected}`;
   }
   recordPlay({
-    track: q.track,
+    trackId: trackId(q.track),
     prompt: promptText,
     expected: q.expected,
     userAnswer: rawInput,
     correct
   });
+  scoreBar.textContent = `Score: ${score}/${questions.length}`;
   const submit = document.getElementById('submit-btn');
-  submit.textContent = current === questions.length - 1 ? 'Finish' : 'Next';
+  const next = document.getElementById('next-btn');
+  submit.disabled = true;
+  next.style.display = 'inline';
   awaitingNext = true;
 }
 
@@ -259,10 +263,16 @@ async function clearHistory() {
 
 document.getElementById('start-btn').addEventListener('click', startQuiz);
 document.getElementById('submit-btn').addEventListener('click', submitAnswer);
+document.getElementById('next-btn').addEventListener('click', nextQuestion);
 document.getElementById('restart-btn').addEventListener('click', restart);
 document.getElementById('history-btn').addEventListener('click', showHistory);
 document.getElementById('history-back-btn').addEventListener('click', () => showView('start-view'));
 document.getElementById('clear-history-btn').addEventListener('click', clearHistory);
+document.getElementById('answer').addEventListener('keydown', e => {
+  if (e.key === 'Enter') {
+    awaitingNext ? nextQuestion() : submitAnswer();
+  }
+});
 
 loadDataset();
 loadAliases();

--- a/public/index.html
+++ b/public/index.html
@@ -22,9 +22,11 @@
   </div>
 
   <div id="question-view" style="display:none">
+    <div id="score-bar"></div>
     <div id="prompt"></div>
     <input id="answer" type="text" autocomplete="off" />
     <button id="submit-btn">Submit</button>
+    <button id="next-btn" style="display:none">Next</button>
     <div id="feedback"></div>
   </div>
 


### PR DESCRIPTION
## Summary
- add score bar and next button to question view
- record plays with track IDs and update scoring
- keyboard enter submits or advances between questions

## Testing
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `test -f public/app.js`
- `rg "normalize\('NFKC'\)" public/app.js`
- `rg "objectStore" public/app.js`
- `grep -iq "dataset.json" public/app.js`
- `grep -iq "aliases.json" public/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68aeb8cf2a40832489cc58fe32dc2e7d