### PR TITLE
Normalize mode values

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -27,8 +27,10 @@ clojure -T:build publish
 python -m http.server -d public 4444
 ```
 
+## UI–E2E contract
+- #mode select must be static with only "multiple-choice" and "free" options; dynamic insertion is forbidden
+
 ## Activity Log
-- E2E: #mode select has static options "multiple-choice" and "free"; do not add dynamically
 - CI: lint + schema test
 - CI: clj-kondo via release binary
 - CI: clj-kondo via setup-clojure

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -37,7 +37,7 @@ async function dumpArtifacts(page, prefix = 'failure') {
           opts.map((o) => o.value || o.textContent.trim())
         );
         if (values.length > 0) {
-          const wanted = ['multiple-choice', 'mc', 'choices', 'free', 'input'];
+          const wanted = ['multiple-choice', 'free'];
           const pick = wanted.find((w) => values.includes(w)) || values[0];
           await page
             .selectOption('#mode', { value: pick })

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -65,7 +65,15 @@ function showUpdateBanner(){
 const SETTINGS_KEY = 'quiz-options';
 function loadSettings() {
   try {
-    return JSON.parse(localStorage.getItem(SETTINGS_KEY)) || {};
+    const s = JSON.parse(localStorage.getItem(SETTINGS_KEY)) || {};
+    if (s.mode === 'mc4') s.mode = 'multiple-choice';
+    if (s.mode === 'text') s.mode = 'free';
+    const q = new URLSearchParams(location.search).get('mode');
+    if (q) {
+      s.mode = q === 'mc4' ? 'multiple-choice' : q === 'text' ? 'free' : q;
+    }
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(s));
+    return s;
   } catch {
     return {};
   }


### PR DESCRIPTION
## Summary
- normalize stored and query mode values to `multiple-choice` or `free`
- restrict E2E test to the new mode names
- document UI–E2E contract for static mode options

## Testing
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm run e2e` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afcc52e9dc8324bc86252f6f429c3d