### PR TITLE
feat: improve results dialog a11y

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,6 +43,7 @@ jobs:
           node e2e/test_lives_visual.mjs
           node e2e/test_pipeline_flag.mjs
           node e2e/test_media_button.mjs
+          node e2e/test_results_modal_a11y.mjs
           node e2e/test_daily_mode.mjs
           node e2e/test_answer_normalize.mjs
 
@@ -90,6 +91,7 @@ jobs:
           node e2e/test_lives_visual.mjs
           node e2e/test_pipeline_flag.mjs
           node e2e/test_media_button.mjs
+          node e2e/test_results_modal_a11y.mjs
           node e2e/test_daily_mode.mjs
           node e2e/test_answer_normalize.mjs
       - name: Upload e2e artifacts

--- a/e2e/test_results_modal_a11y.mjs
+++ b/e2e/test_results_modal_a11y.mjs
@@ -1,0 +1,71 @@
+import { chromium } from 'playwright';
+
+(async () => {
+  const TIMEOUT = 30000;
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  const base = process.env.E2E_BASE_URL || process.env.APP_URL || 'http://127.0.0.1:8080/app/';
+  const url = (() => {
+    try {
+      const u = new URL(base);
+      const p = u.searchParams;
+      p.set('test', '1');
+      p.set('mock', '1');
+      p.set('daily', '2000-01-01'); // 1問で終了
+      p.set('autostart', '0');
+      return u.toString();
+    } catch {
+      return base + (base.includes('?') ? '&' : '?') + 'test=1&mock=1&daily=2000-01-01&autostart=0';
+    }
+  })();
+
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.click('[data-testid="start-btn"]');
+  await page.waitForSelector('[data-testid="quiz-view"]', { state: 'visible', timeout: TIMEOUT });
+
+  // 1問を適当に回答→Next→結果
+  const hasFree = await page.$('#answer, [data-testid="answer"]');
+  if (hasFree) {
+    await page.fill('#answer, [data-testid="answer"]', 'wrong');
+    await page.click('#submit-btn, [data-testid="submit-btn"]');
+  } else {
+    await page.click('#choices button, .choice, [data-testid="choice"]');
+  }
+  await page.click('#next-btn, [data-testid="next-btn"]');
+  await page.waitForSelector('#result-view[role="dialog"]', { state: 'visible', timeout: TIMEOUT });
+
+  // 初期フォーカスはダイアログ内
+  const inDialog = await page.evaluate(() => {
+    const dlg = document.getElementById('result-view');
+    return dlg && dlg.contains(document.activeElement);
+  });
+  if (!inDialog) throw new Error('initial focus is not inside result dialog');
+
+  // Tabがループするか（先頭→末尾→先頭）
+  await page.keyboard.press('Shift+Tab'); // 末尾へ
+  const afterShiftTab = await page.evaluate(() => {
+    const dlg = document.getElementById('result-view');
+    const focusables = (sel => Array.from(dlg.querySelectorAll(sel)))(
+      'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])'
+    );
+    return dlg && focusables.length && document.activeElement === focusables[focusables.length - 1];
+  });
+  if (!afterShiftTab) throw new Error('Shift+Tab did not wrap to last');
+
+  await page.keyboard.press('Tab'); // 先頭へ
+  const afterTab = await page.evaluate(() => {
+    const dlg = document.getElementById('result-view');
+    const focusables = (sel => Array.from(dlg.querySelectorAll(sel)))(
+      'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])'
+    );
+    return dlg && focusables.length && document.activeElement === focusables[0];
+  });
+  if (!afterTab) throw new Error('Tab did not wrap to first');
+
+  // EscでStartに戻る（Startボタンが再び見える）
+  await page.keyboard.press('Escape');
+  await page.waitForSelector('[data-testid="start-btn"]', { state: 'visible', timeout: TIMEOUT });
+
+  await browser.close();
+})();

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -919,6 +919,8 @@ function showResult() {
 
   // v2: 結果の共有導線（コピー／Share）をセットアップ
   setupResultShare();
+  // v2.1: 終了ダイアログのA11y制御（初期フォーカス / Tabトラップ / Escで閉じる）
+  openResultDialogA11y();
 }
 
 // --- Share helpers (結果画面専用) ---
@@ -952,6 +954,7 @@ function buildResultShareText() {
   ].join('\n');
 }
 
