### PR TITLE
Add Playwright E2E smoke test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,33 @@
+name: e2e
+
+on:
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+      - name: Setup Clojure CLI
+        uses: DeLaGuardo/setup-clojure@13.4
+        with:
+          cli: latest
+      - name: Build dataset
+        run: clojure -T:build publish
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install Playwright
+        run: |
+          npm install --no-save playwright
+          npx playwright install --with-deps chromium
+      - name: Start static server
+        run: python3 -m http.server 8080 -d public &
+      - name: Run test
+        run: node e2e/test.js

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -1,0 +1,61 @@
+const { chromium } = require('playwright');
+const fs = require('fs');
+const path = require('path');
+
+(async () => {
+  const datasetPath = path.join(__dirname, '..', 'public', 'build', 'dataset.json');
+  const dataset = JSON.parse(fs.readFileSync(datasetPath, 'utf-8'));
+  const tracks = dataset.tracks || [];
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/');
+
+  await page.waitForSelector('#start-btn:not([disabled])');
+  await page.fill('#count', '1');
+  await page.click('#start-btn');
+
+  await page.waitForSelector('#prompt');
+  const promptText = await page.textContent('#prompt');
+
+  let expected;
+  if (promptText.startsWith('Which game is the track')) {
+    const title = /"(.+)"/.exec(promptText)[1];
+    const track = tracks.find(t => t.title === title);
+    expected = track.game;
+  } else if (promptText.startsWith('Who composed the music for')) {
+    const game = /"(.+)"/.exec(promptText)[1];
+    const track = tracks.find(t => t.game === game);
+    expected = track.composer;
+  } else if (promptText.startsWith('Who composed the track')) {
+    const title = /"(.+)"/.exec(promptText)[1];
+    const track = tracks.find(t => t.title === title);
+    expected = track.composer;
+  } else {
+    throw new Error(`Unknown prompt: ${promptText}`);
+  }
+
+  await page.fill('#answer', expected);
+  await page.click('#submit-btn');
+
+  const feedback = await page.textContent('#feedback');
+  if (!/Correct!|正解/.test(feedback)) {
+    throw new Error(`Unexpected feedback: ${feedback}`);
+  }
+
+  const scoreText = await page.textContent('#score-bar');
+  if (!/^Score: 1\/\d+/.test(scoreText)) {
+    throw new Error(`Unexpected score: ${scoreText}`);
+  }
+
+  await page.click('#next-btn');
+  await page.click('#restart-btn');
+  await page.click('#history-btn');
+  await page.waitForSelector('#history-list li');
+  const historyCount = await page.locator('#history-list li').count();
+  if (historyCount < 1) {
+    throw new Error('History not recorded');
+  }
+
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- add Playwright script that loads the quiz, answers a question, checks score and history
- run script on pull requests via new e2e workflow

## Testing
- `npm install --no-save playwright` (fails: 403 Forbidden)
- `node e2e/test.js` (fails: Cannot find module 'playwright')

------
https://chatgpt.com/codex/tasks/task_e_68aeba756dfc83248eac033a81c3f83a