### PR TITLE
feat: add dataset update prompt for PWA

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -4,7 +4,9 @@
             [clojure.java.io :as io]
             [clojure.data.json :as json])
   (:import (java.io PushbackReader)
-           (java.util UUID)))
+           (java.util UUID)
+           (java.security MessageDigest)
+           (java.math BigInteger)))
 
 (defn clean [_]
   (b/delete {:path "build"}))
@@ -91,6 +93,23 @@
         (ensure-dir (.getParent (io/file json-path)))
         (spit (io/file json-path) (json/write-str data :key-fn kw->json-key))))))
 
+(defn- file-digest [^MessageDigest md ^java.io.File f]
+  (with-open [is (io/input-stream f)]
+    (let [buf (byte-array 8192)]
+      (loop []
+        (let [n (.read is buf)]
+          (when (pos? n)
+            (.update md buf 0 n)
+            (recur)))))))
+
+(defn- dataset-version []
+  (let [md (MessageDigest/getInstance "SHA-256")]
+    (doseq [path ["public/build/dataset.json" "public/build/aliases.json"]]
+      (let [f (io/file path)]
+        (when (.exists f)
+          (file-digest md f))))
+    (format "%064x" (BigInteger. 1 (.digest md)))))
+
 (defn publish [_]
   ;; 1) 生成
   (dataset nil)
@@ -105,7 +124,10 @@
   ;; 5) version.json
   (let [sha (System/getenv "GITHUB_SHA")
         commit (if (and sha (<= 7 (count sha))) (subs sha 0 7) "dev")
+        ds-meta (-> (slurp (io/file "public/build/dataset.json"))
+                    (json/read-str :key-fn keyword))
         ver {:commit commit
-             :generated_at (str (java.time.Instant/now))}]
+             :dataset_version (dataset-version)
+             :generated_at (:generated_at ds-meta)}]
     (spit (io/file "public/build/version.json")
           (json/write-str ver))))

--- a/public/app.js
+++ b/public/app.js
@@ -5,6 +5,7 @@ let score = 0;
 let awaitingNext = false;
 const aliases = {};
 window.__APP_VERSION__ = 'dev';
+window.__DATASET_VERSION__ = null;
 
 const DB_NAME = 'vgm-quiz';
 const STORE = 'plays';
@@ -140,6 +141,7 @@ async function loadVersion() {
     const res = await fetch('./build/version.json');
     const data = await res.json();
     window.__APP_VERSION__ = data.commit || 'dev';
+    window.__DATASET_VERSION__ = data.dataset_version || null;
   } catch (err) {
     console.warn('Failed to load version', err);
   }
@@ -279,6 +281,22 @@ loadAliases();
 
 loadVersion().then(() => {
   if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.addEventListener('message', async event => {
+      if (event.data && event.data.type === 'dataset-updated') {
+        try {
+          const res = await fetch('./build/version.json');
+          const v = await res.json();
+          if (v.dataset_version && v.dataset_version !== window.__DATASET_VERSION__) {
+            if (confirm('新しい問題が利用可能です。更新しますか？')) {
+              location.reload();
+            }
+            window.__DATASET_VERSION__ = v.dataset_version;
+          }
+        } catch (err) {
+          console.error('Failed to check dataset version', err);
+        }
+      }
+    });
     navigator.serviceWorker.register(`sw.js?v=${encodeURIComponent(window.__APP_VERSION__ || 'dev')}`).then(registration => {
       function showUpdateBanner() {
         if (document.getElementById('sw-update')) return;

--- a/public/build/version.json
+++ b/public/build/version.json
@@ -1,1 +1,1 @@
-{"commit":"dev","generated_at":"2025-01-01T00:00:00Z"}
+{"commit":"dev","dataset_version":"dev","generated_at":"2025-01-01T00:00:00Z"}

--- a/public/sw.js
+++ b/public/sw.js
@@ -14,13 +14,31 @@ self.addEventListener('install', event => {
 });
 
 self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+  if (url.pathname.endsWith('/build/dataset.json') || url.pathname.endsWith('/build/aliases.json')) {
+    event.respondWith((async () => {
+      const cache = await caches.open(CACHE_NAME);
+      const cached = await cache.match(event.request);
+      const network = fetch(event.request).then(async response => {
+        if (response.ok) {
+          await cache.put(event.request, response.clone());
+          const clients = await self.clients.matchAll();
+          clients.forEach(c => c.postMessage({type:'dataset-updated'}));
+        }
+        return response;
+      }).catch(() => {});
+      event.waitUntil(network);
+      return cached || network;
+    })());
+    return;
+  }
   event.respondWith(
     caches.match(event.request).then(cached => {
-      const fetchPromise = fetch(event.request).then(response => {
-        caches.open(CACHE_NAME).then(cache => cache.put(event.request, response.clone()));
+      return cached || fetch(event.request).then(response => {
+        const resClone = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, resClone));
         return response;
       });
-      return cached || fetchPromise;
     })
   );
 });
@@ -30,4 +48,3 @@ self.addEventListener('message', event => {
     self.skipWaiting();
   }
 });
-


### PR DESCRIPTION
## Summary
- add stale-while-revalidate fetch handling in service worker and notify clients of dataset updates
- check dataset version on update and prompt users to reload
- generate version.json with dataset hash metadata

## Testing
- `rg -F "postMessage({type:'dataset-updated'})" public/sw.js`
- `rg "serviceWorker" public/app.js`
- `test -f public/build/version.json`
- `clojure -M:test` *(fails: command not found)*
- `clojure -T:build publish` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aebbfb0ebc8324b4eeb8fe2d8ccc19