### PR TITLE
feat: improve ARIA roles and focus handling

### DIFF
--- a/e2e/test_free_aria.js
+++ b/e2e/test_free_aria.js
@@ -57,6 +57,78 @@ const { chromium } = require('playwright');
     }
     console.log('[A11y] timer present; visible=', timerState.visible, 'aria-live=', timerState.ariaLive, 'aria-atomic=', timerState.ariaAtomic);
 
+    // === 追加A11yチェック: フォーカス・MCのaria-pressed・progressbar ===
+    // Start → Quiz へ（Startは test.js 側でも押しているが、このテスト単体でも安全に進める）
+    const startBtn = await page.$('[data-testid="start-btn"], #start-btn');
+    if (startBtn) {
+      await page.click('[data-testid="start-btn"]');
+      await page.waitForSelector('[data-testid="quiz-view"]', { state: 'visible', timeout: 30000 });
+    }
+
+    // フォーカス: 最初の操作対象に来ているか（Free: answer / MC: 最初のchoice）
+    const focusOk = await page.evaluate(() => {
+      const ae = document.activeElement;
+      if (!ae) return false;
+      const answer = document.querySelector('[data-testid="answer"], #answer');
+      const firstChoice = document.querySelector('#choices button, .choice, [data-testid="choice"]');
+      return ae === answer || ae === firstChoice;
+    });
+    console.log('[A11y] focus on first control:', focusOk);
+
+    // MCなら role="button" と aria-pressed のトグルを確認
+    const isMC = await page.evaluate(() => {
+      const el = document.querySelector('#choices');
+      return !!el && getComputedStyle(el).display !== 'none';
+    });
+    if (isMC) {
+      await page.waitForFunction(() => {
+        const btns = Array.from(document.querySelectorAll('#choices button, .choice, [data-testid="choice"]'));
+        return btns.length >= 4;
+      }, { timeout: 30000 });
+      const firstSel = '#choices button:nth-of-type(1), .choice:nth-of-type(1), [data-testid="choice"]:nth-of-type(1)';
+      // role="button" 付与
+      const roleOk = await page.getAttribute(firstSel, 'role');
+      if (roleOk !== 'button') throw new Error('choice role must be "button"');
+      // クリックで aria-pressed が true
+      await page.click(firstSel);
+      const pressed = await page.getAttribute(firstSel, 'aria-pressed');
+      if (pressed !== 'true') throw new Error('clicked choice aria-pressed should be "true"');
+    }
+
+    // スコアバー: progressbar + now が数値で、正解時に増加（0から上がる）※可視は問わない
+    const barSel = '[data-testid="score-bar"], #score-bar';
+    const bar = await page.$(barSel);
+    if (bar) {
+      const role = await page.getAttribute(barSel, 'role');
+      if (role !== 'progressbar') throw new Error('score-bar must have role="progressbar"');
+      const val0 = parseInt((await page.getAttribute(barSel, 'aria-valuenow')) || '0', 10) || 0;
+      // 正解を1回入れて上昇を観測（FreeとMC両対応）
+      await page.waitForFunction(() => !!window.__expectedAnswer, { timeout: 30000 });
+      const expected = await page.evaluate(() => window.__expectedAnswer);
+      const mc = await page.evaluate(() => {
+        const el = document.querySelector('#choices');
+        return !!el && getComputedStyle(el).display !== 'none';
+      });
+      if (mc) {
+        // 正解ボタンを探してクリック（なければ先頭）
+        const texts = await page.$$eval('#choices button, .choice, [data-testid="choice"]', btns => btns.map(b => b.textContent.trim()));
+        const idx = Math.max(0, texts.findIndex(t => t === expected));
+        const sel = `#choices button:nth-of-type(${idx + 1}), .choice:nth-of-type(${idx + 1}), [data-testid="choice"]:nth-of-type(${idx + 1})`;
+        await page.click(sel);
+      } else {
+        await page.fill('[data-testid="answer"]', expected || 'test');
+        const submit = await page.$('[data-testid="submit-btn"], #submit-btn, [data-testid="submit"]');
+        if (submit) await submit.click();
+      }
+      // 値の上昇を待つ
+      await page.waitForFunction((sel, prev) => {
+        const el = document.querySelector(sel);
+        if (!el) return false;
+        const now = parseInt(el.getAttribute('aria-valuenow') || '0', 10) || 0;
+        return now > prev;
+      }, barSel, val0, { timeout: 30000 });
+    }
+
     // Free answer flow: type wrong answer once to see HUD change (lives or prompt)
     await page.fill('[data-testid="answer"]', 'dummy wrong answer');
     const livesBefore = (await page.textContent('[data-testid="lives"]')).trim();

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -789,3 +789,78 @@ loadVersion().then(() => {
     }
   }
 });
