### PR TITLE
feat: add dataset version footer

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -280,19 +280,43 @@ async function loadAliases() {
 }
 
 async function loadVersion() {
+  let commit = 'dev';
   try {
-    const res = await fetch(VERSION_URL);
+    const res = await fetch(VERSION_URL, { cache: 'no-store' });
     const data = await res.json();
-    window.__APP_VERSION__ = data.commit || 'dev';
     window.__DATASET_VERSION__ = data.dataset_version || null;
+    const parts = [
+      `Dataset v${data.dataset_version}`,
+      data.content_hash.slice(0, 8),
+      new Date(data.generated_at).toLocaleString()
+    ];
+
+    try {
+      const metaRes = await fetch('build/app-meta.json', { cache: 'no-store' });
+      if (metaRes.ok) {
+        const meta = await metaRes.json();
+        if (meta.commit) {
+          commit = meta.commit;
+          parts.push(`commit: ${commit.slice(0, 7)}`);
+        }
+      } else if (data.commit) {
+        commit = data.commit;
+      }
+    } catch (_) {
+      if (data.commit) commit = data.commit;
+    }
+
+    window.__APP_VERSION__ = commit;
+    const el = document.getElementById('ver');
+    if (el) {
+      el.textContent = parts.join(' • ');
+      el.style.fontSize = 'small';
+      el.style.opacity = '0.7';
+      el.style.textAlign = 'center';
+    }
   } catch (err) {
     console.warn('Failed to load version', err);
   }
-  const el = document.createElement('div');
-  el.id = 'app-version';
-  el.style.marginTop = '1em';
-  el.textContent = `Version: ${window.__APP_VERSION__}`;
-  document.body.appendChild(el);
 }
 
 function escapeCsv(str) {

--- a/public/index.html
+++ b/public/index.html
@@ -63,6 +63,8 @@
     <button id="restart-btn">Restart</button>
   </div>
 
+  <footer id="ver"></footer>
+
     <script src="mc.js"></script>
     <script src="app.js?ver=d27d0cc" data-version="d27d0cc"></script>
   <script>


### PR DESCRIPTION
## Summary
- show dataset version in app footer
- fetch version info without caching and display commit when available

## Testing
- `clojure -M:test` (fails: command not found)
- `apt-get update` (fails: repository not signed / 403)

------
https://chatgpt.com/codex/tasks/task_e_68aeeb9d70b88324a5d2aa887540ee80