### PR TITLE
Ensure MC and timer UI show and cache bust app.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ python -m http.server -d public 4444
 # or: npx serve public
 ```
 
+CI builds provide the current commit hash via the `GITHUB_SHA` environment variable.
+`build.clj` reads this with `System/getenv` to write `public/build/app-meta.json`
+for cache-busting purposes.
+
 Index page displays dataset version and track count.
 
 ## Snapshot

--- a/build.clj
+++ b/build.clj
@@ -123,4 +123,10 @@
              :content_hash (sha256-file "public/build/dataset.json")
              :generated_at (:generated_at ds-meta)}]
     (spit (io/file "public/build/version.json")
-          (json/write-str ver))))
+          (json/write-str ver))
+    ;; app metadata for cache busting; CI provides GITHUB_SHA env var
+    (let [commit (or (System/getenv "GITHUB_SHA") "unknown")
+          meta {:commit commit
+                :built_at (str (java.time.Instant/now))}]
+      (spit (io/file "public/build/app-meta.json")
+            (json/write-str meta)))))

--- a/public/app.js
+++ b/public/app.js
@@ -10,7 +10,8 @@ let questionMode = 'input'; // multiple choice mode uses 'mc'
 let timerId = null;
 let remaining = 20;
 let paused = false;
-window.__APP_VERSION__ = 'dev';
+const scriptTag = document.currentScript;
+window.__APP_VERSION__ = scriptTag?.dataset?.version || 'dev';
 window.__DATASET_VERSION__ = null;
 
 const VERSION_URL = 'build/version.json';
@@ -603,6 +604,8 @@ if (settings.mode) {
   questionMode = settings.mode;
 }
 updateStartButton();
+
+console.log('features', { mode: questionMode === 'mc' ? 'MC' : 'Text', timer: '20s' });
 
 checkOnLoad();
 loadDataset();

--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,7 @@
         <option value="20">20</option>
       </select>
     </label>
+    <div id="timer-info">Timer 20s</div>
     <button id="start-btn" disabled>Start</button>
     <div id="dataset-error" style="display:none;color:red;"></div>
     <button id="history-btn">History</button>
@@ -62,8 +63,8 @@
     <button id="restart-btn">Restart</button>
   </div>
 
-  <script src="mc.js"></script>
-  <script src="app.js"></script>
+    <script src="mc.js"></script>
+    <script src="app.js?ver=d27d0cc" data-version="d27d0cc"></script>
   <script>
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('sw.js');


### PR DESCRIPTION
## Summary
- Show timer status on start view and add commit-based cache busting for app.js
- Log mode and timer features on load and expose app version via data attribute
- Record build metadata (commit and timestamp) during publish

## Testing
- `clojure -M:test` *(fails: command not found)*
- `node e2e/test.js` *(fails: Cannot find module 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68aee97f0ba4832499b20adb68e992dd