### PR TITLE
feat(e2e): improve diagnostics and artifact upload

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,8 +44,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: e2e-artifacts-nightly
-          path: e2e-artifacts/**
+          path: artifacts/**
           if-no-files-found: ignore
+          retention-days: 7
   e2e:
     runs-on: ubuntu-latest
     steps:
@@ -83,5 +84,6 @@ jobs:
         with:
           name: e2e-artifacts
           path: |
-            e2e-artifacts/**
+            artifacts/**
           if-no-files-found: ignore
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ e2e:
 	APP_URL="http://127.0.0.1:8080/app/" node e2e/test.js
 
 trace:
-	npx playwright show-trace e2e-artifacts/trace.zip
+        npx playwright show-trace artifacts/trace.zip

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -28,8 +28,8 @@
 3. Footer should show: `Dataset vX • <content_hash> • <generated_at> • commit: <short_sha>`
 
 ## E2E artifacts (for failures)
-- Artifacts directory: `e2e-artifacts/`
-  - `trace.zip` — Open with `npx playwright show-trace e2e-artifacts/trace.zip`
+- Artifacts directory: `artifacts/`
+  - `trace.zip` — Open with `npx playwright show-trace artifacts/trace.zip`
   - `console.log` — Console messages, page errors
   - `network.log` — Failed/Non-OK requests
   - `*.html` / `*.png` — DOM snapshot and screenshot at failure

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ APP_URL="http://127.0.0.1:8080/app/" node e2e/test.js
 - **e2e (on-demand)**: manual/nightly — stable E2E with mock+seed+test
 
 ### Debugging E2E failures
-- Download `e2e-artifacts/trace.zip` and view:
+- Download `artifacts/trace.zip` and view:
 ```bash
-npx playwright show-trace e2e-artifacts/trace.zip
+npx playwright show-trace artifacts/trace.zip
 ```
 - Check `console.log` and `network.log` in the same artifact.
 

--- a/e2e.test.js
+++ b/e2e.test.js
@@ -4,12 +4,12 @@ const TIMEOUT = 45000;
 
 async function dumpArtifacts(page, prefix = 'failure') {
   try {
-    fs.mkdirSync('e2e-artifacts', { recursive: true });
+    fs.mkdirSync('artifacts', { recursive: true });
     await page
-      .screenshot({ path: `e2e-artifacts/${prefix}.png`, fullPage: true })
+      .screenshot({ path: `artifacts/${prefix}.png`, fullPage: true })
       .catch(() => {});
     const html = await page.content().catch(() => '');
-    fs.writeFileSync(`e2e-artifacts/${prefix}.html`, html);
+    fs.writeFileSync(`artifacts/${prefix}.html`, html);
   } catch (_) {}
 }
 
@@ -71,20 +71,22 @@ async function dumpArtifacts(page, prefix = 'failure') {
       // continue even if mode selection fails
     }
 
-    // Be tolerant: #start might appear slightly late on CI
+    // Be tolerant: start button might appear slightly late on CI
     try {
-      await page.waitForSelector('#start', { state: 'visible', timeout: 20000 });
+      await page.waitForSelector('[data-testid="start-btn"]', { state: 'visible', timeout: 20000 });
     } catch {
       // one soft retry after a small settle time, with artifact if still failing
       await page.waitForTimeout(1000);
       try {
-        await page.waitForSelector('#start', { state: 'visible', timeout: 10000 });
+        await page.waitForSelector('[data-testid="start-btn"]', { state: 'visible', timeout: 10000 });
       } catch (e) {
         await dumpArtifacts(page, 'start-visible');
         throw e;
       }
     }
-    await page.click('#start');
+    await page.click('[data-testid="start-btn"]');
+
+    await page.waitForSelector('[data-testid="quiz-view"]', { state: 'visible' });
 
     await page.waitForFunction(
       () => {
@@ -97,7 +99,7 @@ async function dumpArtifacts(page, prefix = 'failure') {
     await page.click('#choices button');
 
     await page.waitForFunction(
-      () => /Score: 1/.test(document.getElementById('score-bar').textContent),
+      () => /Score: 1/.test(document.querySelector('[data-testid="score-bar"]').textContent),
       { timeout: TIMEOUT }
     );
   } catch (e) {

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -1,7 +1,7 @@
 const { chromium } = require('playwright');
 const fs = require('fs');
 const TIMEOUT = 45000;
-const ART_DIR = 'e2e-artifacts';
+const ART_DIR = 'artifacts';
 
 async function dumpArtifacts(page, prefix = 'failure') {
   try {
@@ -32,20 +32,32 @@ async function dumpArtifacts(page, prefix = 'failure') {
       fs.appendFileSync(`${ART_DIR}/${name}`, text + '\n');
     } catch (_) {}
   };
-  page.on('console', (msg) => log('console.log', `[${msg.type()}] ${msg.text()}`));
-  page.on('pageerror', (err) => log('console.log', `[pageerror] ${err?.message || err}`));
-  page.on('requestfailed', (req) =>
-    log('network.log', `[fail] ${req.method()} ${req.url()} - ${req.failure()?.errorText}`)
-  );
+  page.on('console', (msg) => {
+    const text = `[${msg.type()}] ${msg.text()}`;
+    log('console.log', text);
+    try { console.log('[console]', msg.type(), msg.text()); } catch (_) {}
+  });
+  page.on('pageerror', (err) => {
+    const text = `[pageerror] ${err?.message || err}`;
+    log('console.log', text);
+    try { console.error('[pageerror]', err); } catch (_) {}
+  });
+  page.on('requestfailed', (req) => {
+    const text = `[fail] ${req.method()} ${req.url()} - ${req.failure()?.errorText}`;
+    log('network.log', text);
+    try { console.warn('[requestfailed]', req.url(), req.failure()?.errorText); } catch (_) {}
+  });
   page.on('response', async (res) => {
-    if (!res.ok()) log('network.log', `[${res.status()}] ${res.request().method()} ${res.url()}`);
+    if (!res.ok()) {
+      const text = `[${res.status()}] ${res.request().method()} ${res.url()}`;
+      log('network.log', text);
+      try { console.warn('[response]', text); } catch (_) {}
+    }
   });
 
   try {
-    const base = process.env.APP_URL || 'http://127.0.0.1:8080/app/';
-    // TEST_MODE + 決定シードで起動
-    const params = ['test=1', 'mock=1', 'seed=e2e'];
-    const url = base.includes('?') ? (base + '&' + params.join('&')) : (base + '?' + params.join('&'));
+    const base = process.env.E2E_BASE_URL || process.env.APP_URL || 'http://127.0.0.1:8080/app/';
+    const url = base.includes('?') ? `${base}&mock=1&seed=e2e` : `${base}?mock=1&seed=e2e`;
     await page.goto(url, {
       waitUntil: 'domcontentloaded',
       timeout: 60000,
@@ -86,11 +98,13 @@ async function dumpArtifacts(page, prefix = 'failure') {
       // continue even if mode selection fails
     }
 
-    await page.waitForSelector('#start', {
+    await page.waitForSelector('[data-testid="start-btn"]', {
       state: 'visible',
       timeout: 15000,
     });
-    await page.click('#start');
+    await page.click('[data-testid="start-btn"]');
+
+    await page.waitForSelector('[data-testid="quiz-view"]', { state: 'visible' });
 
     await page.waitForFunction(
       () => {
@@ -103,11 +117,11 @@ async function dumpArtifacts(page, prefix = 'failure') {
     await page.click('#choices button');
 
     await page.waitForFunction(
-      () => /Score: 1/.test(document.getElementById('score-bar').textContent),
+      () => /Score: 1/.test(document.querySelector('[data-testid="score-bar"]').textContent),
       { timeout: TIMEOUT }
     );
   } catch (e) {
-    await dumpArtifacts(page);
+    await dumpArtifacts(page, 'fail_test_js');
     throw e;
   } finally {
     try {

--- a/e2e/test_free_aria.js
+++ b/e2e/test_free_aria.js
@@ -7,6 +7,8 @@ const { chromium } = require('playwright');
   const browser = await chromium.launch();
   const ctx = await browser.newContext();
   const page = await ctx.newPage();
+  // --- diagnostics: tracing ---
+  try { await ctx.tracing.start({ screenshots: true, snapshots: true, sources: true }); } catch {}
 
   try {
     await page.goto(base, { waitUntil: 'domcontentloaded' });
@@ -54,6 +56,13 @@ const { chromium } = require('playwright');
 
     console.log('[OK] free-mode, timer, aria-live basic checks passed');
   } finally {
+    try {
+      require('fs').mkdirSync('artifacts', { recursive: true });
+      await ctx.tracing.stop({ path: 'artifacts/trace_free_aria.zip' });
+      await page.screenshot({ path: 'artifacts/fail_free_aria.png', fullPage: true }).catch(()=>{});
+      const html = await page.content().catch(()=>null);
+      if (html) require('fs').writeFileSync('artifacts/dom_free_aria.html', html, 'utf-8');
+    } catch {}
     await ctx.close();
     await browser.close();
   }


### PR DESCRIPTION
## Summary
- log console and network issues in Playwright E2E tests and use data-testid selectors
- capture screenshots and DOM on failure and collect traces
- upload artifacts from `artifacts/` in e2e workflow and docs

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository not signed)*
- `E2E_BASE_URL=https://nantes-rfli.github.io/vgm-quiz/app/?test=1 node e2e/test.js` *(fails: Cannot find module 'playwright')*
- `npm install --no-save playwright` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b10a0599b08324a9a75ebb9ed88260