### PR TITLE
feat(e2e): harden mode selection and capture diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,11 @@ jobs:
             ~/.deps.clj
             .cpcache
           key: cljdeps-${{ runner.os }}-${{ hashFiles('**/deps.edn') }}
+
+      - name: Upload e2e artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-artifacts
+          path: e2e-artifacts
+          if-no-files-found: ignore

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -1,42 +1,81 @@
 const { chromium } = require('playwright');
+const fs = require('fs');
 const TIMEOUT = 45000;
 
 (async () => {
   const browser = await chromium.launch();
   const page = await browser.newPage();
 
-  await page.goto('http://localhost:8080/', { waitUntil: 'domcontentloaded', timeout: TIMEOUT });
-  await page.waitForResponse(
-    (resp) => resp.url().endsWith('/build/dataset.json') && resp.ok(),
-    { timeout: TIMEOUT }
-  );
+  try {
+    await page.goto('http://localhost:8080/', {
+      waitUntil: 'domcontentloaded',
+      timeout: TIMEOUT,
+    });
+    await page.waitForResponse(
+      (resp) => resp.url().endsWith('/build/dataset.json') && resp.ok(),
+      { timeout: TIMEOUT }
+    );
 
-  await page.selectOption('#mode', { value: 'mc' });
+    await page.waitForSelector('#mode', { state: 'visible' });
+    await page.waitForFunction(
+      () => {
+        const el = document.querySelector('#mode');
+        return el && el.querySelectorAll('option').length >= 2;
+      },
+      { timeout: 30000 }
+    );
 
-  await page.waitForSelector('#start-btn', { state: 'attached', timeout: TIMEOUT });
-  await page.waitForFunction(
-    () => {
-      const b = document.querySelector('#start-btn');
-      return b && !b.disabled;
-    },
-    { timeout: TIMEOUT }
-  );
-  await page.click('#start-btn');
+    const values = await page.$$eval('#mode option', (opts) =>
+      opts.map((o) => o.value || o.textContent.trim())
+    );
+    const wanted = ['multiple-choice', 'mc', 'choices', 'free', 'input'];
+    const pick =
+      wanted.find((w) => values.includes(w)) || values.find((v) => v) || null;
+    if (!pick) {
+      throw new Error(`No selectable option: got [${values.join(', ')}]`);
+    }
+    await page
+      .selectOption('#mode', { value: pick })
+      .catch(async () => {
+        await page.selectOption('#mode', { label: pick });
+      });
 
-  await page.waitForFunction(
-    () => {
-      const first = document.querySelector('#choices button');
-      return first && first.textContent.trim() === window.__expectedAnswer;
-    },
-    { timeout: TIMEOUT }
-  );
+    await page.waitForSelector('#start-btn', {
+      state: 'attached',
+      timeout: TIMEOUT,
+    });
+    await page.waitForFunction(
+      () => {
+        const b = document.querySelector('#start-btn');
+        return b && !b.disabled;
+      },
+      { timeout: TIMEOUT }
+    );
+    await page.click('#start-btn');
 
-  await page.click('#choices button');
+    await page.waitForFunction(
+      () => {
+        const first = document.querySelector('#choices button');
+        return first && first.textContent.trim() === window.__expectedAnswer;
+      },
+      { timeout: TIMEOUT }
+    );
 
-  await page.waitForFunction(
-    () => /Score: 1/.test(document.getElementById('score-bar').textContent),
-    { timeout: TIMEOUT }
-  );
+    await page.click('#choices button');
 
-  await browser.close();
+    await page.waitForFunction(
+      () => /Score: 1/.test(document.getElementById('score-bar').textContent),
+      { timeout: TIMEOUT }
+    );
+  } catch (e) {
+    await page
+      .screenshot({ path: 'e2e-artifacts/failure.png', fullPage: true })
+      .catch(() => {});
+    const html = await page.content().catch(() => '');
+    fs.mkdirSync('e2e-artifacts', { recursive: true });
+    fs.writeFileSync('e2e-artifacts/dom.html', html);
+    throw e;
+  } finally {
+    await browser.close();
+  }
 })();


### PR DESCRIPTION
## Summary
- wait for mode selector, ensure options load, then pick a real value
- capture screenshot and DOM when e2e test fails
- upload e2e artifacts in CI

## Testing
- `curl -L -O https://download.clojure.org/install/linux-install.sh` (fails: CONNECT tunnel failed, response 403)
- `npm install --no-save playwright@1.49.0` (fails: 403 Forbidden)
- `node e2e/test.js` (fails: Cannot find module 'playwright')

------
https://chatgpt.com/codex/tasks/task_e_68af1c1b1c108324907711aa94307f14