### PR TITLE
fix: handle service worker updates gracefully

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -660,8 +660,10 @@ loadVersion().then(() => {
         const btn = document.createElement('button');
         btn.textContent = '更新があります。リロードしますか？';
         btn.addEventListener('click', () => {
-          registration.waiting?.postMessage({ type: 'SKIP_WAITING' });
-          applyUpdateAndReload();
+          registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+          navigator.serviceWorker.addEventListener('controllerchange', () => {
+            window.location.reload();
+          });
         });
         banner.appendChild(btn);
         document.body.appendChild(banner);
@@ -680,7 +682,6 @@ loadVersion().then(() => {
           });
         }
       });
-      navigator.serviceWorker.addEventListener('controllerchange', showUpdateBanner);
     });
   }
 });

--- a/public/sw.js
+++ b/public/sw.js
@@ -16,7 +16,7 @@ self.addEventListener('install', event => {
 self.addEventListener('install', e => { self.skipWaiting(); });
 self.addEventListener('activate', e => { e.waitUntil(self.clients.claim()); });
 
-  self.addEventListener('fetch', event => {
+self.addEventListener('fetch', event => {
     const url = new URL(event.request.url);
     if (url.pathname.endsWith('/build/dataset.json') || url.pathname.endsWith('/build/version.json')) {
       event.respondWith((async () => {


### PR DESCRIPTION
## Summary
- reload page after service worker takes control instead of immediately on update banner click
- remove global controllerchange listener to avoid persistent update banner
- ensure service worker skips waiting and claims clients on activation

## Testing
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aeef0900fc83248b91f7dd04d560a6