### PR TITLE
chore: skip auto merge on workflow changes

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,8 +8,24 @@ permissions:
   pull-requests: write
 
 jobs:
+  changed:
+    runs-on: ubuntu-latest
+    outputs:
+      touched_workflows: ${{ steps.filter.outputs.workflows }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            workflows:
+              - '.github/workflows/**'
+
   enable:
+    needs: changed
     if: >
+      needs.changed.outputs.touched_workflows != 'true' &&
       github.event.pull_request.head.repo.full_name == github.repository && (
         startsWith(github.event.pull_request.head.ref, 'codex/') ||
         startsWith(github.event.pull_request.head.ref, 'bot/') ||
@@ -23,3 +39,22 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash
+
+  comment-when-workflow:
+    needs: changed
+    if: ${{ needs.changed.outputs.touched_workflows == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) return;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: "\U0001F512 This PR modifies GitHub Actions workflows. Auto-merge is skipped by policy. Please merge manually after checks are green."
+            });
+


### PR DESCRIPTION
## Summary
- detect if PR modifies workflows
- only enable auto-merge when workflows untouched
- comment on PRs that modify workflows

## Testing
- `clojure -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af0f17cff8832486c9ec8c6945336e