### PR TITLE
chore(ci): use provided throttling for Lighthouse

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -38,6 +38,7 @@ jobs:
             --url="$URL" \
             --numberOfRuns=1 \
             --settings.emulatedFormFactor=desktop \
+            --settings.throttlingMethod=provided \
             --settings.disableStorageReset=true \
             --settings.chromePath="$(which google-chrome)"
 


### PR DESCRIPTION
## Summary
- ensure LHCI collect uses provided throttling settings

## Testing
- `npm test` (fails: clojure: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b08e05a1f48324b906c1e7e922de48