### PR TITLE
feat: add lives rule endgame and test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,6 +44,7 @@ jobs:
           node e2e/test_pipeline_flag.mjs
           node e2e/test_media_button.mjs
           node e2e/test_results_modal_a11y.mjs
+          node e2e/test_lives_rule_end.mjs
           node e2e/test_daily_mode.mjs
           node e2e/test_answer_normalize.mjs
 
@@ -92,6 +93,7 @@ jobs:
           node e2e/test_pipeline_flag.mjs
           node e2e/test_media_button.mjs
           node e2e/test_results_modal_a11y.mjs
+          node e2e/test_lives_rule_end.mjs
           node e2e/test_daily_mode.mjs
           node e2e/test_answer_normalize.mjs
       - name: Upload e2e artifacts

--- a/e2e/test_lives_rule_end.mjs
+++ b/e2e/test_lives_rule_end.mjs
@@ -1,0 +1,63 @@
+// e2e/test_lives_rule_end.mjs
+import { chromium } from 'playwright';
+
+(async () => {
+  const TIMEOUT = 30000;
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const base = process.env.E2E_BASE_URL || process.env.APP_URL || 'http://127.0.0.1:8080/app/';
+  const url = (() => {
+    try {
+      const u = new URL(base);
+      const p = u.searchParams;
+      if (!p.has('test')) p.set('test', '1');
+      if (!p.has('mock')) p.set('mock', '1');
+      p.set('lives', 'on');          // ← 3ミスで終了
+      p.set('autostart', '0');
+      return u.toString();
+    } catch {
+      return base + (base.includes('?')?'&':'?') + 'test=1&mock=1&lives=on&autostart=0';
+    }
+  })();
+
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.click('[data-testid="start-btn"]');
+  await page.waitForSelector('[data-testid="quiz-view"]', { state: 'visible', timeout: TIMEOUT });
+
+  const answerWrongOnce = async () => {
+    // Free/MC 両対応の不正解送出
+    const isMC = await page.evaluate(() => {
+      const el = document.querySelector('#choices');
+      return !!el && getComputedStyle(el).display !== 'none';
+    });
+    if (isMC) {
+      await page.waitForSelector('#choices button, .choice, [data-testid="choice"]', { timeout: TIMEOUT });
+      // 正解インデックスを避けて1番目を押す（best-effort）
+      await page.click('#choices button, .choice, [data-testid="choice"]');
+    } else {
+      await page.fill('#answer, [data-testid="answer"]', 'totally wrong');
+      await page.click('#submit-btn, [data-testid="submit-btn"]');
+    }
+    await page.waitForSelector('#next-btn, [data-testid="next-btn"]', { state: 'visible', timeout: TIMEOUT });
+    await page.click('#next-btn, [data-testid="next-btn"]');
+  };
+
+  // 3回わざと誤答 → ここで早期終了し、結果ビューが出る
+  for (let i = 0; i < 3; i++) {
+    await answerWrongOnce();
+    const resultVisible = await page.$('#result-view[role="dialog"]');
+    if (resultVisible) break;
+  }
+
+  await page.waitForSelector('#result-view[role="dialog"]', { state: 'visible', timeout: TIMEOUT });
+  // lives 表示が 3/3 を含む（Misses: 3/3）
+  const livesText = await page.evaluate(() => {
+    const el = document.getElementById('lives') || document.querySelector('[data-testid="lives"]');
+    return (el && el.textContent) || '';
+  });
+  if (!/3\s*\/\s*3/.test(livesText)) throw new Error('lives not reached 3/3');
+
+  await browser.close();
+})();

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -11,9 +11,10 @@ if (typeof window.__rng !== 'function') {
   window.__rng = Math.random.bind(Math);
 }
 let rngForPipeline = window.__rng;
-const MAX_LIVES = 3;
+let MAX_LIVES = 3; // 既定値（?lives=on などで上書き可）
 let mistakes = 0;
 let __livesInterval = null;
