### PR TITLE
Add stubbed media preview and e2e coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,6 +42,7 @@ jobs:
           node e2e/test_results_share.mjs
           node e2e/test_lives_visual.mjs
           node e2e/test_pipeline_flag.mjs
+          node e2e/test_media_button.mjs
           node e2e/test_daily_mode.mjs
           node e2e/test_answer_normalize.mjs
 
@@ -88,6 +89,7 @@ jobs:
           node e2e/test_results_share.mjs
           node e2e/test_lives_visual.mjs
           node e2e/test_pipeline_flag.mjs
+          node e2e/test_media_button.mjs
           node e2e/test_daily_mode.mjs
           node e2e/test_answer_normalize.mjs
       - name: Upload e2e artifacts

--- a/e2e/test_media_button.mjs
+++ b/e2e/test_media_button.mjs
@@ -1,0 +1,38 @@
+import { chromium } from 'playwright';
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const base = process.env.E2E_BASE_URL || process.env.APP_URL || 'http://127.0.0.1:8080/app/';
+  const url = (() => {
+    try {
+      const u = new URL(base);
+      const p = u.searchParams;
+      if (!p.has('test')) p.set('test','1');  // ← stub動作
+      if (!p.has('mock')) p.set('mock','1');
+      if (!p.has('seed')) p.set('seed','alpha');
+      if (!p.has('autostart')) p.set('autostart','0');
+      return u.toString();
+    } catch {
+      return base + (base.includes('?')?'&':'?') + 'test=1&mock=1&seed=alpha&autostart=0';
+    }
+  })();
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.click('[data-testid="start-btn"]');
+  await page.waitForSelector('[data-testid="quiz-view"]', { state: 'visible' });
+  // 再生ボタンが出る（mockの1問目にmediaを付与済み）
+  await page.waitForSelector('[data-testid="play-clip"]', { state: 'visible' });
+  await page.click('[data-testid="play-clip"]');
+  // stub フラグが立つ
+  const played = await page.evaluate(() => !!window.__mediaPlayed);
+  if (!played) throw new Error('media did not play (stub)');
+  // そのまま解答～次へが可能（UIブロックなし）
+  const hasFree = await page.$('#answer, [data-testid="answer"]');
+  if (hasFree) {
+    await page.fill('#answer, [data-testid="answer"]', 'wrong');
+    await page.click('#submit-btn, [data-testid="submit-btn"]');
+  } else {
+    await page.click('#choices button:nth-of-type(1)');
+  }
+  await page.click('#next-btn, [data-testid="next-btn"]');
+  await browser.close();
+})();

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1,5 +1,6 @@
 import { normalize as normalizeV2 } from './normalize.mjs';
 import { orderByYearBucket } from './question_pipeline.mjs';
+import { createMediaControl } from './media_player.mjs';
 
 let tracks = [];
 let questions = [];
