### PR TITLE
Add Makefile helpers for local ops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# vgm-quiz Makefile helpers
+# Usage:
+#   make publish   # build static site into public/
+#   make smoke     # lightweight HTML contract test
+#   make e2e       # run Playwright E2E locally (uses TEST_MODE + seed via test.js)
+#   make trace     # open last Playwright trace.zip
+
+.PHONY: publish smoke e2e trace
+
+publish:
+	clojure -T:build publish
+
+smoke:
+	npm run smoke
+
+e2e:
+	APP_URL="http://127.0.0.1:8080/app/" node e2e/test.js
+
+trace:
+	npx playwright show-trace e2e-artifacts/trace.zip


### PR DESCRIPTION
## Summary
- add Makefile shortcuts for publish, smoke, e2e, and trace tasks

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b045e2f53c832488f1110fb1ae6ac7