### PR TITLE
Refine mode selection validation

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -66,11 +66,12 @@ const SETTINGS_KEY = 'quiz-options';
 function loadSettings() {
   try {
     const s = JSON.parse(localStorage.getItem(SETTINGS_KEY)) || {};
-    if (s.mode === 'mc4') s.mode = 'multiple-choice';
-    if (s.mode === 'text') s.mode = 'free';
     const q = new URLSearchParams(location.search).get('mode');
-    if (q) {
-      s.mode = q === 'mc4' ? 'multiple-choice' : q === 'text' ? 'free' : q;
+    if (q === 'multiple-choice' || q === 'free') {
+      s.mode = q;
+    }
+    if (s.mode !== 'multiple-choice' && s.mode !== 'free') {
+      s.mode = 'free';
     }
     localStorage.setItem(SETTINGS_KEY, JSON.stringify(s));
     return s;


### PR DESCRIPTION
## Summary
- Ensure quiz mode query parameter only accepts `multiple-choice` or `free`
- Default mode to `free` when setting is missing or invalid

## Testing
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68afe90d0b348324b55efe9b7b3ef5a5