### PR TITLE
feat: improve service worker update handling

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -119,14 +119,10 @@
   ;; 5) version.json
   (let [ds-meta (-> (slurp (io/file "public/build/dataset.json"))
                     (json/read-str :key-fn keyword))
+        commit (or (System/getenv "GITHUB_SHA") "dev")
         ver {:dataset_version 1
              :content_hash (sha256-file "public/build/dataset.json")
-             :generated_at (:generated_at ds-meta)}]
+             :generated_at (:generated_at ds-meta)
+             :commit commit}]
     (spit (io/file "public/build/version.json")
-          (json/write-str ver))
-    ;; app metadata for cache busting; CI provides GITHUB_SHA env var
-    (let [commit (or (System/getenv "GITHUB_SHA") "unknown")
-          meta {:commit commit
-                :built_at (str (java.time.Instant/now))}]
-      (spit (io/file "public/build/app-meta.json")
-            (json/write-str meta)))))
+          (json/write-str ver))))

--- a/public/app.js
+++ b/public/app.js
@@ -37,10 +37,27 @@ async function applyUpdateAndReload(){
   location.reload();
 }
 
-function showUpdatePrompt(){
-  if(confirm('新しい問題が利用可能です。更新しますか？')){
-    applyUpdateAndReload();
-  }
+let swRegistration = null;
+function showUpdateBanner(){
+  if(document.getElementById('sw-update') || !swRegistration) return;
+  const banner = document.createElement('div');
+  banner.id = 'sw-update';
+  banner.style.position = 'fixed';
+  banner.style.bottom = '0';
+  banner.style.left = '0';
+  banner.style.right = '0';
+  banner.style.background = '#333';
+  banner.style.color = '#fff';
+  banner.style.padding = '8px';
+  banner.style.textAlign = 'center';
+  const btn = document.createElement('button');
+  btn.textContent = '更新があります。リロードしますか？';
+  btn.addEventListener('click', () => {
+    swRegistration.waiting?.postMessage({type:'SKIP_WAITING'});
+    navigator.serviceWorker.addEventListener('controllerchange', applyUpdateAndReload);
+  });
+  banner.appendChild(btn);
+  document.body.appendChild(banner);
 }
 
 const SETTINGS_KEY = 'quiz-options';
@@ -280,33 +297,18 @@ async function loadAliases() {
 }
 
 async function loadVersion() {
-  let commit = 'dev';
   try {
     const res = await fetch(VERSION_URL, { cache: 'no-store' });
     const data = await res.json();
     window.__DATASET_VERSION__ = data.dataset_version || null;
+    const commit = data.commit || 'dev';
+    window.__APP_VERSION__ = commit;
     const parts = [
       `Dataset v${data.dataset_version}`,
       data.content_hash.slice(0, 8),
-      new Date(data.generated_at).toLocaleString()
+      new Date(data.generated_at).toLocaleString(),
+      `commit: ${commit.slice(0, 7)}`
     ];
-
-    try {
-      const metaRes = await fetch('build/app-meta.json', { cache: 'no-store' });
-      if (metaRes.ok) {
-        const meta = await metaRes.json();
-        if (meta.commit) {
-          commit = meta.commit;
-          parts.push(`commit: ${commit.slice(0, 7)}`);
-        }
-      } else if (data.commit) {
-        commit = data.commit;
-      }
-    } catch (_) {
-      if (data.commit) commit = data.commit;
-    }
-
-    window.__APP_VERSION__ = commit;
     const el = document.getElementById('ver');
     if (el) {
       el.textContent = parts.join(' • ');
@@ -638,45 +640,22 @@ loadAliases();
 navigator.serviceWorker?.addEventListener('message', async (e)=>{
   if(e.data?.type==='version-refreshed'){
     const {content_hash} = await readVersionNoStore();
-    if(currentHash() !== content_hash){ showUpdatePrompt(); }
+    if(currentHash() !== content_hash){ showUpdateBanner(); }
   }
 });
 
 loadVersion().then(() => {
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register(`sw.js?v=${encodeURIComponent(window.__APP_VERSION__ || 'dev')}`).then(registration => {
-      function showUpdateBanner() {
-        if (document.getElementById('sw-update')) return;
-        const banner = document.createElement('div');
-        banner.id = 'sw-update';
-        banner.style.position = 'fixed';
-        banner.style.bottom = '0';
-        banner.style.left = '0';
-        banner.style.right = '0';
-        banner.style.background = '#333';
-        banner.style.color = '#fff';
-        banner.style.padding = '8px';
-        banner.style.textAlign = 'center';
-        const btn = document.createElement('button');
-        btn.textContent = '更新があります。リロードしますか？';
-        btn.addEventListener('click', () => {
-          registration.waiting.postMessage({ type: 'SKIP_WAITING' });
-          navigator.serviceWorker.addEventListener('controllerchange', () => {
-            window.location.reload();
-          });
-        });
-        banner.appendChild(btn);
-        document.body.appendChild(banner);
-      }
-
-      if (registration.waiting) {
+    navigator.serviceWorker.register(`sw.js?v=${encodeURIComponent(window.__APP_VERSION__ || 'dev')}`).then(reg => {
+      swRegistration = reg;
+      if (swRegistration.waiting) {
         showUpdateBanner();
       }
-      registration.addEventListener('updatefound', () => {
-        const newWorker = registration.installing;
+      swRegistration.addEventListener('updatefound', () => {
+        const newWorker = swRegistration.installing;
         if (newWorker) {
           newWorker.addEventListener('statechange', () => {
-            if (registration.waiting) {
+            if (swRegistration.waiting) {
               showUpdateBanner();
             }
           });

--- a/public/build/version.json
+++ b/public/build/version.json
@@ -1,1 +1,1 @@
-{"dataset_version":1,"content_hash":"dev","generated_at":"2025-01-01T00:00:00Z"}
+{"dataset_version":1,"content_hash":"dev","generated_at":"2025-01-01T00:00:00Z","commit":"dev"}

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,42 +10,53 @@ const CORE_ASSETS = [
 self.addEventListener('install', event => {
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(CORE_ASSETS))
+      .then(() => self.skipWaiting())
   );
 });
-
-self.addEventListener('install', e => { self.skipWaiting(); });
 self.addEventListener('activate', e => { e.waitUntil(self.clients.claim()); });
 
 self.addEventListener('fetch', event => {
     const url = new URL(event.request.url);
-    if (url.pathname.endsWith('/build/dataset.json') || url.pathname.endsWith('/build/version.json')) {
+    if (url.pathname.endsWith('/build/dataset.json')) {
       event.respondWith((async () => {
         const cache = await caches.open(CACHE_NAME);
         const cached = await cache.match(event.request);
-        const network = fetch(event.request, {cache:'no-store'}).then(async response => {
-          if (response.ok) {
-            await cache.put(event.request, response.clone());
-            if (url.pathname.endsWith('/build/version.json')) {
-              const clients = await self.clients.matchAll();
-              clients.forEach(c => c.postMessage({type:'version-refreshed'}));
-            }
-          }
-          return response;
+        const network = fetch(event.request, { cache: 'no-store' }).then(async r => {
+          if (r.ok) await cache.put(event.request, r.clone());
+          return r;
         }).catch(() => {});
         event.waitUntil(network);
         return cached || network;
       })());
       return;
     }
-    event.respondWith(
-      caches.match(event.request).then(cached => {
-        return cached || fetch(event.request).then(response => {
-          const resClone = response.clone();
-          caches.open(CACHE_NAME).then(cache => cache.put(event.request, resClone));
-          return response;
-        });
-      })
-    );
+    if (url.pathname.endsWith('/build/version.json')) {
+      event.respondWith((async () => {
+        const cache = await caches.open(CACHE_NAME);
+        const cached = await cache.match(event.request);
+        const network = fetch(event.request, { cache: 'no-store' }).then(async r => {
+          if (r.ok) {
+            await cache.put(event.request, r.clone());
+            const clients = await self.clients.matchAll();
+            clients.forEach(c => c.postMessage({ type: 'version-refreshed' }));
+          }
+          return r;
+        }).catch(() => {});
+        event.waitUntil(network);
+        return cached || network;
+      })());
+      return;
+    }
+    event.respondWith((async () => {
+      const cache = await caches.open(CACHE_NAME);
+      const cached = await cache.match(event.request);
+      const fetchPromise = fetch(event.request).then(async r => {
+        if (r.ok) await cache.put(event.request, r.clone());
+        return r;
+      }).catch(() => {});
+      if (cached) event.waitUntil(fetchPromise);
+      return cached || fetchPromise;
+    })());
   });
 
 self.addEventListener('message', event => {


### PR DESCRIPTION
## Summary
- include commit and content hash in generated version.json
- perform no-store fetch for version metadata in service worker and notify clients
- register service worker with update banner and reload using pre-remembered dataset hash

## Testing
- `clojure -M:test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aef05c1e9c8324ae51858bc8d6c572