### PR TITLE
feat: add result share actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,6 +39,7 @@ jobs:
           node e2e/test.js
           node e2e/test_free_aria.js
           node e2e/test_footer_version.js
+          node e2e/test_results_share.mjs
           node e2e/test_answer_normalize.mjs
 
       - name: Upload e2e artifacts
@@ -81,6 +82,7 @@ jobs:
           node e2e/test.js
           node e2e/test_free_aria.js
           node e2e/test_footer_version.js
+          node e2e/test_results_share.mjs
           node e2e/test_answer_normalize.mjs
       - name: Upload e2e artifacts
         if: always()

--- a/e2e/test_results_share.mjs
+++ b/e2e/test_results_share.mjs
@@ -1,0 +1,75 @@
+// 結果画面に「結果をコピー」ボタンが表示され、クリックでクリップボードへ書けることを確認
+import { chromium } from 'playwright';
+import fs from 'fs';
+
+(async () => {
+  const TIMEOUT = 30000;
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  // クリップボード権限を付与（ヘッドレスで必要）
+  await context.grantPermissions(['clipboard-read','clipboard-write']);
+  const page = await context.newPage();
+
+  // 既存E2Eと同様にクエリを補完
+  const base = process.env.E2E_BASE_URL || process.env.APP_URL || 'http://127.0.0.1:8080/app/';
+  const url = (() => {
+    try {
+      const u = new URL(base);
+      const p = u.searchParams;
+      if (!p.has('test'))      p.set('test', '1');
+      if (!p.has('mock'))      p.set('mock', '1');
+      if (!p.has('seed'))      p.set('seed', 'e2e');
+      if (!p.has('autostart')) p.set('autostart', '0');
+      return u.toString();
+    } catch {
+      return base + (base.includes('?') ? '&' : '?') + 'test=1&mock=1&seed=e2e&autostart=0';
+    }
+  })();
+
+  await page.goto(url, { waitUntil: 'networkidle' });
+
+  // Start → Quiz
+  await page.waitForSelector('[data-testid="start-btn"]:not([disabled])', { state: 'visible', timeout: TIMEOUT });
+  await page.click('[data-testid="start-btn"]');
+  await page.waitForSelector('[data-testid="quiz-view"]', { state: 'visible', timeout: TIMEOUT });
+
+  // helper: MC なら選択肢から __expectedAnswer を選んで即回答、Free なら入力して Submit
+  const isMC = async () => await page.evaluate(() => {
+    const el = document.querySelector('#choices');
+    return !!el && getComputedStyle(el).display !== 'none';
+  });
+  const answerOnce = async () => {
+    await page.waitForFunction(() => !!window.__expectedAnswer, { timeout: TIMEOUT });
+    const expected = await page.evaluate(() => window.__expectedAnswer);
+    if (await isMC()) {
+      await page.waitForFunction(() => {
+        const btns = Array.from(document.querySelectorAll('#choices button,.choice,[data-testid="choice"]'));
+        return btns.length >= 4 && btns.every(b => (b.textContent || '').trim().length > 0);
+      }, { timeout: TIMEOUT });
+      const idx = await page.$$eval('#choices button,.choice,[data-testid="choice"]',
+        (btns, expected) => btns.findIndex(b => (b.textContent || '').trim().toLowerCase() === String(expected).trim().toLowerCase()), expected);
+      const clickSel = `#choices button:nth-of-type(${idx + 1}), .choice:nth-of-type(${idx + 1}), [data-testid="choice"]:nth-of-type(${idx + 1})`;
+      await page.click(clickSel);
+    } else {
+      await page.fill('#answer, [data-testid="answer"]', expected);
+      await page.click('#submit-btn, [data-testid="submit-btn"]');
+    }
+    await page.waitForSelector('#next-btn, [data-testid="next-btn"]', { state: 'visible', timeout: TIMEOUT });
+    await page.click('#next-btn, [data-testid="next-btn"]');
+  };
+
+  // 5問（既定値）を連続で正解し、結果画面へ
+  for (let i = 0; i < 5; i++) { await answerOnce(); }
+  await page.waitForSelector('#result-view', { state: 'visible', timeout: TIMEOUT });
+
+  // コピー -> クリップボードに "Score:" を含むことを検証
+  await page.click('#copy-result-btn, [data-testid="copy-result-btn"]', { timeout: TIMEOUT });
+  const clip = await page.evaluate(async () => (await navigator.clipboard.readText?.()) || '');
+  if (!clip.includes('Score:')) throw new Error('clipboard does not contain "Score:"');
+
+  // アーティファクト
+  await page.screenshot({ path: 'artifacts/final_test_share.png', fullPage: true });
+  fs.writeFileSync('artifacts/dom_test_share.html', await page.content());
+
+  await browser.close();
+})();

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -716,6 +716,90 @@ function showResult() {
     li.textContent = `${TYPE_LABELS[q.type]} - ${q.correct ? '✅' : '❌'} - ${q.expected} - ${q.userAnswer || ''} - ${q.track.year} - ${q.track.game} - ${q.elapsed}s`;
     list.appendChild(li);
   });
