### PR TITLE
ci: pin LHCI version in lighthouse workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install Lighthouse CI CLI
-        run: npm install -g @lhci/cli@0.14.0
+      - name: Show LHCI version (npx, pinned)
+        run: npx -y @lhci/cli@0.14.1 --version
 
       - name: Run Lighthouse (prod URL, SW disabled via ?test=1)
         env:
@@ -34,7 +34,7 @@ jobs:
           echo "Target URL: $URL"
 
           # 1) Collect Lighthouse results into .lighthouseci/
-          lhci collect \
+          npx -y @lhci/cli@0.14.1 collect \
             --url="$URL" \
             --numberOfRuns=1 \
             --settings.emulatedFormFactor=desktop \
@@ -42,7 +42,7 @@ jobs:
             --settings.chromePath="$(which chrome)"
 
           # 2) Assert thresholds (fail workflow if under)
-          lhci assert \
+          npx -y @lhci/cli@0.14.1 assert \
             --assert.preset=none \
             --assert.assertions.categories.performance="error:>=0.80" \
             --assert.assertions.categories.accessibility="error:>=0.90" \
@@ -50,7 +50,7 @@ jobs:
             --assert.assertions.categories.seo="error:>=0.90"
 
           # 3) Upload reports to artifacts-friendly directory
-          lhci upload \
+          npx -y @lhci/cli@0.14.1 upload \
             --target=filesystem \
             --outputDir="./lhci-report"
 


### PR DESCRIPTION
## Summary
- switch lighthouse workflow to run `npx -y @lhci/cli@0.14.1`
- log the pinned LHCI version instead of installing globally

## Testing
- `npm test` *(fails: clojure: not found)*
- `npx -y @lhci/cli@0.14.1 --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b0591f21dc8324bafc231eea5ace98