+const LIVES = { enabled: false, limit: 3, triggered: false };
 let current = 0;
 let score = 0;
 let awaitingNext = false;
@@ -437,7 +438,8 @@ function updateLivesDisplay() {
   el.setAttribute('role', 'status');
   el.setAttribute('aria-live', 'polite');
   el.setAttribute('aria-atomic', 'true');
-  el.textContent = `Misses: ${mistakes}/${MAX_LIVES}`;
+  const lim = LIVES.enabled ? LIVES.limit : MAX_LIVES;
+  el.textContent = `Misses: ${mistakes}/${lim}`;
 }
 
 function recomputeMistakes() {
@@ -449,6 +451,7 @@ function recomputeMistakes() {
     // フォールバック（何もしない）
   }
   updateLivesDisplay();
+  maybeEndGameByLives();
 }
 
 function startLivesTicker() {
@@ -945,6 +948,7 @@ function showResult() {
 
   // v2: 結果の共有導線（コピー／Share）をセットアップ
   setupResultShare();
+  // （必要ならここで LIVES.triggered は true のままでOK）
   // v2.1: 終了ダイアログのA11y制御（初期フォーカス / Tabトラップ / Escで閉じる）
   openResultDialogA11y();
 }
@@ -1222,6 +1226,8 @@ navigator.serviceWorker?.addEventListener('message', async (e)=>{
 // ---------------------
 window.addEventListener('DOMContentLoaded', () => {
   try {
+    // Lives ルールを起動時に解釈
+    initLivesRule();
     // Daily 検出＆先読み開始
     initDaily();
     if (DAILY.active) { preloadDailyMap(); }
@@ -1230,6 +1236,7 @@ window.addEventListener('DOMContentLoaded', () => {
     if (startBtn && !startBtn.dataset._livesbound) {
       startBtn.addEventListener('click', () => {
         mistakes = 0;
+        LIVES.triggered = false;
         startLivesTicker();
       }, { passive: true });
       startBtn.dataset._livesbound = '1';
@@ -1248,6 +1255,35 @@ window.addEventListener('DOMContentLoaded', () => {
     // 他の初期化があれば既存処理…
   } catch (_) {}
 });
+
+// --- Lives ルール: 3ミスで即終了（?lives=on または ?lives=3 等数値指定） ---
+function initLivesRule() {
+  const v = getQueryParam('lives');
+  if (!v) { LIVES.enabled = false; LIVES.limit = MAX_LIVES; return; }
+  if (v === 'on' || v === 'true') { LIVES.enabled = true; LIVES.limit = 3; MAX_LIVES = 3; return; }
+  const n = parseInt(v, 10);
+  if (Number.isFinite(n) && n > 0 && n <= 9) {
+    LIVES.enabled = true;
+    LIVES.limit = n;
+    MAX_LIVES = n;
+    return;
+  }
+  // デフォルト
+  LIVES.enabled = true; LIVES.limit = 3; MAX_LIVES = 3;
+}
+function maybeEndGameByLives() {
+  if (!LIVES.enabled || LIVES.triggered) return;
+  if (mistakes >= LIVES.limit) {
+    LIVES.triggered = true;
+    try { stopLivesTicker(); } catch (_) {}
+    // 可能なUI操作を止めて安全に結果へ
+    try {
+      document.querySelectorAll('#choices button,[data-testid="choice"],#submit-btn')
+        .forEach(el => el.setAttribute('disabled', 'true'));
+    } catch (_) {}
+    showResult();
+  }
+}
 // 初期化時に1回だけ実行（以降の呼び出しはガードで即return）
 window.addEventListener('DOMContentLoaded', () => {
   if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- end game after configurable number of mistakes using ?lives query
- cover early termination via new e2e test
- run lives-rule test in e2e workflow

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden)*
- `npm test` *(fails: clojure: not found)*
- `node e2e/test_lives_rule_end.mjs` *(fails: Cannot find package 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68b29ad90c408324aad9c169203e7f12