+
+  // v2: 結果の共有導線（コピー／Share）をセットアップ
+  setupResultShare();
+}
+
+// --- Share helpers (結果画面専用) ---
+function canonicalAppUrl() {
+  // 現在の URL から検証用クエリを取り除いた共有用URLを返す
+  try {
+    const u = new URL(location.href);
+    const rm = ['test','mock','autostart','lhci','debug'];
+    rm.forEach(k => u.searchParams.delete(k));
+    return u.toString();
+  } catch {
+    return location.origin + location.pathname;
+  }
+}
+
+function buildResultShareText() {
+  const total = questions.length || 0;
+  const correct = score || 0;
+  const acc = total ? Math.round((correct / total) * 100) : 0;
+  const types = selectedTypes().map(t => TYPE_LABELS[t] || t).join(', ');
+  const mode = (questionMode === 'multiple-choice') ? '4択' : '自由入力';
+  const seed = window.__SEED__ || new URLSearchParams(location.search).get('seed') || '';
+  const timer = useTimer ? '20s' : 'off';
+  const url = canonicalAppUrl();
+  return [
+    'VGM Quiz',
+    `Score: ${correct}/${total} (${acc}%)`,
+    `Mode: ${mode}${seed ? ` | seed: ${seed}` : ''} | Timer: ${timer}`,
+    `Types: ${types}`,
+    `Play: ${url}`
+  ].join('\n');
+}
+
+async function copyToClipboard(text) {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+    } else {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+    const toast = document.getElementById('copy-toast');
+    if (toast) toast.textContent = 'コピーしました';
+  } catch (e) {
+    alert('コピーに失敗しました: ' + e.message);
+  }
+}
+
+function setupResultShare() {
+  const copyBtn = document.getElementById('copy-result-btn');
+  const shareBtn = document.getElementById('share-result-btn');
+  const toast = document.getElementById('copy-toast');
+  if (toast) toast.textContent = ''; // 直前の表示をリセット
+  if (!copyBtn || !shareBtn) return;
+  if (!copyBtn.dataset._bound) {
+    copyBtn.addEventListener('click', async () => {
+      await copyToClipboard(buildResultShareText());
+    }, { passive: true });
+    copyBtn.dataset._bound = '1';
+  }
+  // Web Share API がある環境だけ Share を出す
+  if (typeof navigator.share === 'function') {
+    shareBtn.style.display = '';
+    if (!shareBtn.dataset._bound) {
+      shareBtn.addEventListener('click', async () => {
+        const text = buildResultShareText();
+        try { await navigator.share({ title: 'VGM Quiz', text, url: canonicalAppUrl() }); }
+        catch (e) {
+          // キャンセル等は無視。それ以外はコピーにフォールバック
+          if (e && e.name !== 'AbortError') await copyToClipboard(text);
+        }
+      }, { passive: true });
+      shareBtn.dataset._bound = '1';
+    }
+  } else {
+    shareBtn.style.display = 'none';
+  }
 }
 
 function restart() {

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -83,6 +83,11 @@
     <h2>Summary</h2>
     <ul id="summary-list"></ul>
   </div>
+  <div id="share-actions" style="margin:8px 0">
+    <button id="copy-result-btn" data-testid="copy-result-btn">結果をコピー</button>
+    <button id="share-result-btn" data-testid="share-result-btn" style="display:none">共有…</button>
+    <span id="copy-toast" role="status" aria-live="polite" style="margin-left:8px;"></span>
+  </div>
   <button id="restart-btn">Restart</button>
 </div>
 


### PR DESCRIPTION
## Summary
- add copy/share buttons for quiz results
- implement share text builder and clipboard/share helpers
- cover result sharing with new e2e test and workflow hook

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `node e2e/test_results_share.mjs` *(fails: Cannot find package 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68b25574d3788324b4c6c04cdbdaaa01