### PR TITLE
Add daily one-question quiz mode and test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,6 +42,7 @@ jobs:
           node e2e/test_results_share.mjs
           node e2e/test_lives_visual.mjs
           node e2e/test_pipeline_flag.mjs
+          node e2e/test_daily_mode.mjs
           node e2e/test_answer_normalize.mjs
 
       - name: Upload e2e artifacts
@@ -87,6 +88,7 @@ jobs:
           node e2e/test_results_share.mjs
           node e2e/test_lives_visual.mjs
           node e2e/test_pipeline_flag.mjs
+          node e2e/test_daily_mode.mjs
           node e2e/test_answer_normalize.mjs
       - name: Upload e2e artifacts
         if: always()

--- a/e2e/test_daily_mode.mjs
+++ b/e2e/test_daily_mode.mjs
@@ -1,0 +1,48 @@
+// e2e/test_daily_mode.mjs
+import { chromium } from 'playwright';
+
+(async () => {
+  const TIMEOUT = 30000;
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const base = process.env.E2E_BASE_URL || process.env.APP_URL || 'http://127.0.0.1:8080/app/';
+  const url = (() => {
+    try {
+      const u = new URL(base);
+      const p = u.searchParams;
+      if (!p.has('test')) p.set('test', '1');
+      if (!p.has('mock')) p.set('mock', '1');
+      if (!p.has('qp'))   p.set('qp', '1');
+      p.set('daily', '2000-01-01');  // daily.json に用意した固定日
+      p.set('autostart', '0');
+      return u.toString();
+    } catch {
+      return base + (base.includes('?') ? '&' : '?') + 'test=1&mock=1&qp=1&daily=2000-01-01&autostart=0';
+    }
+  })();
+
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.click('[data-testid="start-btn"]');
+  await page.waitForSelector('[data-testid="quiz-view"]', { state: 'visible', timeout: TIMEOUT });
+
+  // Freeモード前提で1問を誤答→Next→結果が /1 になること
+  const hasFree = await page.$('#answer, [data-testid="answer"]');
+  if (hasFree) {
+    await page.fill('#answer, [data-testid="answer"]', 'totally wrong');
+    await page.click('#submit-btn, [data-testid="submit-btn"]');
+  } else {
+    // MC の場合は1番目を選んで不正解にする（best-effort）
+    await page.click('#choices button:nth-of-type(1), .choice:nth-of-type(1), [data-testid="choice"]:nth-of-type(1)');
+  }
+  await page.click('#next-btn, [data-testid="next-btn"]');
+  await page.waitForSelector('#result-view', { state: 'visible', timeout: TIMEOUT });
+
+  const final = await page.textContent('#final-score');
+  if (!/\/\s*1\b/.test(final || '')) {
+    throw new Error(`final score is not */1: got "${final}"`);
+  }
+
+  await browser.close();
+})();

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -86,6 +86,87 @@ function initSeededRandom() {
 
 initSeededRandom();
 
+// ---------------------
+// Daily 1-question mode
+// ---------------------
+const DAILY = {
+  active: false,
+  dateStr: null,        // 'YYYY-MM-DD'
+  wanted: null,         // { id?: string, title?: string }
+  mapLoaded: false,
+};
+
+function getQueryParam(name) {
+  try { return new URLSearchParams(location.search).get(name); }
+  catch { return null; }
+}
+
+function todayJST() {
+  // 'YYYY-MM-DD' を JST で作る
+  const fmt = new Intl.DateTimeFormat('ja-JP', { timeZone: 'Asia/Tokyo', year: 'numeric', month: '2-digit', day: '2-digit' });
+  const [{value: y}, , {value: m}, , {value: d}] = fmt.formatToParts(new Date());
+  return `${y}-${m}-${d}`;
+}
+
+function detectDailyParam() {
+  const v = getQueryParam('daily');
+  if (!v) return null;
+  if (v === '1' || v === 'true') return todayJST();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return v;
+  return null;
+}
+
+async function preloadDailyMap() {
+  try {
+    const res = await fetch('./daily.json', { cache: 'no-cache' });
+    if (!res.ok) throw new Error(`daily.json ${res.status}`);
+    const data = await res.json();
+    DAILY.map = data?.map || {};
+    DAILY.mapLoaded = true;
+  } catch (e) {
+    console.warn('[daily] failed to load daily.json:', e);
+    DAILY.map = {};
+    DAILY.mapLoaded = true;
+  }
+}
+
+function initDaily() {
+  const date = detectDailyParam();
+  if (!date) return;
+  DAILY.active = true;
+  DAILY.dateStr = date;
+}
+
+// タイトル/IDの正規化一致
+function normKey(s) { return normalizeV2(String(s || '')); }
+function pickDailyWantedFromMap() {
+  if (!DAILY.active) return;
+  const entry = DAILY.map?.[DAILY.dateStr];
+  if (!entry) return;
+  if (typeof entry === 'string') {
+    DAILY.wanted = { id: entry }; // 旧式：そのままID扱い
+  } else if (entry && typeof entry === 'object') {
+    DAILY.wanted = { id: entry.id, title: entry.title };
+  }
+}
+
+// 質問配列を 1 問に絞る（可能なら該当トラックを優先）
+function applyDailyRestriction() {
+  if (!DAILY.active || !Array.isArray(questions) || questions.length === 0) return;
+  // 優先順位: ID → タイトル（正規化一致）
+  let idx = -1;
+  if (DAILY.wanted?.id) {
+    const target = normKey(DAILY.wanted.id);
+    idx = questions.findIndex(q => normKey(q?.track?.id) === target);
+  }
+  if (idx < 0 && DAILY.wanted?.title) {
+    const target = normKey(DAILY.wanted.title);
+    idx = questions.findIndex(q => normKey(q?.track?.title) === target);
+  }
+  if (idx < 0) idx = 0; // フォールバック
+  questions = [questions[idx]];
+}
+
 // === バージョン読み取りのメモ化（60s TTL） ========================
 const VERSION_TTL_MS = 60_000;
 let __readVersionCache = { ts: 0, data: null, etag: null };
@@ -306,12 +387,24 @@ function canonical(str) {
 // 例：buildQuestions() / startGame() の直後など、questions が最終確定した箇所にフック
 function afterQuestionsBuiltHook() {
   try {
+    // (1) 出題順の分散（フラグ qp=1 のとき）
     if (getQueryBool('qp') && Array.isArray(questions) && questions.length > 0) {
       // v0.2: ここで明示的に seed RNG を使う（フォールバックは rngForPipeline 側で済）
       const order = orderByYearBucket(questions, rngForPipeline);
       questions = order.map(i => questions[i]);
     }
-    // test=1 のとき、確認しやすい詳細も公開（再入しても問題ない冪等処理）
+    // (2) デイリー1問（フラグ daily=... のとき）
+    if (DAILY.active) {
+      if (!DAILY.mapLoaded) {
+        // 先読み未完の場合は同期的に見えるところで諦め、次回以降に反映（安全策）
+        console.warn('[daily] map not loaded yet; using fallback (first question)');
+        questions = [questions[0]];
+      } else {
+        pickDailyWantedFromMap();
+        applyDailyRestriction();
+      }
+    }
+    // (3) test=1 のときデバッグ公開
     if (getQueryBool('test') && Array.isArray(questions)) {
       window.__questionIds = questions.map(q => q?.track?.id ?? q?.track?.title ?? '').join(',');
       window.__questionDebug = questions.map(q => ({
@@ -989,9 +1082,14 @@ navigator.serviceWorker?.addEventListener('message', async (e)=>{
     if(currentHash() !== content_hash){ showUpdateBanner(); }
   }
 });
-// 既存の開始/遷移UIにフックして lives を更新
+// ---------------------
+// 起動時フック
+// ---------------------
 window.addEventListener('DOMContentLoaded', () => {
   try {
+    // Daily 検出＆先読み開始
+    initDaily();
+    if (DAILY.active) { preloadDailyMap(); }
     // Start を押したらリセット
     const startBtn = document.getElementById('start-btn') || document.querySelector('[data-testid="start-btn"]');
     if (startBtn && !startBtn.dataset._livesbound) {

--- a/public/app/daily.json
+++ b/public/app/daily.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "tz": "Asia/Tokyo",
+  "map": {
+    "2000-01-01": { "title": "Stickerbrush Symphony" },
+    "2025-08-30": { "title": "Stickerbrush Symphony" }
+  }
+}


### PR DESCRIPTION
## Summary
- Support daily one-question mode selected via `?daily` query and `public/app/daily.json`
- Restrict question set and preload daily map; hook daily logic into startup and pipeline
- Add Playwright E2E test for daily mode and run it in CI

## Testing
- `npm test` *(fails: clojure: not found)*
- `node e2e/test_daily_mode.mjs` *(fails: Cannot find package 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68b273ecc16083249d05e6a4f3ae6242