@@ -724,6 +725,8 @@ function startQuiz() {
 function showQuestion() {
   awaitingNext = false;
   showView('question-view');
+  // media reset
+  try { document.getElementById('media-slot')?.replaceChildren(); } catch (_) {}
   // test=1 時はデバッグ情報を常に同期しておく（冪等）
   try {
     if (getQueryBool('test') && Array.isArray(questions)) {
@@ -745,6 +748,15 @@ function showQuestion() {
   const aliasBtn = document.getElementById('propose-alias-btn');
   const choices = document.getElementById('choices');
   const countdown = document.getElementById('countdown');
+  // --- v: メディア（任意） ---
+  try {
+    const media = q?.media || q?.track?.media;
+    const slot = document.getElementById('media-slot');
+    if (slot && media && media.provider) {
+      const ctrl = createMediaControl(media);
+      slot.replaceChildren(ctrl);
+    }
+  } catch (_) {}
   clearInterval(timerId);
   remaining = 20;
   answer.value = '';

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -62,6 +62,7 @@
   </div>
   <div id="score-bar" aria-label="score bar" aria-live="polite" aria-atomic="true" data-testid="score-bar"></div>
   <div id="countdown" aria-live="polite" aria-atomic="true" style="display:none; margin-top:6px;" data-testid="countdown"></div>
+  <div id="media-slot" aria-label="audio preview area"></div>
   <div id="prompt" role="status" aria-live="polite" aria-atomic="true" data-testid="prompt"></div>
   <div id="choices" style="display:none; margin-top:8px">
     <button class="choice" aria-label="choice 1"></button>

--- a/public/app/media_player.mjs
+++ b/public/app/media_player.mjs
@@ -1,0 +1,88 @@
+// Lightweight media player (YouTube only for now) with test/LHCI stubbing.
+
+function secOf(ms) { return Math.max(0, Math.floor((ms || 0) / 1000)); }
+function isFlagOn(name) {
+  try {
+    const v = new URLSearchParams(location.search).get(name);
+    return v === '1' || v === 'true';
+  } catch { return false; }
+}
+
+export function createMediaControl(media, opts = {}) {
+  // media: { provider, id, start_ms?, duration_ms? }
+  // opts: { testMode, lhciMode }
+  const testMode = opts.testMode ?? isFlagOn('test');
+  const lhciMode = opts.lhciMode ?? isFlagOn('lhci');
+  const noMedia  = isFlagOn('nomedia');
+  const stubOnly = testMode || lhciMode || noMedia;
+
+  const root = document.createElement('div');
+  root.setAttribute('role', 'group');
+  root.setAttribute('aria-label', 'audio preview');
+  root.id = 'media-control';
+
+  if (!media || !media.provider) {
+    root.hidden = true;
+    return root;
+  }
+
+  const btn = document.createElement('button');
+  btn.textContent = '\u25B6\uFE0E \u518D\u751F';
+  btn.setAttribute('data-testid', 'play-clip');
+  btn.setAttribute('aria-label', '\u97F3\u6E90\u30D7\u30EC\u30D3\u30E5\u30FC\u3092\u518D\u751F');
+  root.appendChild(btn);
+
+  const slot = document.createElement('div');
+  slot.id = 'media-embed-slot';
+  slot.style.marginTop = '8px';
+  root.appendChild(slot);
+
+  btn.addEventListener('click', () => {
+    if (stubOnly) {
+      // \u30c6\u30b9\u30c8/\u8a55\u4fa1\u6642\u306f\u5b9fiframe\u3092\u51fa\u3055\u305a\u306b\u30b9\u30bf\u30d6\u8868\u793a
+      const stub = document.createElement('div');
+      stub.id = 'media-stub';
+      stub.textContent = '[media stub]';
+      slot.replaceChildren(stub);
+      window.__mediaPlayed = true;
+      return;
+    }
+    if (media.provider === 'youtube' && media.id) {
+      const start = secOf(media.start_ms);
+      const end   = (media.duration_ms ? start + secOf(media.duration_ms) : undefined);
+      // YouTube embed
+      const iframe = document.createElement('iframe');
+      const base = 'https://www.youtube-nocookie.com/embed/' + encodeURIComponent(media.id);
+      const params = new URLSearchParams({
+        autoplay: '1',
+        controls: '0',
+        modestbranding: '1',
+        rel: '0',
+        disablekb: '1',
+        playsinline: '1',
+        start: String(start || 0)
+      });
+      if (end) params.set('end', String(end));
+      iframe.src = `${base}?${params.toString()}`;
+      iframe.width = '320';
+      iframe.height = '180';
+      iframe.allow = 'autoplay; encrypted-media';
+      iframe.title = 'YouTube audio preview';
+      iframe.setAttribute('frameborder', '0');
+      slot.replaceChildren(iframe);
+      window.__mediaPlayed = true;
+    } else {
+      // \u672a\u5bfe\u5fdc\u30d7\u30ed\u30d0\u30a4\u30c0\u306f\u7121\u8996\uff08\u5c06\u6765\u62e1\u5f35\uff09
+      const stub = document.createElement('div');
+      stub.id = 'media-stub';
+      stub.textContent = '[media unsupported]';
+      slot.replaceChildren(stub);
+      window.__mediaPlayed = true;
+    }
+  }, { passive: true });
+
+  return root;
+}
+
+export default { createMediaControl };
+

--- a/public/app/mock/dataset.json
+++ b/public/app/mock/dataset.json
@@ -6,7 +6,18 @@
     { "title": "時の回廊", "game": "クロノ・トリガー", "composer": "光田康典", "year": 1995 },
     { "title": "MEGALOVANIA", "game": "UNDERTALE", "composer": "Toby Fox", "year": 2015 },
     { "title": "Green Hill Zone", "game": "ソニック・ザ・ヘッジホッグ", "composer": "中村正人", "year": 1991 },
-    { "title": "Stickerbrush Symphony", "game": "スーパードンキーコング2", "composer": "David Wise", "year": 1995 },
+    {
+      "title": "Stickerbrush Symphony",
+      "game": "スーパードンキーコング2",
+      "composer": "David Wise",
+      "year": 1995,
+      "media": {
+        "provider": "youtube",
+        "id": "J66pko0lGzo",
+        "start_ms": 45000,
+        "duration_ms": 12000
+      }
+    },
     { "title": "Gusty Garden Galaxy", "game": "スーパーマリオギャラクシー", "composer": "近藤浩治", "year": 2007 },
     { "title": "Corridors of Time", "game": "クロノ・トリガー", "composer": "光田康典", "year": 1995 },
     { "title": "Main Theme", "game": "ゼルダの伝説: 時のオカリナ", "composer": "近藤浩治", "year": 1998 }


### PR DESCRIPTION
## Summary
- Add lightweight media_player utility for YouTube clips with test/LHCI stubs
- Render optional media slot and control when question contains media
- Extend mock dataset, add media button e2e test, and update workflow to run it

## Testing
- ⚠️ `npm test` *(failed: clojure: not found)*
- ⚠️ `node e2e/test_media_button.mjs` *(failed: Cannot find package 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68b277b8eab08324a12abfe5e7174e4e