### PR TITLE
feat: memoize version requests

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -62,9 +62,35 @@ function initSeededRandom() {
 
 initSeededRandom();
 
-async function readVersionNoStore(){
-  const r = await fetch(VERSION_URL,{cache:'no-store'});
-  return r.json();
+// === バージョン読み取りのメモ化（60s TTL） ========================
+const VERSION_TTL_MS = 60_000;
+let __readVersionCache = { ts: 0, data: null, etag: null };
+
+async function readVersionNoStore(force = false) {
+  if (!force && __readVersionCache.data && (Date.now() - __readVersionCache.ts) < VERSION_TTL_MS) {
+    return __readVersionCache.data;
+  }
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), 3000);
+  try {
+    const init = { signal: ctrl.signal, cache: 'no-store', headers: {} };
+    if (__readVersionCache.etag) init.headers['If-None-Match'] = __readVersionCache.etag;
+    const res = await fetch(VERSION_URL, init);
+    if (res.status === 304 && __readVersionCache.data) {
+      __readVersionCache.ts = Date.now();
+      return __readVersionCache.data;
+    }
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const etag = res.headers.get('ETag');
+    const data = await res.json();
+    __readVersionCache = { ts: Date.now(), data, etag };
+    return data;
+  } catch (_) {
+    if (__readVersionCache.data) return __readVersionCache.data;
+    return { dataset: 'mock', commit: 'local', content_hash: 'local' };
+  } finally {
+    clearTimeout(t);
+  }
 }
 function rememberHash(h){ localStorage.setItem(HASH_KEY,h); }
 function currentHash(){ return localStorage.getItem(HASH_KEY); }
@@ -756,7 +782,7 @@ loadAliases();
 
 navigator.serviceWorker?.addEventListener('message', async (e)=>{
   if(e.data?.type==='version-refreshed'){
-    const {content_hash} = await readVersionNoStore();
+    const {content_hash} = await readVersionNoStore(true);
     if(currentHash() !== content_hash){ showUpdateBanner(); }
   }
 });

--- a/public/app/sw.js
+++ b/public/app/sw.js
@@ -1,5 +1,18 @@
+/* eslint-disable no-restricted-globals */
+'use strict';
 self.__APP_VERSION__ = new URL(self.location).searchParams.get('v');
 const CACHE_NAME = 'vgm-quiz-' + (self.__APP_VERSION__ || 'dev');
+
+// --- バージョン監視の安定化設定 ----------------------------------------
+const VERSION_URL = self.VERMETA_URL || './build/version.json';
+const MIN_CHECK_INTERVAL_MS = 60 * 1000; // 最短60秒
+const CLIENT_POST_DEBOUNCE_MS = 60 * 1000; // 通知も最短60秒にデボンス
+let __versionWatchStarted = false;
+let __lastCheckAt = 0;
+let __lastNotifyAt = 0;
+let __lastETag = null;
+let __lastHash = null;
+// -----------------------------------------------------------------------
 
 self.addEventListener('install', event => {
   event.waitUntil(self.skipWaiting());
@@ -81,9 +94,57 @@ self.addEventListener('fetch', event => {
   })());
 });
 
+// ====== バージョン定期チェック =======================================
+async function safeFetchVersion() {
+  try {
+    const init = { cache: 'no-store', headers: {} };
+    if (__lastETag) init.headers['If-None-Match'] = __lastETag;
+    const res = await fetch(VERSION_URL, init);
+    if (res.status === 304) return { notModified: true };
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    __lastETag = res.headers.get('ETag');
+    const j = await res.json();
+    return { json: j };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+async function checkAndNotify() {
+  const now = Date.now();
+  if (now - __lastCheckAt < MIN_CHECK_INTERVAL_MS) return;
+  __lastCheckAt = now;
+  const { json, notModified } = await safeFetchVersion();
+  if (notModified || !json) return;
+  const newHash = json.content_hash || json.hash || json.commit || null;
+  if (!newHash || newHash === __lastHash) return;
+  __lastHash = newHash;
+  if (now - __lastNotifyAt < CLIENT_POST_DEBOUNCE_MS) return;
+  __lastNotifyAt = now;
+  const all = await self.clients.matchAll({ includeUncontrolled: true, type: 'window' });
+  for (const c of all) {
+    c.postMessage({ type: 'version-refreshed', content_hash: newHash });
+  }
+}
+
+function startVersionWatch() {
+  if (__versionWatchStarted) return;
+  __versionWatchStarted = true;
+  const loop = async () => {
+    await checkAndNotify();
+    setTimeout(loop, MIN_CHECK_INTERVAL_MS);
+  };
+  loop();
+}
+
+startVersionWatch();
+
 self.addEventListener('message', event => {
   if (event.data && event.data.type === 'SKIP_WAITING') {
     self.skipWaiting();
+  }
+  if (event.data && event.data.type === 'force-version-check') {
+    checkAndNotify();
   }
 });
 


### PR DESCRIPTION
## Summary
- memoize version.json fetches with 60s TTL and ETag support
- add periodic version watcher in service worker with debounced client notifications

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1700b41408324b041a3d21db1a913