### PR TITLE
Disable LHCI preset in Lighthouse CI assert

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -43,6 +43,7 @@ jobs:
 
           # 2) Assert thresholds (fail workflow if under)
           npx -y @lhci/cli@0.15.1 assert \
+            --preset=none \
             --assertions.categories:performance="error:>=0.80" \
             --assertions.categories:accessibility="error:>=0.90" \
             --assertions.categories:best-practices="error:>=0.90" \


### PR DESCRIPTION
## Summary
- avoid LHCI default preset by adding `--preset=none` to the assert step

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b086668664832493d38219e8b34e29