### PR TITLE
feat: add question pipeline with year buckets and e2e coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,6 +41,7 @@ jobs:
           node e2e/test_footer_version.js
           node e2e/test_results_share.mjs
           node e2e/test_lives_visual.mjs
+          node e2e/test_pipeline_flag.mjs
           node e2e/test_answer_normalize.mjs
 
       - name: Upload e2e artifacts
@@ -85,6 +86,7 @@ jobs:
           node e2e/test_footer_version.js
           node e2e/test_results_share.mjs
           node e2e/test_lives_visual.mjs
+          node e2e/test_pipeline_flag.mjs
           node e2e/test_answer_normalize.mjs
       - name: Upload e2e artifacts
         if: always()

--- a/e2e/test_pipeline_flag.mjs
+++ b/e2e/test_pipeline_flag.mjs
@@ -1,0 +1,45 @@
+import { chromium } from 'playwright';
+
+function withParams(base, extra) {
+  try {
+    const u = new URL(base);
+    const p = u.searchParams;
+    Object.entries(extra).forEach(([k,v]) => p.set(k, String(v)));
+    return u.toString();
+  } catch {
+    const q = Object.entries(extra).map(([k,v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`).join('&');
+    return base + (base.includes('?') ? '&' : '?') + q;
+  }
+}
+
+(async () => {
+  const TIMEOUT = 30000;
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const base0 = process.env.E2E_BASE_URL || process.env.APP_URL || 'http://127.0.0.1:8080/app/';
+  const base = withParams(base0, { test: 1, mock: 1, qp: 1, autostart: 0 });
+
+  // run with seed A
+  await page.goto(withParams(base, { seed: 'qp-seed-a' }), { waitUntil: 'networkidle' });
+  await page.click('[data-testid="start-btn"]');
+  await page.waitForFunction(() => !!window.__questionIds, { timeout: TIMEOUT });
+  const a = await page.evaluate(() => window.__questionIds);
+
+  // reload with same seed A -> must be identical
+  await page.goto(withParams(base, { seed: 'qp-seed-a' }), { waitUntil: 'networkidle' });
+  await page.click('[data-testid="start-btn"]');
+  await page.waitForFunction(() => !!window.__questionIds, { timeout: TIMEOUT });
+  const a2 = await page.evaluate(() => window.__questionIds);
+  if (a !== a2) throw new Error('order not stable for same seed');
+
+  // run with different seed B -> should differ (best-effort; allow equality if dataset is tiny)
+  await page.goto(withParams(base, { seed: 'qp-seed-b' }), { waitUntil: 'networkidle' });
+  await page.click('[data-testid="start-btn"]');
+  await page.waitForFunction(() => !!window.__questionIds, { timeout: TIMEOUT });
+  const b = await page.evaluate(() => window.__questionIds);
+  if (a === b) console.warn('[warn] order equals between seeds; dataset may be too small, continuing');
+
+  await browser.close();
+})();

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1,4 +1,5 @@
 import { normalize as normalizeV2 } from './normalize.mjs';
+import { orderByYearBucket } from './question_pipeline.mjs';
 
 let tracks = [];
 let questions = [];
@@ -28,6 +29,14 @@ const HASH_KEY = 'dataset_hash';
 const __SEARCH_PARAMS__ = new URLSearchParams(location.search);
 const __IS_TEST_MODE__ = __SEARCH_PARAMS__.get('test') === '1';
 const __DEBUG__ = __SEARCH_PARAMS__.get('debug') === '1';
+
+// URLクエリのbool取得（既存があればそれを使用、なければ補助）
+function getQueryBool(key) {
+  try {
+    const v = new URLSearchParams(location.search).get(key);
+    return v === '1' || v === 'true';
+  } catch { return false; }
+}
 
 // DETERMINISTIC RNG: URL に ?seed=xxx があれば Math.random を決定化
 function initSeededRandom() {
@@ -281,6 +290,23 @@ function norm(str) {
 function canonical(str) {
   const n = norm(str);
   return aliases[n] || n;
+}
+
+// 質問配列が作られた直後（既存ロジックの直後）で並べ替えを適用
+// 例：buildQuestions() / startGame() の直後など、questions が最終確定した箇所にフック
+function afterQuestionsBuiltHook() {
+  try {
+    if (getQueryBool('qp') && Array.isArray(questions) && questions.length > 0) {
+      // 既存のシード RNG を使う（なければ Math.random）
+      const rng = (typeof window.__rng === 'function') ? window.__rng : Math.random;
+      const order = orderByYearBucket(questions, rng);
+      questions = order.map(i => questions[i]);
+    }
+    // test=1 のとき E2E から見えるように公開（IDが無ければ title を代替）
+    if (getQueryBool('test') && Array.isArray(questions)) {
+      window.__questionIds = questions.map(q => q?.track?.id ?? q?.track?.title ?? '').join(',');
+    }
+  } catch (_) {}
 }
 
 // --- lives（残機）: 誤答数をHUDに反映 ---
@@ -582,6 +608,7 @@ function startQuiz() {
     console.info('[DEBUG] attempts', attempts);
   }
   questions = built;
+  afterQuestionsBuiltHook();
   current = 0;
   score = 0;
   showQuestion();

--- a/public/app/question_pipeline.mjs
+++ b/public/app/question_pipeline.mjs
@@ -1,0 +1,58 @@
+// Question selection pipeline (front) — v0.1
+// - decade buckets (e.g., 1990s, 2000s, unknown)
+// - shuffle inside each bucket using provided RNG
+// - round-robin across buckets to produce an index order
+// Usage:
+//   const order = orderByYearBucket(questions, rng); // returns array of indices
+//   const reordered = order.map(i => questions[i]);
+
+function decadeOf(year) {
+  const y = Number(year);
+  if (!Number.isFinite(y)) return 'unknown';
+  return `${Math.floor(y / 10) * 10}s`;
+}
+
+function shuffleInPlace(arr, rng) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+export function orderByYearBucket(questions, rng = Math.random) {
+  // group indices by decade
+  const buckets = new Map(); // decade -> indices[]
+  questions.forEach((q, i) => {
+    const yr = q?.track?.year;
+    const k = decadeOf(yr);
+    if (!buckets.has(k)) buckets.set(k, []);
+    buckets.get(k).push(i);
+  });
+  // shuffle inside each bucket
+  for (const [, idxs] of buckets) shuffleInPlace(idxs, rng);
+  // round-robin across buckets
+  const keys = Array.from(buckets.keys());
+  let remaining = questions.length;
+  const out = [];
+  let p = 0;
+  while (remaining > 0 && keys.length > 0) {
+    const k = keys[p % keys.length];
+    const bin = buckets.get(k);
+    const v = bin.shift();
+    if (v != null) {
+      out.push(v);
+      remaining--;
+    }
+    if (bin.length === 0) {
+      buckets.delete(k);
+      keys.splice(p % keys.length, 1);
+      // don't advance p when removing current bucket
+      continue;
+    }
+    p++;
+  }
+  return out;
+}
+
+export default { orderByYearBucket };


### PR DESCRIPTION
## Summary
- add client-side question_pipeline.mjs to shuffle questions by decade buckets and round-robin them for balanced order
- expose query flags in app.js to enable pipeline and debug question ids, applying reordering with afterQuestionsBuiltHook
- extend e2e workflow and tests with pipeline flag coverage

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `npm install --no-save playwright` *(fails: 403 Forbidden)*
- `node e2e/test_pipeline_flag.mjs` *(fails: Cannot find package 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68b260c1b9608324bf09156fdeec3e5a