### PR TITLE
ci: skip lighthouserc in LHCI assert

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -43,7 +43,7 @@ jobs:
 
           # 2) Assert thresholds (fail workflow if under)
           npx -y @lhci/cli@0.15.1 assert \
-            --preset=none \
+            --no-lighthouserc \
             --assertions.categories:performance="error:>=0.80" \
             --assertions.categories:accessibility="error:>=0.90" \
             --assertions.categories:best-practices="error:>=0.90" \


### PR DESCRIPTION
## Summary
- avoid using project lighthouserc when running lhci assert

## Testing
- `npm test` *(fails: clojure: not found)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b08a69a8488324807c0916a10157d0