+let _copyToastTimer = null;
 async function copyToClipboard(text) {
   try {
     if (navigator.clipboard?.writeText) {
@@ -965,7 +968,16 @@ async function copyToClipboard(text) {
       document.body.removeChild(ta);
     }
     const toast = document.getElementById('copy-toast');
-    if (toast) toast.textContent = 'コピーしました';
+    if (toast) {
+      toast.textContent = 'コピーしました';
+      toast.setAttribute('aria-live', 'polite');
+      // 数秒で自動クリア（多重クリックにも対応）
+      if (_copyToastTimer) clearTimeout(_copyToastTimer);
+      _copyToastTimer = setTimeout(() => {
+        toast.textContent = '';
+        _copyToastTimer = null;
+      }, 2000);
+    }
   } catch (e) {
     alert('コピーに失敗しました: ' + e.message);
   }
@@ -1001,6 +1013,91 @@ function setupResultShare() {
     shareBtn.style.display = 'none';
   }
 }
+
+// --- Result dialog A11y: focus trap / initial focus / ESC close ---
+let _resultDialogPrevFocus = null;
+let _resultDialogKeydown = null;
+function focusablesIn(node) {
+  const sel = [
+    'a[href]', 'button:not([disabled])', 'input:not([disabled])',
+    'select:not([disabled])', 'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])'
+  ].join(',');
+  return Array.from(node.querySelectorAll(sel)).filter(el => {
+    const s = getComputedStyle(el);
+    return s.visibility !== 'hidden' && s.display !== 'none';
+  });
+}
+function openResultDialogA11y() {
+  const dlg = document.getElementById('result-view');
+  if (!dlg) return;
+  // 保存：開く前のフォーカス
+  _resultDialogPrevFocus = document.activeElement;
+  // 初期フォーカス（コピー > 共有 > リスタート の優先）
+  const first =
+    document.getElementById('copy-result-btn') ||
+    document.getElementById('share-result-btn') ||
+    document.getElementById('restart-btn') ||
+    dlg;
+  first.focus();
+  // Tabトラップ
+  _resultDialogKeydown = (ev) => {
+    if (ev.key === 'Tab') {
+      const list = focusablesIn(dlg);
+      if (!list.length) return;
+      const first = list[0], last = list[list.length - 1];
+      if (ev.shiftKey && document.activeElement === first) {
+        last.focus(); ev.preventDefault();
+      } else if (!ev.shiftKey && document.activeElement === last) {
+        first.focus(); ev.preventDefault();
+      }
+    } else if (ev.key === 'Escape' || ev.key === 'Esc') {
+      // Escで結果を閉じて Start に戻す（安全に戻れない場合はフォーカスだけ返す）
+      closeResultDialogA11y(true);
+    }
+  };
+  dlg.addEventListener('keydown', _resultDialogKeydown);
+  // 念のため属性を強化
+  dlg.setAttribute('aria-modal', 'true');
+  dlg.setAttribute('role', 'dialog');
+  dlg.setAttribute('tabindex', '-1');
+}
+function closeResultDialogA11y(goStart = false) {
+  const dlg = document.getElementById('result-view');
+  if (dlg && _resultDialogKeydown) {
+    dlg.removeEventListener('keydown', _resultDialogKeydown);
+  }
+  _resultDialogKeydown = null;
+  // 戻り先：Startビュー or 直前フォーカス
+  if (goStart) {
+    try {
+      showView('start-view');
+      const sb = document.getElementById('start-btn') || document.querySelector('[data-testid="start-btn"]');
+      sb?.focus();
+      return;
+    } catch (_) {}
+  }
+  if (_resultDialogPrevFocus && _resultDialogPrevFocus.focus) {
+    _resultDialogPrevFocus.focus();
+  }
+  _resultDialogPrevFocus = null;
+}
+
+// Restartボタンで閉じるときもフォーカスを安全に処理
+(() => {
+  const bind = () => {
+    const r = document.getElementById('restart-btn');
+    if (r && !r.dataset._a11yBound) {
+      r.addEventListener('click', () => closeResultDialogA11y(false), { passive: true });
+      r.dataset._a11yBound = '1';
+    }
+  };
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bind, { once: true });
+  } else {
+    bind();
+  }
+})();
 
 function restart() {
   showView('start-view');

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -78,7 +78,10 @@
   <button id="propose-alias-btn" style="display:none">別名として提案</button>
 </div>
 
-<div id="result-view" style="display:none">
+<div
+  id="result-view"
+  role="dialog" aria-modal="true" aria-labelledby="final-score" tabindex="-1"
+  style="display:none" data-testid="result-dialog">
   <div id="final-score"></div>
   <div id="summary">
     <h2>Summary</h2>


### PR DESCRIPTION
## Summary
- treat result view as modal dialog with proper ARIA attributes
- trap focus and restore on close; auto-clear copy toast
- add E2E for result dialog accessibility and wire into workflow

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.1.67 8080])* 
- `npm install --no-save playwright` *(fails: 403 Forbidden)*
- `node e2e/test_results_modal_a11y.mjs` *(fails: Cannot find package 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68b28359577483248b43600a8adb2993