### PR TITLE
Make E2E on-demand, archive legacy CI to manual, and make autofetch manual

### DIFF
--- a/.github/workflows/autofetch.yml
+++ b/.github/workflows/autofetch.yml
@@ -1,8 +1,6 @@
 name: Auto-fetch
 
 on:
-  schedule:
-    - cron: "30 18 * * *"
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
-name: CI
+name: CI (legacy, manual)
 
 on:
-  pull_request:
-  push:
-    branches: [main]
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,14 +1,9 @@
-name: e2e
+name: e2e (on-demand)
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - "public/**"
-      - "src/**"
-      - "e2e/**"
-      - ".github/workflows/e2e.yml"
   workflow_dispatch: {}
+  schedule:
+    - cron: "0 18 * * *"  # JST 03:00 頃に相当（不要ならこのブロックを削除）
 
 jobs:
   e2e:


### PR DESCRIPTION
## Summary
- run e2e workflow only on manual dispatch and nightly schedule
- restrict legacy CI workflow to manual dispatch only
- run autofetch workflow only when manually dispatched

## Testing
- `grep -E '^name: e2e \(on-demand\)$' .github/workflows/e2e.yml`
- `bash -lc '! grep -E "^\s*pull_request:" .github/workflows/e2e.yml'`
- `grep -E '^name: CI \(legacy, manual\)$' .github/workflows/ci.yml`
- `bash -lc '! grep -E "^\s*pull_request:|^\s*push:" .github/workflows/ci.yml'`
- `grep -E '^\s*workflow_dispatch:' .github/workflows/autofetch.yml`
- `bash -lc '! grep -E "^\s*schedule:" .github/workflows/autofetch.yml && echo "OK"'`
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: The repository ... InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b00c084a7483248df4c648eff1d5b7