+// --- A11y shim: focus/roles/progressbar ARIA without changing visuals ---
+(() => {
+  const once = (fn) => {
+    let done = false;
+    return (...args) => { if (!done) { done = true; fn(...args); } };
+  };
+
+  const ensureTimerAria = () => {
+    const t = document.querySelector('[data-testid="timer"], #timer');
+    if (!t) return;
+    if (!t.getAttribute('aria-live'))   t.setAttribute('aria-live', 'polite');
+    if (!t.getAttribute('aria-atomic')) t.setAttribute('aria-atomic', 'true');
+  };
+
+  const ensureProgressbarAria = () => {
+    const bar = document.querySelector('[data-testid="score-bar"], #score-bar');
+    if (!bar) return;
+    bar.setAttribute('role', 'progressbar');
+    bar.setAttribute('aria-valuemin', '0');
+    bar.setAttribute('aria-valuemax', '100');
+    const updateNow = () => {
+      // 期待: style="width: NN%"
+      const w = (bar.style && bar.style.width) || '';
+      const m = w.match(/(\d+(?:\.\d+)?)%/);
+      if (m) bar.setAttribute('aria-valuenow', String(Math.round(parseFloat(m[1]))));
+    };
+    updateNow();
+    // 変化を監視して now を追従
+    const mo = new MutationObserver(() => updateNow());
+    mo.observe(bar, { attributes: true, attributeFilter: ['style'] });
+  };
+
+  const annotateChoices = () => {
+    const container = document.querySelector('#choices') || document.querySelector('[data-testid="choices"]');
+    if (!container) return;
+    container.querySelectorAll('button, .choice, [data-testid="choice"]').forEach((el) => {
+      el.setAttribute('role', 'button'); // button要素でも冗長OK
+      if (!el.hasAttribute('aria-pressed')) el.setAttribute('aria-pressed', 'false');
+    });
+    // クリックで aria-pressed をトグル（選択反映）
+    container.addEventListener('click', (e) => {
+      const target = e.target.closest('button, .choice, [data-testid="choice"]');
+      if (!target) return;
+      container.querySelectorAll('button, .choice, [data-testid="choice"]').forEach((el) => {
+        el.setAttribute('aria-pressed', el === target ? 'true' : 'false');
+      });
+    }, { passive: true });
+  };
+
+  const focusFirstControl = once(() => {
+    // Free: answer、MC: 最初の選択肢
+    const answer = document.querySelector('[data-testid="answer"], #answer');
+    if (answer) { answer.focus?.(); return; }
+    const firstChoice = document.querySelector('#choices button, .choice, [data-testid="choice"]');
+    firstChoice?.focus?.();
+  });
+
+  const observeQuiz = () => {
+    const quizView = document.querySelector('#question-view') || document.querySelector('[data-testid="quiz-view"]');
+    if (!quizView) return;
+    // 出題レンダ後にA11yを適用
+    const apply = () => { ensureTimerAria(); ensureProgressbarAria(); annotateChoices(); focusFirstControl(); };
+    const mo = new MutationObserver(() => apply());
+    mo.observe(quizView, { childList: true, subtree: true, attributes: true });
+    apply();
+  };
+
+  window.addEventListener('DOMContentLoaded', () => {
+    // Start押下後にもフォーカスが飛ぶよう保険
+    const startBtn = document.querySelector('[data-testid="start-btn"], #start-btn');
+    if (startBtn) startBtn.addEventListener('click', () => setTimeout(() => focusFirstControl(), 0), { once: true });
+    observeQuiz();
+  });
+})();
+// --- /A11y shim ---


### PR DESCRIPTION
## Summary
- add lightweight accessibility shim to track progress bar values, annotate choices, and auto-focus first control
- extend Playwright ARIA test to verify focus, choice roles, and score bar updates

## Testing
- `npm test` *(fails: clojure not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*
- `node e2e/test_free_aria.js` *(fails: Cannot find module 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68b15e69f18483249047e05f2dfb7e92