### PR TITLE
feat: broaden Pages triggers and add debug logging

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,9 +1,16 @@
-name: github-pages
+name: Pages
 
 on:
+  # 通常ルート: main に入れば必ず実行
   push:
-    branches: [ "main" ]
-  workflow_dispatch:
+    branches: [ main ]
+  # 保険ルート: CI Fast が成功で完了したら実行（重複は concurrency で抑止）
+  workflow_run:
+    workflows: [ "CI Fast" ]
+    types:
+      - completed
+  # 手動実行も残す
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -19,6 +26,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Print context (debug)
+        run: |
+          echo "event_name=$GITHUB_EVENT_NAME"
+          echo "ref=$GITHUB_REF  sha=$GITHUB_SHA"
+          echo "run_id=$GITHUB_RUN_ID  repo=$GITHUB_REPOSITORY"
+          if [ "$GITHUB_EVENT_NAME" = "workflow_run" ]; then
+            echo "Triggered by workflow_run (likely CI Fast completion)."
+            # 成功時のみ実行する（保険トリガーの誤発動防止）
+            # workflow_runのpayloadはgithub.event.workflow_run.conclusionに入る
+            if [ "${{ github.event.workflow_run.conclusion }}" != "success" ]; then
+              echo "Upstream workflow not successful; exiting without deploy."
+              exit 1
+            fi
+          fi
 
       - name: Setup Java
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary
- run Pages deploy for push to main
- fallback deploy when CI Fast completes successfully
- print GitHub context for easier debug

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: 403 - repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b028e4c6f8832489f91e536adc6374