### PR TITLE
Limit E2E workflow to pull requests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,13 @@ name: e2e
 
 on:
   pull_request:
+    branches: [ main ]
+    paths:
+      - "public/**"
+      - "src/**"
+      - "e2e/**"
+      - ".github/workflows/e2e.yml"
+  workflow_dispatch: {}
 
 jobs:
   e2e:


### PR DESCRIPTION
## Summary
- run e2e tests only on pull requests to main
- allow manual dispatch and skip when web files unchanged

## Testing
- `rg "^on:" -n .github/workflows/e2e.yml`
- `rg "push:" -n .github/workflows/e2e.yml`
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install clojure -y` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68aec6a5bf7483249db3c4fe67faf4c9