### PR TITLE
feat: add みんはや export

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -206,7 +206,10 @@ function selectedTypes() {
 }
 
 function updateStartButton() {
-  document.getElementById('start-btn').disabled = !datasetLoaded || selectedTypes().length === 0;
+  const disabled = !datasetLoaded || selectedTypes().length === 0;
+  document.getElementById('start-btn').disabled = disabled;
+  const btn = document.getElementById('export-minhaya-btn');
+  if (btn) btn.disabled = disabled;
 }
 
 async function loadDataset() {
@@ -256,6 +259,51 @@ async function loadVersion() {
   el.style.marginTop = '1em';
   el.textContent = `Version: ${window.__APP_VERSION__}`;
   document.body.appendChild(el);
+}
+
+function escapeCsv(str) {
+  return '"' + String(str).replace(/"/g, '""') + '"';
+}
+
+function toMinhayaCsv(items) {
+  const rows = items.map(it => `${escapeCsv(it.question)},${escapeCsv(it.answer)},${escapeCsv(it.explanation || '')}`);
+  return `question,answer,explanation\n${rows.join('\n')}`;
+}
+
+function exportMinhaya() {
+  const countSelect = document.getElementById('count');
+  let n = parseInt(countSelect.value, 10) || 5;
+  const deduped = distinctBy(['title', 'game', 'composer'], tracks);
+  n = Math.min(n, deduped.length);
+  const selected = spreadByBucket(deduped, t => yearBucket(t.year), n);
+  const types = selectedTypes();
+  const items = selected.map(track => {
+    const type = types[Math.floor(Math.random() * types.length)];
+    switch (type) {
+      case 'title-game':
+        return { question: `この曲の収録作品は？: ${track.title}`,
+                 answer: track.game,
+                 explanation: `${track.year} / ${track.composer}` };
+      case 'game-composer':
+        return { question: `この作品の作曲者は？: ${track.game}`,
+                 answer: track.composer,
+                 explanation: `${track.year}` };
+      case 'title-composer':
+        return { question: `この曲の作曲者は？: ${track.title}`,
+                 answer: track.composer,
+                 explanation: `${track.year} / ${track.game}` };
+    }
+  });
+  const csv = toMinhayaCsv(items);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'minhaya.csv';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 }
 
 function startQuiz() {
@@ -419,6 +467,11 @@ document.getElementById('history-btn').addEventListener('click', showHistory);
 document.getElementById('history-back-btn').addEventListener('click', () => showView('start-view'));
 document.getElementById('clear-history-btn').addEventListener('click', clearHistory);
 document.getElementById('export-aliases-btn').addEventListener('click', exportAliasProposals);
+const exportMinhayaBtn = document.createElement('button');
+exportMinhayaBtn.id = 'export-minhaya-btn';
+exportMinhayaBtn.textContent = 'Export for みんはや';
+exportMinhayaBtn.addEventListener('click', exportMinhaya);
+document.getElementById('start-view').appendChild(exportMinhayaBtn);
 document.querySelectorAll('input[name="qtype"]').forEach(cb => {
   cb.addEventListener('change', () => {
     settings.types = selectedTypes();

--- a/src/vgm/cli.clj
+++ b/src/vgm/cli.clj
@@ -23,11 +23,19 @@
       (let [{:keys [n format]} (parse-opts opts)
             n (or (some-> n Integer/parseInt) 30)
             format (keyword (or format "plain"))
-            items (export/build-questions n)
+            items (export/build-questions n {})
             out (case format
                   :csv (export/to-csv items)
                   (export/to-plain items))]
         (println out))
+
+      "export-minhaya"
+      (let [[out & more] opts
+            {:keys [n]} (parse-opts more)
+            n (or (some-> n Integer/parseInt) 100)
+            items (export/build-questions n {})
+            csv (export/to-minhaya-csv items)]
+        (spit out csv))
 
       "import-csv"
       (let [[in out] opts

--- a/src/vgm/export.clj
+++ b/src/vgm/export.clj
@@ -5,19 +5,29 @@
             [vgm.question-pipeline :as qp]))
 
 (defn build-questions
-  "Generate N questions using the existing pipeline."
-  [n]
-  (let [tracks (core/load-tracks)
-        _ (assert (core/valid-dataset? tracks) "Invalid dataset")
-        {:keys [items]} (qp/pick-questions tracks
-                                           {:n n
-                                            :distinct-by [:title :game :composer]
-                                            :spread-by :year-bucket
-                                            :qtypes [:title->game :game->composer :title->composer]})]
-    (->> items
-         (map (fn [{:keys [track qtype]}]
-                (core/make-question qtype track)))
-         vec)))
+  "Generate N questions using the existing pipeline.
+
+  Returns a vector of maps with keys :prompt, :answer and :explanation.
+  Accepts an optional opts map which is forwarded to
+  `vgm.question-pipeline/pick-questions`."
+  ([n] (build-questions n {}))
+  ([n opts]
+   (let [tracks (core/load-tracks)
+         _ (assert (core/valid-dataset? tracks) "Invalid dataset")
+         {:keys [items]} (qp/pick-questions tracks
+                                            (merge {:n n
+                                                    :distinct-by [:title :game :composer]
+                                                    :spread-by :year-bucket
+                                                    :qtypes [:title->game :game->composer :title->composer]}
+                                                   opts))]
+     (->> items
+          (map (fn [{:keys [track qtype]}]
+                 (let [{:keys [prompt answer]} (core/make-question qtype track)
+                       explanation (str (:year track) " / " (:composer track))]
+                   {:prompt prompt
+                    :answer answer
+                    :explanation explanation})))
+          vec))))
 
 (defn to-plain
   "Return plain text with one question per line: prompt\tanswer."
@@ -37,3 +47,13 @@
                     (str (escape-csv prompt) "," (escape-csv answer)))
                   items)]
     (str "question,answer\n" (str/join "\n" rows))))
+
+(defn to-minhaya-csv
+  "Return CSV for みんはや with header question,answer,explanation."
+  [items]
+  (let [rows (map (fn [{:keys [prompt answer explanation]}]
+                    (str (escape-csv prompt) ","
+                         (escape-csv answer) ","
+                         (escape-csv (or explanation ""))))
+                  items)]
+    (str "question,answer,explanation\n" (str/join "\n" rows))))

--- a/test/vgm/export_test.clj
+++ b/test/vgm/export_test.clj
@@ -1,0 +1,15 @@
+(ns vgm.export-test
+  (:require [clojure.test :refer :all]
+            [clojure.string :as str]
+            [vgm.export :as sut]))
+
+(deftest minhaya-csv
+  (let [items (sut/build-questions 3 {})
+        csv (sut/to-minhaya-csv items)
+        lines (str/split-lines csv)]
+    (is (= "question,answer,explanation" (first lines)))
+    (is (= 4 (count lines)))
+    (doseq [line (rest lines)]
+      (let [[q a _] (str/split line #"," 3)]
+        (is (not (str/blank? q)))
+        (is (not (str/blank? a)))))))


### PR DESCRIPTION
## Summary
- add CSV export tailored for みんはや with explanations
- expose `export-minhaya` CLI subcommand to write CSV
- add web button to download みんはや CSV

## Testing
- `clojure -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec98e50c083248375e883557c8418