### PR TITLE
feat: display lives HUD

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,7 @@ jobs:
           node e2e/test_free_aria.js
           node e2e/test_footer_version.js
           node e2e/test_results_share.mjs
+          node e2e/test_lives_visual.mjs
           node e2e/test_answer_normalize.mjs
 
       - name: Upload e2e artifacts
@@ -83,6 +84,7 @@ jobs:
           node e2e/test_free_aria.js
           node e2e/test_footer_version.js
           node e2e/test_results_share.mjs
+          node e2e/test_lives_visual.mjs
           node e2e/test_answer_normalize.mjs
       - name: Upload e2e artifacts
         if: always()

--- a/e2e/test_lives_visual.mjs
+++ b/e2e/test_lives_visual.mjs
@@ -1,0 +1,58 @@
+import { chromium } from 'playwright';
+
+(async () => {
+  const TIMEOUT = 30000;
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const base = process.env.E2E_BASE_URL || process.env.APP_URL || 'http://127.0.0.1:8080/app/';
+  const url = (() => {
+    try {
+      const u = new URL(base);
+      const p = u.searchParams;
+      if (!p.has('test'))      p.set('test', '1');
+      if (!p.has('mock'))      p.set('mock', '1');
+      if (!p.has('seed'))      p.set('seed', 'e2e');
+      if (!p.has('autostart')) p.set('autostart', '0');
+      return u.toString();
+    } catch {
+      return base + (base.includes('?') ? '&' : '?') + 'test=1&mock=1&seed=e2e&autostart=0';
+    }
+  })();
+
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.click('[data-testid="start-btn"]');
+  await page.waitForSelector('[data-testid="quiz-view"]', { state: 'visible', timeout: TIMEOUT });
+
+  // 1問目：わざと不正解にする
+  await page.waitForFunction(() => !!window.__expectedAnswer, { timeout: TIMEOUT });
+  const expected = await page.evaluate(() => window.__expectedAnswer);
+
+  // MC があれば別の選択肢をクリック、Free なら適当な誤答を入れて Submit
+  const isMC = await page.evaluate(() => {
+    const el = document.querySelector('#choices');
+    return !!el && getComputedStyle(el).display !== 'none';
+  });
+  if (isMC) {
+    const choices = await page.$$eval('#choices button,.choice,[data-testid="choice"]', els => els.map(e => (e.textContent || '').trim()));
+    const wrongIdx = Math.max(0, choices.findIndex(t => t.toLowerCase() !== String(window.__expectedAnswer || '').toLowerCase()));
+    await page.click(`#choices button:nth-of-type(${wrongIdx + 1}), .choice:nth-of-type(${wrongIdx + 1}), [data-testid="choice"]:nth-of-type(${wrongIdx + 1})`);
+  } else {
+    await page.fill('#answer, [data-testid="answer"]', 'totally wrong');
+    await page.click('#submit-btn, [data-testid="submit-btn"]');
+  }
+  await page.click('#next-btn, [data-testid="next-btn"]');
+
+  // lives のテキストが "1/3" 相当を含むか（言語差異を避けて数字だけ検査）
+  await page.waitForFunction(() => {
+    const el = document.getElementById('lives') || document.querySelector('[data-testid="lives"]');
+    if (!el) return false;
+    const t = (el.textContent || '').replace(/\s+/g,'');
+    // "1/3" や "Misses:1/3" 等
+    return /(?:^|[^0-9])1\s*\/\s*3(?:[^0-9]|$)/.test(t);
+  }, { timeout: TIMEOUT });
+
+  await browser.close();
+})();
+

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -2,6 +2,9 @@ import { normalize as normalizeV2 } from './normalize.mjs';
 
 let tracks = [];
 let questions = [];
+const MAX_LIVES = 3;
+let mistakes = 0;
+let __livesInterval = null;
 let current = 0;
 let score = 0;
 let awaitingNext = false;
@@ -278,6 +281,43 @@ function norm(str) {
 function canonical(str) {
   const n = norm(str);
   return aliases[n] || n;
+}
+
+// --- lives（残機）: 誤答数をHUDに反映 ---
+function updateLivesDisplay() {
+  const el = document.getElementById('lives') || document.querySelector('[data-testid="lives"]');
+  if (!el) return;
+  // A11y: role/status として polite に更新
+  el.setAttribute('role', 'status');
+  el.setAttribute('aria-live', 'polite');
+  el.setAttribute('aria-atomic', 'true');
+  el.textContent = `Misses: ${mistakes}/${MAX_LIVES}`;
+}
+
+function recomputeMistakes() {
+  try {
+    // 既に回答済みの設問から誤答をカウント
+    // （構造: q.correct が boolean / userAnswer が入るのを想定）
+    mistakes = (questions || []).filter(q => q && q.userAnswer != null && q.correct === false).length;
+  } catch (_) {
+    // フォールバック（何もしない）
+  }
+  updateLivesDisplay();
+}
+
+function startLivesTicker() {
+  stopLivesTicker();
+  // 次の問題表示や手動/自動の遷移に追随するため、軽い定期更新
+  __livesInterval = setInterval(recomputeMistakes, 400);
+  // 開始時に即時1回
+  recomputeMistakes();
+}
+
+function stopLivesTicker() {
+  if (__livesInterval) {
+    clearInterval(__livesInterval);
+    __livesInterval = null;
+  }
 }
 
 function levenshtein(a, b) {
@@ -709,6 +749,9 @@ function showResult() {
   }
   showView('result-view');
   document.getElementById('final-score').textContent = `Score: ${score}/${questions.length}`;
+  // 結果画面では定期更新を停止し、最終値を表示
+  stopLivesTicker();
+  recomputeMistakes();
   const list = document.getElementById('summary-list');
   list.innerHTML = '';
   questions.forEach(q => {
@@ -893,6 +936,32 @@ navigator.serviceWorker?.addEventListener('message', async (e)=>{
     const {content_hash} = await readVersionNoStore(true);
     if(currentHash() !== content_hash){ showUpdateBanner(); }
   }
+});
+// 既存の開始/遷移UIにフックして lives を更新
+window.addEventListener('DOMContentLoaded', () => {
+  try {
+    // Start を押したらリセット
+    const startBtn = document.getElementById('start-btn') || document.querySelector('[data-testid="start-btn"]');
+    if (startBtn && !startBtn.dataset._livesbound) {
+      startBtn.addEventListener('click', () => {
+        mistakes = 0;
+        startLivesTicker();
+      }, { passive: true });
+      startBtn.dataset._livesbound = '1';
+    }
+
+    // Next（次の問題へ）で再集計
+    document.addEventListener('click', (e) => {
+      const t = e.target;
+      const id = t && (t.id || t.getAttribute?.('data-testid')) || '';
+      if (id === 'next-btn') {
+        // DOM更新後に集計する
+        setTimeout(recomputeMistakes, 0);
+      }
+    }, { passive: true });
+
+    // 他の初期化があれば既存処理…
+  } catch (_) {}
 });
 // 初期化時に1回だけ実行（以降の呼び出しはガードで即return）
 window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- track misses and update lives HUD in quiz
- add E2E test verifying lives HUD updates
- run lives test in CI workflow

## Testing
- `npm test` *(fails: clojure: not found)*
- `node e2e/test_lives_visual.mjs` *(fails: Cannot find package 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68b25d2e872083249baec26707906e4b