### PR TITLE
Improve E2E test coverage

### DIFF
--- a/e2e/test.js
+++ b/e2e/test.js
@@ -1,193 +1,151 @@
 const { chromium } = require('playwright');
 const fs = require('fs');
-const TIMEOUT = 45000;
-const ART_DIR = 'artifacts';
-
-async function dumpArtifacts(page, prefix = 'failure') {
-  try {
-    fs.mkdirSync(ART_DIR, { recursive: true });
-    await page
-      .screenshot({ path: `${ART_DIR}/${prefix}.png`, fullPage: true })
-      .catch(() => {});
-    const html = await page.content().catch(() => '');
-    fs.writeFileSync(`${ART_DIR}/${prefix}.html`, html);
-  } catch (_) {}
-}
 
 (async () => {
+  const TIMEOUT = 30000;
   const browser = await chromium.launch();
-  // context を切ってトレースを有効化
   const context = await browser.newContext();
   const page = await context.newPage();
 
-  // artifacts ディレクトリ
-  fs.mkdirSync(ART_DIR, { recursive: true });
-
-  // Playwright Trace を常時収集（失敗時の操作履歴/ネットワーク/スクショ等）
-  await context.tracing.start({ screenshots: true, snapshots: true, sources: false });
-
-  // 失敗の手がかりになるログも保存
-  const log = (name, text) => {
+  // --- 必須クエリを“必ず”付ける（ベルト＆サスペンダー） ---
+  const base = process.env.E2E_BASE_URL || process.env.APP_URL || 'http://127.0.0.1:8080/app/';
+  const url = (() => {
     try {
-      fs.appendFileSync(`${ART_DIR}/${name}`, text + '\n');
-    } catch (_) {}
+      const u = new URL(base);
+      const p = u.searchParams;
+      if (!p.has('test'))      p.set('test', '1');
+      if (!p.has('mock'))      p.set('mock', '1');
+      if (!p.has('seed'))      p.set('seed', 'e2e');
+      if (!p.has('autostart')) p.set('autostart', '0');
+      return u.toString();
+    } catch {
+      return base + (base.includes('?') ? '&' : '?') + 'test=1&mock=1&seed=e2e&autostart=0';
+    }
+  })();
+
+  await context.tracing.start({ screenshots: true, snapshots: true });
+  await page.goto(url, { waitUntil: 'networkidle' });
+  console.log('[E2E URL]', url);
+
+  // Start → Quiz へ（autostart=0 前提）
+  await page.waitForSelector('[data-testid="start-btn"]:not([disabled])', { state: 'visible', timeout: TIMEOUT });
+  await page.click('[data-testid="start-btn"]');
+
+  // Quiz 画面の表示
+  await page.waitForSelector('[data-testid="quiz-view"]', { state: 'visible', timeout: TIMEOUT });
+
+  // ------ ヘルパ ------
+  const getText = async (sel) => (await page.$(sel)) ? (await page.textContent(sel)).trim() : null;
+  const waitAnyChange = async (promptBefore) => {
+    return Promise.race([
+      page.waitForSelector('#next-btn, [data-testid="next-btn"]', { state: 'visible', timeout: TIMEOUT }),
+      page.waitForSelector('#feedback:not(:empty), [data-testid="feedback"]:not(:empty)', { timeout: TIMEOUT }),
+      page.waitForFunction((sel, prev) => {
+        const el = document.querySelector(sel);
+        return el && el.textContent && el.textContent.trim() !== (prev || '').trim();
+      }, '[data-testid="prompt"]', promptBefore, { timeout: TIMEOUT }),
+    ]);
   };
-  page.on('console', (msg) => {
-    const text = `[${msg.type()}] ${msg.text()}`;
-    log('console.log', text);
-    try { console.log('[console]', msg.type(), msg.text()); } catch (_) {}
-  });
-  page.on('pageerror', (err) => {
-    const text = `[pageerror] ${err?.message || err}`;
-    log('console.log', text);
-    try { console.error('[pageerror]', err); } catch (_) {}
-  });
-  page.on('requestfailed', (req) => {
-    const text = `[fail] ${req.method()} ${req.url()} - ${req.failure()?.errorText}`;
-    log('network.log', text);
-    try { console.warn('[requestfailed]', req.url(), req.failure()?.errorText); } catch (_) {}
-  });
-  page.on('response', async (res) => {
-    if (!res.ok()) {
-      const text = `[${res.status()}] ${res.request().method()} ${res.url()}`;
-      log('network.log', text);
-      try { console.warn('[response]', text); } catch (_) {}
-    }
-  });
-
-  try {
-    const base = process.env.E2E_BASE_URL || process.env.APP_URL || 'http://127.0.0.1:8080/app/';
-    // 必要なクエリ（test/mock/seed/autostart）を“必ず”付ける
-    const url = (() => {
-      try {
-        const u = new URL(base);
-        const p = u.searchParams;
-        if (!p.has('test'))      p.set('test', '1');
-        if (!p.has('mock'))      p.set('mock', '1');
-        if (!p.has('seed'))      p.set('seed', 'e2e');
-        if (!p.has('autostart')) p.set('autostart', '0');
-        return u.toString();
-      } catch (_) {
-        // base が相対URL等でも壊れないようにフォールバック
-        return base + (base.includes('?') ? '&' : '?') + 'test=1&mock=1&seed=e2e&autostart=0';
-      }
-    })();
-    await page.goto(url, {
-      waitUntil: 'domcontentloaded',
-      timeout: 60000,
-    });
-    // 参考ログ（トレースで確認可能）
-    try { console.log('[E2E URL]', url); } catch (_) {}
-    // TEST_MODE では SW 未登録なので、キャッシュ関連の更新待ちは軽くなる
-    // dataset の取得は環境により '/mock/dataset.json' 等になるため、
-    // ネットワーク待機は包括条件に変更し、失敗しても非致命にする
-    await page
-      .waitForResponse(
-        (resp) => {
-          const u = resp.url();
-          return (u.includes('/mock/dataset.json') || u.endsWith('/dataset.json')) && resp.ok();
-        },
-        { timeout: 10000 }
-      )
-      .catch(() => {});
-    let picked = false;
-    try {
-      const hasMode = await page.$('#mode');
-      if (hasMode) {
-        await page
-          .waitForSelector('#mode', { state: 'visible', timeout: 5000 })
-          .catch(() => {});
-        const values = await page.$$eval('#mode option', (opts) =>
-          opts.map((o) => o.value || o.textContent.trim())
-        );
-        if (values.length > 0) {
-          const wanted = ['multiple-choice', 'free'];
-          const pick = wanted.find((w) => values.includes(w)) || values[0];
-          await page
-            .selectOption('#mode', { value: pick })
-            .catch(async () => {
-              await page
-                .selectOption('#mode', { label: pick })
-                .catch(() => {});
-            });
-          picked = true;
-        }
-      }
-    } catch (e) {
-      await dumpArtifacts(page, 'mode-select');
-      // continue even if mode selection fails
-    }
-
-    // すでにクイズ中か？（Start なしで question-view が出ているケースに対応）
-    let inQuiz = await page.isVisible('[data-testid="quiz-view"]');
-    if (!inQuiz) {
-      const hasStart = await page.isVisible('[data-testid="start-btn"]');
-      if (hasStart) {
-        await page.waitForSelector('[data-testid="start-btn"]:not([disabled])', { timeout: 15000 });
-        await page.click('[data-testid="start-btn"]');
-      }
-    }
-
-    // クイズ画面が見えるまで待機（Start を押した場合/自動開始どちらでも成立）
-    await page.waitForSelector('[data-testid="quiz-view"]', { state: 'visible', timeout: 15000 });
-    await page.waitForTimeout(200);
-
-    // 出題準備：正解テキストがセットされるのを待つ
-    await page.waitForFunction(() => !!window.__expectedAnswer, { timeout: TIMEOUT });
-
-    // MCかFreeか判定（#choices が可視ならMC）
-    const isMC = await page.evaluate(() => {
+  const isMCVisible = async () => {
+    return await page.evaluate(() => {
       const el = document.querySelector('#choices');
       return !!el && getComputedStyle(el).display !== 'none';
     });
-
-    let acted = false;
+  };
+  const waitChoicesReady = async () => {
+    await page.waitForFunction(() => {
+      const btns = Array.from(document.querySelectorAll('#choices button, .choice, [data-testid="choice"]'));
+      return btns.length >= 4 && btns.every(b => (b.textContent || '').trim().length > 0);
+    }, { timeout: TIMEOUT });
+  };
+  const clickChoiceByIndex = async (idx) => {
+    const sel = `#choices button:nth-of-type(${idx + 1}), .choice:nth-of-type(${idx + 1}), [data-testid="choice"]:nth-of-type(${idx + 1})`;
+    await page.click(sel);
+  };
+  const answerQuestion = async ({ correct }) => {
+    await page.waitForFunction(() => !!window.__expectedAnswer, { timeout: TIMEOUT });
+    const expected = await page.evaluate(() => window.__expectedAnswer);
+    const isMC = await isMCVisible();
     if (isMC) {
-      // 4択が全て描画されるまで待つ
-      await page.waitForFunction(() => {
-        const btns = Array.from(document.querySelectorAll('#choices button'));
-        return btns.length >= 4 && btns.every((b) => (b.textContent || '').trim().length > 0);
-      }, { timeout: TIMEOUT });
-      // 正解テキストと一致するボタンをクリック（無ければ先頭）
-      const expected = await page.evaluate(() => window.__expectedAnswer);
-      const texts = await page.$$eval('#choices button', (btns) => btns.map((b) => b.textContent.trim()));
-      const idx = texts.findIndex((t) => t === expected);
-      const sel = idx >= 0 ? `#choices button:nth-of-type(${idx + 1})` : '#choices button:nth-of-type(1)';
-      await page.click(sel);
-      acted = true;
+      await waitChoicesReady();
+      const texts = await page.$$eval('#choices button, .choice, [data-testid="choice"]', btns => btns.map(b => b.textContent.trim()));
+      let idx;
+      if (correct) {
+        idx = texts.findIndex(t => t === expected);
+        if (idx < 0) idx = 0; // 保険
+      } else {
+        idx = texts.findIndex(t => t !== expected);
+        if (idx < 0) idx = 0; // すべて同一なら先頭
+      }
+      await clickChoiceByIndex(idx);
     } else {
-      // Free入力：正解を入れて送信
-      const expected = await page.evaluate(() => window.__expectedAnswer);
-      await page.fill('[data-testid="answer"]', expected || 'test');
-      const submitBtn = await page.$('[data-testid="submit-btn"], #submit-btn');
-      if (submitBtn) await submitBtn.click();
-      acted = true;
+      if (correct) {
+        await page.fill('[data-testid="answer"]', expected || 'test');
+      } else {
+        await page.fill('[data-testid="answer"]', 'this is surely wrong');
+      }
+      const submit = await page.$('[data-testid="submit-btn"], #submit-btn, [data-testid="submit"]');
+      if (submit) await submit.click();
     }
+  };
+  const parseLives = async () => {
+    const el = await page.$('[data-testid="lives"], #lives');
+    if (!el) return null;
+    const txt = (await el.textContent() || '').trim();
+    const m = txt.match(/\d+/);
+    if (m) return parseInt(m[0], 10);
+    // ハート数え（♥/❤）
+    const hearts = (txt.match(/\u2665|\u2764/g) || []).length;
+    return hearts || null;
+  };
 
-    // 何らかの状態変化を確認（次へ / フィードバック / プロンプト変化）
-    if (acted) {
-      const promptBefore = await page.textContent('[data-testid="prompt"]').catch(() => null);
-      // いずれか出現で OK：Nextボタン可視 / フィードバック非空 / プロンプト文面の変化
-      await Promise.race([
-        page.waitForSelector('#next-btn', { state: 'visible', timeout: 5000 }),
-        page.waitForFunction(() => {
-          const fb = document.getElementById('feedback');
-          return fb && fb.textContent && fb.textContent.trim().length > 0;
-        }, { timeout: 5000 }),
-        page.waitForFunction((prev) => {
-          const p = document.querySelector('[data-testid="prompt"]');
-          return p && p.textContent && p.textContent.trim() !== (prev || '').trim();
-        }, { timeout: 5000 }, promptBefore),
-      ]).catch(() => {}); // どれも満たさなくてもテストは継続（フレーク抑制）
+  // 1問目：あえてミス → 状態変化（lives減少 or feedback or next）を観測
+  const prompt0 = await getText('[data-testid="prompt"]');
+  const lives0 = await parseLives();
+  await answerQuestion({ correct: false });
+  await waitAnyChange(prompt0);
+  const lives1 = await parseLives();
+  if (lives0 != null && lives1 != null) {
+    console.log('[E2E] lives:', lives0, '->', lives1);
+  }
+  // 次へ（ボタンがあれば押す）
+  const nextBtn = await page.$('#next-btn, [data-testid="next-btn"]');
+  if (nextBtn) await nextBtn.click();
+
+  // 2問目に遷移したことを確認（prompt 変化）
+  await page.waitForFunction((sel, prev) => {
+    const el = document.querySelector(sel);
+    return el && el.textContent && el.textContent.trim() !== (prev || '').trim();
+  }, '[data-testid="prompt"]', prompt0, { timeout: TIMEOUT });
+  const prompt1 = await getText('[data-testid="prompt"]');
+  console.log('[E2E] prompt0 -> prompt1:', prompt0, '=>', prompt1);
+
+  // 2問目：正解で進める
+  await answerQuestion({ correct: true });
+  await waitAnyChange(prompt1);
+
+  // タイマー観測（onなら減少を観測、offならスキップ）※可視は必須にしない
+  try {
+    const timerPresent = await page.$('[data-testid="timer"]');
+    if (timerPresent) {
+      const before = await getText('[data-testid="timer"]');
+      await page.waitForTimeout(1200);
+      const after = await getText('[data-testid="timer"]');
+      if (before && after && before !== after) {
+        console.log('[E2E] timer ticked:', before, '->', after);
+      } else {
+        console.log('[E2E] timer did not tick (likely off); present OK');
+      }
     }
   } catch (e) {
-    await dumpArtifacts(page, 'fail_test_js');
-    throw e;
-  } finally {
-    try {
-      await context.tracing.stop({ path: `${ART_DIR}/trace.zip` });
-    } catch (_) {}
-    await browser.close();
+    console.log('[E2E] timer check skipped:', e.message);
   }
+
+  // スクショとDOM保存（常時）
+  await page.screenshot({ path: 'final_test_js.png', fullPage: true });
+  fs.writeFileSync('dom_test_js.html', await page.content());
+  await context.tracing.stop({ path: 'trace_test_js.zip' });
+
+  await browser.close();
 })();
 


### PR DESCRIPTION
## Summary
- strengthen E2E test to always append required query params
- add helper utilities to handle multiple choice/free answers, lives tracking and timer observation
- capture screenshot and DOM after running questions

## Testing
- `npm test` *(fails: clojure not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68b15c39b7f88324bfe2d1bfce99cb3f