### PR TITLE
Fix E2E base URL parameters

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,10 +31,10 @@ jobs:
           echo "Running E2E against deployed site"
           echo "APP_URL=https://nantes-rfli.github.io/vgm-quiz/app/"
 
-      - name: Run E2E (prod URL, test+mock+seed are appended by test.js)
+      - name: Run E2E (prod URL, test+mock+seed+autostart fixed)
         env:
           APP_URL: https://nantes-rfli.github.io/vgm-quiz/app/
-          E2E_BASE_URL: https://nantes-rfli.github.io/vgm-quiz/app/?test=1
+          E2E_BASE_URL: https://nantes-rfli.github.io/vgm-quiz/app/?test=1&mock=1&seed=e2e&autostart=0
         run: |
           node e2e/test.js
           node e2e/test_free_aria.js
@@ -74,7 +74,7 @@ jobs:
         run: python3 -m http.server 8080 -d public &
       - name: Run E2E
         env:
-          E2E_BASE_URL: http://127.0.0.1:8080/app/?test=1
+          E2E_BASE_URL: http://127.0.0.1:8080/app/?test=1&mock=1&seed=e2e&autostart=0
         run: |
           node e2e/test.js
           node e2e/test_free_aria.js

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -57,7 +57,21 @@ async function dumpArtifacts(page, prefix = 'failure') {
 
   try {
     const base = process.env.E2E_BASE_URL || process.env.APP_URL || 'http://127.0.0.1:8080/app/';
-    const url = base.includes('?') ? `${base}&mock=1&seed=e2e` : `${base}?mock=1&seed=e2e`;
+    // 必要なクエリ（test/mock/seed/autostart）を“必ず”付ける
+    const url = (() => {
+      try {
+        const u = new URL(base);
+        const p = u.searchParams;
+        if (!p.has('test'))      p.set('test', '1');
+        if (!p.has('mock'))      p.set('mock', '1');
+        if (!p.has('seed'))      p.set('seed', 'e2e');
+        if (!p.has('autostart')) p.set('autostart', '0');
+        return u.toString();
+      } catch (_) {
+        // base が相対URL等でも壊れないようにフォールバック
+        return base + (base.includes('?') ? '&' : '?') + 'test=1&mock=1&seed=e2e&autostart=0';
+      }
+    })();
     await page.goto(url, {
       waitUntil: 'domcontentloaded',
       timeout: 60000,


### PR DESCRIPTION
## Summary
- Add test/mock/seed/autostart params to E2E_BASE_URL in CI
- Ensure e2e/test.js always appends these parameters

## Testing
- `npm test` *(fails: clojure not found)*
- `npm install --no-save playwright` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b1535d0e7483249efb5197ece6146d