### PR TITLE
feat: support mock dataset for testing

### DIFF
--- a/e2e/test.js
+++ b/e2e/test.js
@@ -44,7 +44,7 @@ async function dumpArtifacts(page, prefix = 'failure') {
   try {
     const base = process.env.APP_URL || 'http://127.0.0.1:8080/app/';
     // TEST_MODE + 決定シードで起動
-    const params = ['test=1', 'seed=e2e'];
+    const params = ['test=1', 'mock=1', 'seed=e2e'];
     const url = base.includes('?') ? (base + '&' + params.join('&')) : (base + '?' + params.join('&'));
     await page.goto(url, {
       waitUntil: 'domcontentloaded',
@@ -55,7 +55,7 @@ async function dumpArtifacts(page, prefix = 'failure') {
     // TEST_MODE では SW 未登録なので、キャッシュ関連の更新待ちは軽くなる
     // 以降の待機ロジックは既存のままでOK
     await page.waitForResponse(
-      (resp) => resp.url().endsWith('/build/dataset.json') && resp.ok(),
+      (resp) => resp.url().endsWith('/dataset.json') && resp.ok(),
       { timeout: TIMEOUT }
     );
     let picked = false;

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -319,9 +319,16 @@ function updateStartButton() {
 
 async function loadDataset() {
   try {
-    const res = await fetch(DATASET_URL, { cache: 'no-store' });
+    // TEST/Mock: URL に ?mock=1 があれば軽量データセットを使用
+    let datasetUrl = DATASET_URL;
+    const mock = __SEARCH_PARAMS__.get('mock') === '1';
+    if (mock) {
+      datasetUrl = './mock/dataset.json';
+      try { console.info('[MOCK_DATASET] using', datasetUrl); } catch (_) {}
+    }
+    const res = await fetch(datasetUrl, { cache: 'no-store' });
     const data = await res.json();
-    tracks = data.tracks;
+    tracks = data.tracks || data; // 互換
     datasetLoaded = true;
     updateStartButton();
   } catch (err) {

--- a/public/app/mock/dataset.json
+++ b/public/app/mock/dataset.json
@@ -1,0 +1,14 @@
+{
+  "tracks": [
+    { "title": "Overworld", "game": "ゼルダの伝説", "composer": "近藤浩治", "year": 1986 },
+    { "title": "Main Theme", "game": "ドラゴンクエスト", "composer": "すぎやまこういち", "year": 1986 },
+    { "title": "Battle", "game": "ファイナルファンタジー", "composer": "植松伸夫", "year": 1987 },
+    { "title": "時の回廊", "game": "クロノ・トリガー", "composer": "光田康典", "year": 1995 },
+    { "title": "MEGALOVANIA", "game": "UNDERTALE", "composer": "Toby Fox", "year": 2015 },
+    { "title": "Green Hill Zone", "game": "ソニック・ザ・ヘッジホッグ", "composer": "中村正人", "year": 1991 },
+    { "title": "Stickerbrush Symphony", "game": "スーパードンキーコング2", "composer": "David Wise", "year": 1995 },
+    { "title": "Gusty Garden Galaxy", "game": "スーパーマリオギャラクシー", "composer": "近藤浩治", "year": 2007 },
+    { "title": "Corridors of Time", "game": "クロノ・トリガー", "composer": "光田康典", "year": 1995 },
+    { "title": "Main Theme", "game": "ゼルダの伝説: 時のオカリナ", "composer": "近藤浩治", "year": 1998 }
+  ]
+}


### PR DESCRIPTION
## Summary
- allow using lightweight mock dataset when `?mock=1` query param is present
- add mock dataset sample for faster testing
- adjust E2E tests to enable mock data and wait for dataset fetch generically

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository InRelease not signed)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*
- `npm install --no-save playwright` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b0222c281483249d8f714acf2ba772