### PR TITLE
ci: update LHCI CLI to v0.14.0

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 20
 
       - name: Install Lighthouse CI CLI
-        run: npm install -g @lhci/cli@0.13.0
+        run: npm install -g @lhci/cli@0.14.0
 
       - name: Run Lighthouse (prod URL, SW disabled via ?test=1)
         env:


### PR DESCRIPTION
## Summary
- update Lighthouse CI CLI to v0.14.0 in nightly workflow

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b055e0859c8324aa4763bf26cb98a8