### PR TITLE
feat: skip analytics only in LHCI runs

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -27,7 +27,7 @@ jobs:
       - name: LHCI version check
         run: npx -y @lhci/cli@0.15.1 --version
 
-      - name: Run Lighthouse (prod URL, SW disabled via ?test=1)
+      - name: Run Lighthouse (prod URL, SW disabled via ?test=1; analytics via &lhci=1)
         env:
           LHCI_BUILD_CONTEXT__CURRENT_HASH: ${{ github.sha }}
         run: |
@@ -35,10 +35,10 @@ jobs:
           mkdir -p lhci-report
           # Run once; you can add more URLs if needed
           # NOTE:
-          # - We append ?test=1 to disable analytics script (mc.js) during audits.
-          #   See public/app/index.html: analytics is skipped when location.search contains test=1.
+          # - We append ?test=1&lhci=1 to disable analytics script (mc.js) during audits.
+          #   See public/app/index.html: analytics is skipped when location.search contains lhci=1.
           # - This keeps production UX unchanged while making perf measurements more stable.
-          URL="https://nantes-rfli.github.io/vgm-quiz/app/?test=1"
+          URL="https://nantes-rfli.github.io/vgm-quiz/app/?test=1&lhci=1"
           echo "Target URL: $URL"
 
           # 1) Collect Lighthouse results into .lighthouseci/

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -104,10 +104,13 @@
 
 </main>
 
-<!-- Skip analytics script only in LHCI test mode (?test=1) -->
+<!-- Only skip analytics/MC helper in Lighthouse audit runs (lhci=1).
+E2E uses ?test=1, but should still load mc.js (logic helpers live there). -->
 <script>
   (function () {
-    if (!location.search.includes('test=1')) {
+    // Only skip analytics/MC helper in Lighthouse audit runs (lhci=1).
+    // E2E uses ?test=1, but should still load mc.js (logic helpers live there).
+    if (!location.search.includes('lhci=1')) {
       var s = document.createElement('script');
       s.src = '../mc.js';
       s.async = true; // analyticsは asyncで十分


### PR DESCRIPTION
## Summary
- load mc.js unless URL has `lhci=1`, so E2E `?test=1` retains helpers
- append `lhci=1` to Lighthouse workflow URL, updating comments accordingly

## Testing
- `npm test` *(fails: clojure: not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68b110b33544832484e9adb763fd6569