### PR TITLE
Use modulepreload and soften dataset wait in e2e

### DIFF
--- a/e2e/test.js
+++ b/e2e/test.js
@@ -65,11 +65,17 @@ async function dumpArtifacts(page, prefix = 'failure') {
     // 参考ログ（トレースで確認可能）
     try { console.log('[E2E URL]', url); } catch (_) {}
     // TEST_MODE では SW 未登録なので、キャッシュ関連の更新待ちは軽くなる
-    // 以降の待機ロジックは既存のままでOK
-    await page.waitForResponse(
-      (resp) => resp.url().endsWith('/dataset.json') && resp.ok(),
-      { timeout: TIMEOUT }
-    );
+    // dataset の取得は環境により '/mock/dataset.json' 等になるため、
+    // ネットワーク待機は包括条件に変更し、失敗しても非致命にする
+    await page
+      .waitForResponse(
+        (resp) => {
+          const u = resp.url();
+          return (u.includes('/mock/dataset.json') || u.endsWith('/dataset.json')) && resp.ok();
+        },
+        { timeout: 10000 }
+      )
+      .catch(() => {});
     let picked = false;
     try {
       const hasMode = await page.$('#mode');
@@ -104,6 +110,8 @@ async function dumpArtifacts(page, prefix = 'failure') {
     });
     await page.click('[data-testid="start-btn"]');
 
+    // 初期描画の揺らぎを吸収
+    await page.waitForTimeout(300);
     await page.waitForSelector('[data-testid="quiz-view"]', { state: 'visible' });
 
     await page.waitForFunction(

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -8,7 +8,8 @@
 <meta name="theme-color" content="#111111">
 <title>VGM Quiz</title>
 <link rel="manifest" href="manifest.webmanifest">
-<link rel="preload" as="script" href="app.js">
+<!-- ESM の事前解決は modulepreload を使う。credentials 警告回避に crossorigin を明示 -->
+<link rel="modulepreload" href="app.js" crossorigin="anonymous">
 <!-- Open Graph (optional but useful for previews) -->
 <meta property="og:title" content="VGM Quiz">
 <meta property="og:description" content="Play a fast, browser-based Video Game Music quiz with multiple modes and composers/titles matching.">


### PR DESCRIPTION
## Summary
- Switch app entry script to `modulepreload` with explicit `crossorigin`
- Broaden dataset fetch wait in e2e to handle mock path and be non-fatal
- Add small delay before checking quiz view in e2e to reduce flakiness

## Testing
- `npm test` *(fails: clojure not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68b1169327788324be261309f451929c