### PR TITLE
feat: auto-merge alias proposals

### DIFF
--- a/.github/workflows/aliases-merge.yml
+++ b/.github/workflows/aliases-merge.yml
@@ -1,0 +1,43 @@
+name: Merge alias proposals
+
+on:
+  pull_request:
+    paths:
+      - 'resources/alias_proposals/*.edn'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+      - name: Setup Clojure CLI
+        uses: DeLaGuardo/setup-clojure@13.4
+        with:
+          cli: latest
+      - run: clojure -T:build publish || true
+      - id: merge
+        run: |
+          table=$(clojure -M -m vgm.aliases merge resources/alias_proposals/*.edn resources/data/aliases.edn)
+          echo "table<<'EOF'" >> $GITHUB_OUTPUT
+          echo "$table" >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update aliases
+          title: Update aliases (auto-merge proposals)
+          body: ${{ steps.merge.outputs.table }}
+          labels: data, aliases
+          branch: bot/aliases-merge-${{ github.run_id }}
+          base: ${{ github.event.pull_request.base.ref }}
+          add-paths: resources/data/aliases.edn
+          delete-branch: true

--- a/.github/workflows/aliases-merge.yml
+++ b/.github/workflows/aliases-merge.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           cli: latest
       - run: clojure -T:build publish || true
+      - name: Preflight require (aliases)
+        run: clojure -M -e "(require 'vgm.aliases)"
       - id: merge
         run: |
           table=$(clojure -M -m vgm.aliases merge resources/alias_proposals/*.edn resources/data/aliases.edn)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
         run: |
           clojure -T:build clean || true
           clojure -T:build publish
+      - name: Preflight require (aliases)
+        run: clojure -M -e "(require 'vgm.aliases)"
+
 
       - name: Tests (if any)
         run: |

--- a/README.md
+++ b/README.md
@@ -48,13 +48,12 @@ clojure -M -m vgm.cli import-csv new_tracks.csv resources/data/tracks.edn
 クイズで誤答した際に表示される「別名として提案」ボタンから候補を保存できます。
 
 1. 提案を溜めたら、スタート画面の「Export alias proposals (.edn)」ボタンでダウンロード。
-2. CLI で既存の `aliases.edn` に統合します。
+2. `resources/alias_proposals/` に `.edn` ファイルを配置して PR を作成すると、ワークフローが自動で `aliases.edn` に統合し、"Update aliases (auto-merge proposals)" という別PRを作成します。
+3. ローカルで確認する場合は次のコマンドでもマージできます。
 
 ```bash
-clojure -M -m vgm.aliases merge-proposals alias-proposals.edn resources/data/aliases.edn
+clojure -M -m vgm.aliases merge resources/alias_proposals/*.edn resources/data/aliases.edn
 ```
-
-3. 生成された `aliases.edn` をコミットして PR を作成してください。
 
 ## 概要
 

--- a/src/vgm/aliases.clj
+++ b/src/vgm/aliases.clj
@@ -27,7 +27,7 @@
   (Normalizer/normalize (str s) Normalizer$Form/NFKC))
 
 (defn- base-normalize [s]
-  (-> s nfkc str/trim str/lower-case))
+  (-> (or s "") nfkc str/trim str/lower-case))
 
 ;; Ensure {:game {:canon #{aliases}} :composer {...}} with sets and normalized keys/values.
 (defn- normalize-alias-map [m]
@@ -70,7 +70,7 @@
                               (for [[canon pset] (get P cat {})]
                                 (let [before (get-in A [cat canon] #{})
                                       diff   (set/difference pset before)]
-                                  [canon (count diff)]))]))
+                                  [canon (count diff)])))]))
         total-added (reduce + 0 (mapcat vals (vals added)))]
     {:result result :added added :total-added total-added}))
 

--- a/src/vgm/aliases.clj
+++ b/src/vgm/aliases.clj
@@ -1,67 +1,96 @@
 (ns vgm.aliases
-  (:gen-class)
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
-            [clojure.set :as set]
-            [vgm.core-shared :as shared]))
+            [clojure.pprint :as pp]
+            [clojure.string :as str]
+            [clojure.set :as set])
+  (:import (java.io PushbackReader)
+           (java.text Normalizer Normalizer$Form)))
 
-(defn- canonicalize [m]
-  (into {}
-        (for [[cat entries] m]
-          [cat
-           (into {}
-                 (for [[canon aliases] entries]
-                   [(shared/normalize canon)
-                    (set (map shared/normalize aliases))]))]))
+;; --- I/O helpers -----------------------------------------------------------
 
-(defn- merge-aliases [base props]
-  (merge-with
-    (fn [m1 m2]
-      (merge-with set/union m1 m2))
-    base props))
+(defn- read-edn-file [path]
+  (let [f (io/file path)]
+    (when (.exists f)
+      (with-open [r (io/reader f)]
+        (edn/read (PushbackReader. r))))))
 
-(defn- diff-stats [base props]
-  (into {}
-        (for [[cat entries] props]
-          (let [base-entries (get base cat {})]
-            [cat {:added   (count (remove #(contains? base-entries %) (keys entries)))
-                  :updated (count (filter (fn [k]
-                                            (let [new (get entries k)
-                                                  old (get base-entries k #{})]
-                                              (not (set/subset? new old))))
-                                          (filter #(contains? base-entries %) (keys entries))))}]))))
+(defn- write-edn-file [path data]
+  (let [f (io/file path)]
+    (when-let [dir (.getParentFile f)]
+      (.mkdirs dir))
+    (spit f (with-out-str (pp/pprint data)))))
 
-(defn merge-proposals [aliases proposals]
-  (let [aliases   (canonicalize aliases)
-        proposals (canonicalize proposals)
-        merged    (merge-aliases aliases proposals)]
-    {:merged merged
-     :stats  (diff-stats aliases proposals)}))
+;; --- Normalization (match core canonicalization) ---------------------------
 
-(defn- stats-table [stats]
-  (let [header "| Category | Added | Updated |\n|---|---:|---:|\n"]
-    (str header
-         (apply str
-                (for [[cat {:keys [added updated]}] (sort-by key stats)]
-                  (format "| %s | %d | %d |\n" (name cat) added updated))))))
+(defn- nfkc [s]
+  (Normalizer/normalize (str s) Normalizer$Form/NFKC))
 
-(defn -main [& args]
-  (let [[cmd & more] args]
-    (case cmd
-      "merge" (let [aliases-path (last more)
-                     props-files  (butlast more)
-                     proposals    (reduce (fn [acc f]
-                                            (merge-aliases acc (canonicalize (edn/read-string (slurp f)))))
-                                          {}
-                                          props-files)
-                     aliases      (if (.exists (io/file aliases-path))
-                                    (edn/read-string (slurp aliases-path))
-                                    {})
-                     {:keys [merged stats]} (merge-proposals aliases proposals)]
-                 (spit aliases-path (pr-str merged))
-                 (println (stats-table stats)))
-      (do
-        (binding [*out* *err*]
-          (println "Unknown command" cmd)
-          (println "Usage: merge <proposals.edn>... <aliases.edn>"))
-        (System/exit 1)))))
+(defn- base-normalize [s]
+  (-> s nfkc str/trim str/lower-case))
+
+;; Ensure {:game {:canon #{aliases}} :composer {...}} with sets and normalized keys/values.
+(defn- normalize-alias-map [m]
+  (letfn [(norm-cat [cat-map]
+            (reduce
+              (fn [acc [canon aliases]]
+                (let [canon* (base-normalize canon)
+                      set*   (into #{} (map base-normalize) (or aliases #{}))
+                      prev   (get acc canon* #{})
+                      merged (into prev set*)]
+                  (assoc acc canon* merged)))
+              {}
+              (or cat-map {})))]
+    {:game     (norm-cat (:game m))
+     :composer (norm-cat (:composer m))}))
+
+;; --- Merge -----------------------------------------------------------------
+
+(defn merge-proposals
+  "Merge proposals into existing aliases.
+   Returns {:result <merged> :added {cat {canon n}} :total-added n}."
+  [aliases proposals]
+  (let [A (normalize-alias-map (or aliases {}))
+        P (normalize-alias-map (or proposals {}))
+        cats [:game :composer]
+        result (reduce
+                 (fn [acc cat]
+                   (update acc cat
+                           (fn [am]
+                             (reduce (fn [am* [canon pset]]
+                                       (update am* canon (fnil into #{}) pset))
+                                     (or am {})
+                                     (get P cat {})))))
+                 A
+                 cats)
+        added  (into {}
+                     (for [cat cats]
+                       [cat
+                        (into {}
+                              (for [[canon pset] (get P cat {})]
+                                (let [before (get-in A [cat canon] #{})
+                                      diff   (set/difference pset before)]
+                                  [canon (count diff)]))]))
+        total-added (reduce + 0 (mapcat vals (vals added)))]
+    {:result result :added added :total-added total-added}))
+
+;; --- CLI -------------------------------------------------------------------
+
+(defn -main [& [cmd proposals-path aliases-path]]
+  (case cmd
+    "merge"
+    (let [proposals (or (and proposals-path (read-edn-file proposals-path)) {})
+          aliases   (or (and aliases-path   (read-edn-file aliases-path))   {})
+          {:keys [result added total-added]} (merge-proposals aliases proposals)
+          out (or aliases-path "resources/data/aliases.edn")]
+      (write-edn-file out result)
+      (println (format "aliases merged → %s (added %d)" out total-added))
+      (doseq [cat [:game :composer]]
+        (let [m (get added cat)
+              m' (into {} (remove (comp zero? val)) m)]
+          (when (seq m')
+            (println (name cat) ":" m'))))
+      (shutdown-agents))
+    (do
+      (println "Usage: clojure -M -m vgm.aliases merge <proposals.edn> <aliases.edn>")
+      (shutdown-agents))))

--- a/src/vgm/aliases.clj
+++ b/src/vgm/aliases.clj
@@ -20,23 +20,48 @@
       (merge-with set/union m1 m2))
     base props))
 
-(defn merge-proposals! [props-path aliases-path]
-  (let [props    (canonicalize (edn/read-string (slurp props-path)))
-        aliases  (if (.exists (io/file aliases-path))
-                   (edn/read-string (slurp aliases-path))
-                   {})
-        merged   (merge-aliases aliases props)
-        bak-path (str aliases-path ".bak")]
-    (when (.exists (io/file aliases-path))
-      (io/copy (io/file aliases-path) (io/file bak-path)))
-    (spit aliases-path (pr-str merged))))
+(defn- diff-stats [base props]
+  (into {}
+        (for [[cat entries] props]
+          (let [base-entries (get base cat {})]
+            [cat {:added   (count (remove #(contains? base-entries %) (keys entries)))
+                  :updated (count (filter (fn [k]
+                                            (let [new (get entries k)
+                                                  old (get base-entries k #{})]
+                                              (not (set/subset? new old))))
+                                          (filter #(contains? base-entries %) (keys entries))))}]))))
+
+(defn merge-proposals [aliases proposals]
+  (let [aliases   (canonicalize aliases)
+        proposals (canonicalize proposals)
+        merged    (merge-aliases aliases proposals)]
+    {:merged merged
+     :stats  (diff-stats aliases proposals)}))
+
+(defn- stats-table [stats]
+  (let [header "| Category | Added | Updated |\n|---|---:|---:|\n"]
+    (str header
+         (apply str
+                (for [[cat {:keys [added updated]}] (sort-by key stats)]
+                  (format "| %s | %d | %d |\n" (name cat) added updated))))))
 
 (defn -main [& args]
-  (let [[cmd props aliases] args]
+  (let [[cmd & more] args]
     (case cmd
-      "merge-proposals" (merge-proposals! props aliases)
+      "merge" (let [aliases-path (last more)
+                     props-files  (butlast more)
+                     proposals    (reduce (fn [acc f]
+                                            (merge-aliases acc (canonicalize (edn/read-string (slurp f)))))
+                                          {}
+                                          props-files)
+                     aliases      (if (.exists (io/file aliases-path))
+                                    (edn/read-string (slurp aliases-path))
+                                    {})
+                     {:keys [merged stats]} (merge-proposals aliases proposals)]
+                 (spit aliases-path (pr-str merged))
+                 (println (stats-table stats)))
       (do
         (binding [*out* *err*]
           (println "Unknown command" cmd)
-          (println "Usage: merge-proposals <proposals.edn> <aliases.edn>"))
+          (println "Usage: merge <proposals.edn>... <aliases.edn>"))
         (System/exit 1)))))

--- a/test/vgm/aliases_test.clj
+++ b/test/vgm/aliases_test.clj
@@ -1,15 +1,14 @@
 (ns vgm.aliases-test
-  (:require [clojure.test :refer [deftest is]]
-            [vgm.aliases :as aliases]))
+  (:require [clojure.test :refer :all]
+            [vgm.aliases :as sut]))
 
-(deftest merge-proposals-test
+(deftest merge-proposals-basic
   (let [aliases   {:game {"dragon quest" #{"dq"}}}
-        proposals {:game {"Dragon Quest" ["ドラゴンクエスト"]
-                           "ゼルダの伝説" ["ゼルダ"]}}
-        {:keys [merged stats]} (aliases/merge-proposals aliases proposals)]
+        proposals {:game {"dragon quest" #{"ドラゴンクエスト" "dq"}}
+                   :composer {"toby fox" #{"トビー・フォックス"}}}
+        {:keys [result added total-added]} (sut/merge-proposals aliases proposals)]
     (is (= #{"dq" "ドラゴンクエスト"}
-           (get-in merged [:game "dragon quest"])))
-    (is (= #{"ゼルダ"}
-           (get-in merged [:game "ゼルダの伝説"])))
-    (is (= {:game {:added 1 :updated 1}}
-           stats))))
+           (get-in result [:game "dragon quest"])))
+    (is (= 1 (get-in added [:game "dragon quest"])))
+    (is (= 1 (get-in added [:composer "toby fox"])))
+    (is (= 2 total-added))))

--- a/test/vgm/aliases_test.clj
+++ b/test/vgm/aliases_test.clj
@@ -1,0 +1,15 @@
+(ns vgm.aliases-test
+  (:require [clojure.test :refer [deftest is]]
+            [vgm.aliases :as aliases]))
+
+(deftest merge-proposals-test
+  (let [aliases   {:game {"dragon quest" #{"dq"}}}
+        proposals {:game {"Dragon Quest" ["ドラゴンクエスト"]
+                           "ゼルダの伝説" ["ゼルダ"]}}
+        {:keys [merged stats]} (aliases/merge-proposals aliases proposals)]
+    (is (= #{"dq" "ドラゴンクエスト"}
+           (get-in merged [:game "dragon quest"])))
+    (is (= #{"ゼルダ"}
+           (get-in merged [:game "ゼルダの伝説"])))
+    (is (= {:game {:added 1 :updated 1}}
+           stats))))


### PR DESCRIPTION
## Summary
- merge alias proposals into aliases.edn with diff stats
- auto-merge alias proposals via GitHub workflow
- document alias proposal workflow and add tests

## Testing
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aecd8def588324bc79b3abfb60f589