### PR TITLE
Improve Lighthouse workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,5 +1,9 @@
 name: lighthouse (nightly)
 
+concurrency:
+  group: lighthouse-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch: {}
   schedule:
@@ -70,3 +74,4 @@ jobs:
           name: lighthouse-report
           path: lhci-report/**
           if-no-files-found: ignore
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# vgm-quiz
+# VGM Quiz
+
+[![Lighthouse nightly](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml/badge.svg)](../../actions/workflows/lighthouse.yml)
 
 A small quiz app for video game music.
 


### PR DESCRIPTION
## Summary
- add concurrency group to nightly Lighthouse workflow
- retain uploaded Lighthouse reports for one week
- show nightly Lighthouse status badge in README

## Testing
- `npm test` *(fails: clojure not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1024459a0832483177f03e00880c0