### PR TITLE
feat: improve answer normalization

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,6 +39,7 @@ jobs:
           node e2e/test.js
           node e2e/test_free_aria.js
           node e2e/test_footer_version.js
+          node e2e/test_answer_normalize.mjs
 
       - name: Upload e2e artifacts
         if: always()
@@ -80,6 +81,7 @@ jobs:
           node e2e/test.js
           node e2e/test_free_aria.js
           node e2e/test_footer_version.js
+          node e2e/test_answer_normalize.mjs
       - name: Upload e2e artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/e2e/test_answer_normalize.mjs
+++ b/e2e/test_answer_normalize.mjs
@@ -1,0 +1,24 @@
+import { normalize } from '../public/app/normalize.mjs';
+import assert from 'node:assert/strict';
+
+function eq(a, b, msg) {
+  assert.equal(normalize(a), normalize(b), `${msg} | got "${normalize(a)}" vs "${normalize(b)}"`);
+}
+
+// Roman numerals ↔ Arabic
+eq('Final Fantasy VII', 'final-fantasy 7', 'Roman VII should equal 7');
+eq('Dragon Quest X', 'dragon quest 10', 'Roman X should equal 10');
+eq('kingdom hearts iii', 'Kingdom Hearts 3', 'iii should equal 3');
+
+// Punctuation / separators / whitespace
+eq('NieR:Automata', 'nier automata', 'Colon should be ignored');
+eq('Metal Gear Solid — Peace Walker', 'metal gear solid peace walker', 'Dashes should be ignored');
+eq('Resident Evil 2 / Biohazard RE:2', 'Resident Evil 2 Biohazard RE 2', 'Slashes/colons ignored');
+
+// JP: spaces / middle dot / long vowel
+eq('ポケットモンスター　赤', 'ポケットモンスター赤', 'JP spaces ignored');
+eq('ドラゴン・クエスト', 'ドラゴンクエスト', 'Middle dot ignored');
+eq('ドンキーコング', 'ドンキーーーコング', 'Long vowel marks ignored');
+
+console.log('[normalize] all tests passed');
+

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1,3 +1,5 @@
+import { normalize as normalizeV2 } from './normalize.mjs';
+
 let tracks = [];
 let questions = [];
 let current = 0;
@@ -268,7 +270,9 @@ async function exportAliasProposals() {
 }
 
 function norm(str) {
-  return str.normalize('NFKC').trim().toLowerCase();
+  // v1.1: 強化版ノーマライズ（normalize.mjs）へ委譲。失敗時は従来フォールバック。
+  try { return normalizeV2(String(str)); }
+  catch (_) { return String(str ?? '').normalize('NFKC').trim().toLowerCase(); }
 }
 
 function canonical(str) {
@@ -374,8 +378,9 @@ async function loadAliases() {
     const data = await res.json();
     Object.values(data).forEach(cat => {
       Object.entries(cat).forEach(([canon, list]) => {
-        aliases[canon] = canon;
-        list.forEach(a => aliases[a] = canon);
+        const canonN = norm(canon);
+        aliases[canonN] = canonN;
+        list.forEach(a => { aliases[norm(a)] = canonN; });
       });
     });
   } catch (err) {

--- a/public/app/normalize.mjs
+++ b/public/app/normalize.mjs
@@ -1,0 +1,48 @@
+// Answer normalization v1.1
+// - NFKC + lowercase
+// - Roman numerals (I,V,X,L,C,D,M / Ⅶ 等もNFKCでOK) → Arabic numerals
+// - 非意味文字の除去：空白/各種ダッシュ/スラッシュ/中点/長音「ー」/記号/括弧 等
+// - 依存なし・小さく実装。ブラウザ/Nodeのどちらでも動作。
+
+function toNFKCLower(s) {
+  return String(s ?? '').normalize('NFKC').trim().toLowerCase();
+}
+
+function romanToIntToken(tok) {
+  const map = { i:1, v:5, x:10, l:50, c:100, d:500, m:1000 };
+  let total = 0, prev = 0;
+  for (let i = tok.length - 1; i >= 0; i--) {
+    const val = map[tok[i]];
+    if (!val) return null;
+    if (val < prev) total -= val; else { total += val; prev = val; }
+  }
+  if (total <= 0 || total > 3999) return null;
+  return total;
+}
+
+function replaceRomanNumerals(s) {
+  // 単独トークンのローマ数字だけ数値化（英数以外に挟まれているものを対象）
+  return s.replace(/(^|[^a-z0-9])([mdclxvi]{1,7})(?=($|[^a-z0-9]))/g, (m, pre, tok) => {
+    const n = romanToIntToken(tok);
+    if (n == null) return m;
+    return pre + String(n);
+  });
+}
+
+const NON_MEANINGFUL_CLASS = [
+  '\\s','\\u00A0','\\u2000-\\u200B','\\u202F\\u205F\\u3000', // 空白
+  '、。·・，．','!"#$%&\\\'“”‘’\\(\\)\\[\\]｢｣「」『』【】〈〉《》{}＜＞<>', // 句読点/括弧
+  ':：;；\\.?？,!！','_','\\\\','\\/', // 区切り類
+  '\\u2010-\\u2015','\\u2212','\\u30FB','\\u30FC','\\-－−' // ダッシュ/中点/長音/マイナス
+].join('');
+const NON_MEANINGFUL_RE = new RegExp('[' + NON_MEANINGFUL_CLASS + ']+', 'g');
+
+export function normalize(input) {
+  let s = toNFKCLower(input);
+  s = replaceRomanNumerals(s);        // 先にローマ数字を処理
+  s = s.replace(NON_MEANINGFUL_RE, ''); // 非意味文字を除去
+  return s;
+}
+
+export default { normalize };
+


### PR DESCRIPTION
## Summary
- add standalone normalization utility handling roman numerals and punctuation
- use new normalization in app and alias loading
- add unit test for normalize and include in e2e workflow

## Testing
- `node e2e/test_answer_normalize.mjs`
- ❌ `npm test` *(missing clojure)*
- ❌ `node e2e/test.js` *(missing playwright)*


------
https://chatgpt.com/codex/tasks/task_e_68b251b4a81c8324bdf3a3f739dfcd3b