### PR TITLE
Add final build.json guard before Pages upload

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -81,6 +81,11 @@ jobs:
           mkdir -p public/app
           cp public/build.json public/app/build.json
 
+      - name: Final guard (must have build.json)
+        run: |
+          test -f public/build.json
+          test -f public/app/build.json
+
       # Contract checks have moved to CI Fast; this workflow handles deploy only.
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- ensure Pages deploy has `public/build.json` and `public/app/build.json` before uploading the artifact

## Testing
- `npm test` (fails: sh: 1: clojure: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b041cc1bec832497fe7fa53f14d3fd