### PR TITLE
feat: sync service worker version URL

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1365,3 +1365,22 @@ window.addEventListener('DOMContentLoaded', () => {
 
 // デバッグ/検証用（TTL/in-flight挙動の確認に使用）
 window.loadVersionPublic = async () => { await readVersionNoStore(false); await loadVersion(); };
+
+function swSetVersionUrl() {
+  try {
+    // app側が実際に参照しているVERSION_URLを組み立て（既存の定義があればそれを優先）
+    const url = (typeof VERSION_URL === 'string' && VERSION_URL) ||
+                new URL('../build/version.json', document.baseURI).toString();
+    if (navigator.serviceWorker && navigator.serviceWorker.controller) {
+      navigator.serviceWorker.controller.postMessage({ type: 'version_url', url });
+      console.log('[app→sw] version_url:', url);
+    }
+  } catch (e) {
+    console.warn('[app→sw] version_url post failed:', e);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  // test=1 でも SW が既に稼働中のことはあるので、常に通知だけは試みる
+  swSetVersionUrl();
+}, { once: true });

--- a/public/app/sw.js
+++ b/public/app/sw.js
@@ -3,12 +3,29 @@
 self.__APP_VERSION__ = new URL(self.location).searchParams.get('v');
 const CACHE_NAME = 'vgm-quiz-' + (self.__APP_VERSION__ || 'dev');
 
-// --- バージョン監視の安定化設定 ----------------------------------------
-// /app/ 配下に SW がいても /build/version.json を確実に指す
-const VERSION_URL = (() => {
-  if (self.VERMETA_URL) return self.VERMETA_URL;
+let VERMETA_URL = undefined; // app側から受け取る最優先URL
+
+// app から version.json の絶対URLを受け取る
+self.addEventListener('message', (event) => {
   try {
-    return new URL('../build/version.json', self.registration.scope).toString();
+    const data = event?.data || {};
+    if (data.type === 'version_url' && typeof data.url === 'string' && data.url) {
+      VERMETA_URL = data.url;
+      // デバッグに活用したい場合は次行を有効化
+      // console.log('[sw] set version_url:', VERMETA_URL);
+    }
+  } catch (e) {}
+});
+
+function computeVersionUrl() {
+  // 1) app から受け取った絶対URLがあればそれを使う
+  if (VERMETA_URL) return VERMETA_URL;
+  // 2) 既存ロジック（スコープ依存の相対→絶対解決）
+  try {
+    const u = new URL('../build/version.json', self.registration.scope);
+    // /app/build/ に解決されてしまう環境では /build/ に補正
+    const s = u.toString().replace(/\/app\/build\//, '/build/');
+    return s;
   } catch (_) {
     try {
       return new URL('../build/version.json', self.location).toString();
@@ -16,7 +33,7 @@ const VERSION_URL = (() => {
       return './build/version.json';
     }
   }
-})();
+}
 const MIN_CHECK_INTERVAL_MS = 60 * 1000; // 最短60秒
 const CLIENT_POST_DEBOUNCE_MS = 60 * 1000; // 通知も最短60秒にデボンス
 let __versionWatchStarted = false;
@@ -111,7 +128,7 @@ async function safeFetchVersion() {
   try {
     const init = { cache: 'no-store', headers: {} };
     if (__lastETag) init.headers['If-None-Match'] = __lastETag;
-    const res = await fetch(VERSION_URL, init);
+    const res = await fetch(computeVersionUrl(), init);
     if (res.status === 304) return { notModified: true };
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     __lastETag = res.headers.get('ETag');


### PR DESCRIPTION
## Summary
- send version.json URL from app to active service worker
- resolve version.json consistently via `computeVersionUrl`

## Testing
- `npm test` *(fails: clojure not found)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b29818dc0c8324a2b5da0ea3a277e7