### PR TITLE
chore: disable service worker in test mode

### DIFF
--- a/e2e/test.js
+++ b/e2e/test.js
@@ -18,10 +18,14 @@ async function dumpArtifacts(page, prefix = 'failure') {
   const page = await browser.newPage();
 
   try {
-    await page.goto(process.env.APP_URL || 'http://127.0.0.1:8080/app/', {
+    const base = process.env.APP_URL || 'http://127.0.0.1:8080/app/';
+    const url = base.includes('?') ? (base + '&test=1') : (base + '?test=1');
+    await page.goto(url, {
       waitUntil: 'domcontentloaded',
       timeout: 60000,
     });
+    // TEST_MODE では SW 未登録なので、キャッシュ関連の更新待ちは軽くなる
+    // 以降の待機ロジックは既存のままでOK
     await page.waitForResponse(
       (resp) => resp.url().endsWith('/build/dataset.json') && resp.ok(),
       { timeout: TIMEOUT }

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -19,6 +19,10 @@ const DATASET_URL = '../build/dataset.json';
 const ALIASES_URL = '../build/aliases.json';
 const HASH_KEY = 'dataset_hash';
 
+// TEST MODE: URL に ?test=1 が付いていたら Service Worker を無効化
+const __SEARCH_PARAMS__ = new URLSearchParams(location.search);
+const __IS_TEST_MODE__ = __SEARCH_PARAMS__.get('test') === '1';
+
 async function readVersionNoStore(){
   const r = await fetch(VERSION_URL,{cache:'no-store'});
   return r.json();
@@ -686,21 +690,25 @@ navigator.serviceWorker?.addEventListener('message', async (e)=>{
 loadVersion().then(() => {
   if ('serviceWorker' in navigator) {
     const v = window.__APP_VERSION__ || 'dev';
-    navigator.serviceWorker.register(`./sw.js?v=${encodeURIComponent(v)}`).then(reg => {
-      swRegistration = reg;
-      if (swRegistration.waiting) {
-        showUpdateBanner();
-      }
-      swRegistration.addEventListener('updatefound', () => {
-        const newWorker = swRegistration.installing;
-        if (newWorker) {
-          newWorker.addEventListener('statechange', () => {
-            if (swRegistration.waiting) {
-              showUpdateBanner();
-            }
-          });
+    if (__IS_TEST_MODE__) {
+      // E2E / CI 用。SW は登録しない
+    } else {
+      navigator.serviceWorker.register(`./sw.js?v=${encodeURIComponent(v)}`).then(reg => {
+        swRegistration = reg;
+        if (swRegistration.waiting) {
+          showUpdateBanner();
         }
+        swRegistration.addEventListener('updatefound', () => {
+          const newWorker = swRegistration.installing;
+          if (newWorker) {
+            newWorker.addEventListener('statechange', () => {
+              if (swRegistration.waiting) {
+                showUpdateBanner();
+              }
+            });
+          }
+        });
       });
-    });
+    }
   }
 });


### PR DESCRIPTION
## Summary
- skip service worker registration when `?test=1` is present
- adjust e2e tests to append `test=1` query parameter

## Testing
- `npm test` *(fails: clojure: not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68b00fa71468832494e3ff00f11edf4c