### PR TITLE
Fix service worker update loop with content hash

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -93,21 +93,16 @@
         (ensure-dir (.getParent (io/file json-path)))
         (spit (io/file json-path) (json/write-str data :key-fn kw->json-key))))))
 
-(defn- file-digest [^MessageDigest md ^java.io.File f]
-  (with-open [is (io/input-stream f)]
-    (let [buf (byte-array 8192)]
-      (loop []
-        (let [n (.read is buf)]
-          (when (pos? n)
-            (.update md buf 0 n)
-            (recur)))))))
-
-(defn- dataset-version []
-  (let [md (MessageDigest/getInstance "SHA-256")]
-    (doseq [path ["public/build/dataset.json" "public/build/aliases.json"]]
-      (let [f (io/file path)]
-        (when (.exists f)
-          (file-digest md f))))
+(defn- sha256-file [path]
+  (let [md (MessageDigest/getInstance "SHA-256")
+        f  (io/file path)]
+    (with-open [is (io/input-stream f)]
+      (let [buf (byte-array 8192)]
+        (loop []
+          (let [n (.read is buf)]
+            (when (pos? n)
+              (.update md buf 0 n)
+              (recur))))))
     (format "%064x" (BigInteger. 1 (.digest md)))))
 
 (defn publish [_]
@@ -122,12 +117,10 @@
   ;; 4) aliases があれば JSON も出力
   (edn->json-file "resources/data/aliases.edn" "public/build/aliases.json")
   ;; 5) version.json
-  (let [sha (System/getenv "GITHUB_SHA")
-        commit (if (and sha (<= 7 (count sha))) (subs sha 0 7) "dev")
-        ds-meta (-> (slurp (io/file "public/build/dataset.json"))
+  (let [ds-meta (-> (slurp (io/file "public/build/dataset.json"))
                     (json/read-str :key-fn keyword))
-        ver {:commit commit
-             :dataset_version (dataset-version)
+        ver {:dataset_version 1
+             :content_hash (sha256-file "public/build/dataset.json")
              :generated_at (:generated_at ds-meta)}]
     (spit (io/file "public/build/version.json")
           (json/write-str ver))))

--- a/public/app.js
+++ b/public/app.js
@@ -13,6 +13,35 @@ let paused = false;
 window.__APP_VERSION__ = 'dev';
 window.__DATASET_VERSION__ = null;
 
+const VERSION_URL = 'build/version.json';
+const HASH_KEY = 'dataset_hash';
+
+async function readVersionNoStore(){
+  const r = await fetch(VERSION_URL,{cache:'no-store'});
+  return r.json();
+}
+function rememberHash(h){ localStorage.setItem(HASH_KEY,h); }
+function currentHash(){ return localStorage.getItem(HASH_KEY); }
+async function checkOnLoad(){
+  try{
+    const {content_hash} = await readVersionNoStore();
+    if(!currentHash()) rememberHash(content_hash);
+  }catch(e){ console.warn('version check failed',e); }
+}
+async function applyUpdateAndReload(){
+  try{
+    const {content_hash} = await readVersionNoStore();
+    rememberHash(content_hash);
+  }catch(_){ }
+  location.reload();
+}
+
+function showUpdatePrompt(){
+  if(confirm('新しい問題が利用可能です。更新しますか？')){
+    applyUpdateAndReload();
+  }
+}
+
 const SETTINGS_KEY = 'quiz-options';
 function loadSettings() {
   try {
@@ -251,7 +280,7 @@ async function loadAliases() {
 
 async function loadVersion() {
   try {
-    const res = await fetch('./build/version.json');
+    const res = await fetch(VERSION_URL);
     const data = await res.json();
     window.__APP_VERSION__ = data.commit || 'dev';
     window.__DATASET_VERSION__ = data.dataset_version || null;
@@ -575,27 +604,19 @@ if (settings.mode) {
 }
 updateStartButton();
 
+checkOnLoad();
 loadDataset();
 loadAliases();
 
+navigator.serviceWorker?.addEventListener('message', async (e)=>{
+  if(e.data?.type==='version-refreshed'){
+    const {content_hash} = await readVersionNoStore();
+    if(currentHash() !== content_hash){ showUpdatePrompt(); }
+  }
+});
+
 loadVersion().then(() => {
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.addEventListener('message', async event => {
-      if (event.data && event.data.type === 'dataset-updated') {
-        try {
-          const res = await fetch('./build/version.json');
-          const v = await res.json();
-          if (v.dataset_version && v.dataset_version !== window.__DATASET_VERSION__) {
-            if (confirm('新しい問題が利用可能です。更新しますか？')) {
-              location.reload();
-            }
-            window.__DATASET_VERSION__ = v.dataset_version;
-          }
-        } catch (err) {
-          console.error('Failed to check dataset version', err);
-        }
-      }
-    });
     navigator.serviceWorker.register(`sw.js?v=${encodeURIComponent(window.__APP_VERSION__ || 'dev')}`).then(registration => {
       function showUpdateBanner() {
         if (document.getElementById('sw-update')) return;
@@ -613,7 +634,7 @@ loadVersion().then(() => {
         btn.textContent = '更新があります。リロードしますか？';
         btn.addEventListener('click', () => {
           registration.waiting?.postMessage({ type: 'SKIP_WAITING' });
-          location.reload();
+          applyUpdateAndReload();
         });
         banner.appendChild(btn);
         document.body.appendChild(banner);

--- a/public/build/version.json
+++ b/public/build/version.json
@@ -1,1 +1,1 @@
-{"commit":"dev","dataset_version":"dev","generated_at":"2025-01-01T00:00:00Z"}
+{"dataset_version":1,"content_hash":"dev","generated_at":"2025-01-01T00:00:00Z"}

--- a/public/sw.js
+++ b/public/sw.js
@@ -13,35 +13,40 @@ self.addEventListener('install', event => {
   );
 });
 
-self.addEventListener('fetch', event => {
-  const url = new URL(event.request.url);
-  if (url.pathname.endsWith('/build/dataset.json') || url.pathname.endsWith('/build/aliases.json')) {
-    event.respondWith((async () => {
-      const cache = await caches.open(CACHE_NAME);
-      const cached = await cache.match(event.request);
-      const network = fetch(event.request).then(async response => {
-        if (response.ok) {
-          await cache.put(event.request, response.clone());
-          const clients = await self.clients.matchAll();
-          clients.forEach(c => c.postMessage({type:'dataset-updated'}));
-        }
-        return response;
-      }).catch(() => {});
-      event.waitUntil(network);
-      return cached || network;
-    })());
-    return;
-  }
-  event.respondWith(
-    caches.match(event.request).then(cached => {
-      return cached || fetch(event.request).then(response => {
-        const resClone = response.clone();
-        caches.open(CACHE_NAME).then(cache => cache.put(event.request, resClone));
-        return response;
-      });
-    })
-  );
-});
+self.addEventListener('install', e => { self.skipWaiting(); });
+self.addEventListener('activate', e => { e.waitUntil(self.clients.claim()); });
+
+  self.addEventListener('fetch', event => {
+    const url = new URL(event.request.url);
+    if (url.pathname.endsWith('/build/dataset.json') || url.pathname.endsWith('/build/version.json')) {
+      event.respondWith((async () => {
+        const cache = await caches.open(CACHE_NAME);
+        const cached = await cache.match(event.request);
+        const network = fetch(event.request, {cache:'no-store'}).then(async response => {
+          if (response.ok) {
+            await cache.put(event.request, response.clone());
+            if (url.pathname.endsWith('/build/version.json')) {
+              const clients = await self.clients.matchAll();
+              clients.forEach(c => c.postMessage({type:'version-refreshed'}));
+            }
+          }
+          return response;
+        }).catch(() => {});
+        event.waitUntil(network);
+        return cached || network;
+      })());
+      return;
+    }
+    event.respondWith(
+      caches.match(event.request).then(cached => {
+        return cached || fetch(event.request).then(response => {
+          const resClone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, resClone));
+          return response;
+        });
+      })
+    );
+  });
 
 self.addEventListener('message', event => {
   if (event.data && event.data.type === 'SKIP_WAITING') {


### PR DESCRIPTION
## Summary
- write `public/build/version.json` with dataset content hash
- make SW fetch dataset/version with `no-store` and notify clients when version refreshes
- remember dataset hash before reloading to avoid repeated update prompts

## Testing
- ⚠️ `clojure -T:build publish` (command not found: clojure)
- ⚠️ `clojure -M:test` (command not found: clojure)


------
https://chatgpt.com/codex/tasks/task_e_68aee4f36eb48324acd2ecdc243c591e