### PR TITLE
Canonicalize mode select options

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -28,7 +28,9 @@ python -m http.server -d public 4444
 ```
 
 ## UI–E2E contract
-- #mode select must be static with only "multiple-choice" and "free" options; dynamic insertion is forbidden
+- #mode is present in initial HTML.
+- Allowed values are exactly multiple-choice and free.
+- Dynamic insertion is forbidden.
 
 ## Activity Log
 - CI: lint + schema test

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -15,8 +15,8 @@
   </fieldset>
   <label>Mode:
     <select id="mode">
-      <option value="multiple-choice">multiple-choice</option>
-      <option value="free">free</option>
+      <option value="multiple-choice">4択</option>
+      <option value="free">自由入力</option>
     </select>
   </label>
   <label style="margin-left:8px">

--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!doctype html><meta charset="utf-8"><title>VGM Quiz</title>
 <select id="mode" style="display:none">
-  <option value="multiple-choice">multiple-choice</option>
-  <option value="free">free</option>
+  <option value="multiple-choice">4択</option>
+  <option value="free">自由入力</option>
 </select>
 <script>
 (async () => {


### PR DESCRIPTION
## Summary
- Canonicalize `#mode` select options in `public/app/index.html` and the root `public/index.html` to static `multiple-choice` and `free` values with Japanese labels.
- Clarify UI–E2E contract in `PROJECT_STATUS.md` to require `#mode` presence and forbid dynamic option insertion.

## Testing
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*
- `npm run e2e` *(fails: missing package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68afce6c0bb48324b6c6b543840f87d8