### PR TITLE
Add operations documentation and cross-reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # VGM Quiz
 
+[![Lighthouse nightly](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml/badge.svg?branch=main)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml)
+
 A small quiz app for video game music. Runs on GitHub Pages.
 
 - **Live:** https://nantes-rfli.github.io/vgm-quiz/app/
@@ -106,4 +108,11 @@ node e2e/test_normalize_cases.mjs   # Node-only assertions for normalize v1.2
 ## License
 
 MIT
+
+## Documentation
+
+- [Ops Runbook](./docs/ops-runbook.md)
+- [Query Flags](./docs/flags.md)
+- [CI & E2E](./docs/ci.md)
+- [Troubleshooting](./docs/troubleshooting.md)
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,24 @@
+# CI & E2E Overview
+
+## Workflows
+
+- `ci.yml` / `ci-fast.yml` – Clojure + JS basics
+- `e2e.yml` – Playwright E2E suite
+- `pages.yml` – Deploy to GitHub Pages on `main`
+- `release.yml` – Release flow
+- `lighthouse.yml` – Nightly Lighthouse CI against production (`?test=1&lhci=1`)
+
+## E2E Suite
+
+```
+node e2e/test.js
+node e2e/test_free_aria.js
+node e2e/test_footer_version.js
+node e2e/test_results_share.mjs
+node e2e/test_lives_visual.mjs
+node e2e/test_pipeline_flag.mjs
+node e2e/test_media_button.mjs
+node e2e/test_results_modal_a11y.mjs
+node e2e/test_lives_rule_end.mjs
+node e2e/test_normalize_cases.mjs
+```

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -1,0 +1,15 @@
+# Query Flags
+
+Common flags you can combine in the URL.
+
+| Flag | Example | Purpose |
+|---|---|---|
+| `test` | `?test=1` | Disable SW registration; expose debug vars; stub media |
+| `mock` | `?mock=1` | Force mock dataset |
+| `seed` | `?seed=alpha` | Deterministic RNG |
+| `qp` | `?qp=1` | Year-bucket order pipeline |
+| `daily` | `?daily=1` / `?daily=2000-01-01` | 1-question mode (JST or fixed date) |
+| `autostart` | `?autostart=0` | Require manual Start |
+| `lhci` | `?lhci=1` | Stub media for Lighthouse |
+| `nomedia` | `?nomedia=1` | Manually stub media |
+| `lives` | `?lives=on` / `?lives=5` | End immediately when misses reach limit |

--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -1,0 +1,47 @@
+# Ops Runbook
+
+This document captures day‑to‑day operations for **vgm-quiz**.
+
+## Canonical URLs
+
+- Normal: `/app/`
+- Test (no SW registration): `/app/?test=1`
+- Mock dataset: `/app/?test=1&mock=1`
+- Deterministic: add `&seed=alpha`
+- Year-bucket pipeline: add `&qp=1`
+- Daily: `&daily=1` (today JST) or `&daily=YYYY-MM-DD`
+- Disable media: `&nomedia=1`
+- Lighthouse: `/app/?test=1&lhci=1`
+
+## Footer / Version fetch
+
+- Footer: `Dataset: vN • commit: abcdefg • updated: YYYY-MM-DD HH:mm` (local time).
+- Fetch policy: **8s timeout**, **in-flight sharing**, **60s TTL**.
+- Helpers: `window.loadVersionPublic()` (TTL/in-flight適用), `window.loadVersionForce()` (強制).
+
+## Service Worker handshake
+
+- App posts the absolute `version.json` URL to SW on startup.
+- SW polls ~60s using that URL (prevents 404 under `/app/` scope).
+- Stop SW (for testing): run in console `navigator.serviceWorker.getRegistrations().then(rs => rs.forEach(r => r.unregister()))` then reload.
+
+## Media preview
+
+- YouTube: prefer `youtube-nocookie.com`, fallback to `youtube.com`, plus "Open in YouTube" link.
+- Tests and Lighthouse automatically **stub** the player (`?test=1`/`?lhci=1`/`?nomedia=1`).
+
+## Lives rule
+
+- Default: display-only HUD `Misses: x/y`.
+- Opt-in: `?lives=on` (or `?lives=5`) → **finish immediately** when misses reach the limit.
+
+## Daily 1 question
+
+- `?daily=1` uses *today (JST)*. `?daily=YYYY-MM-DD` for fixed day.
+- Mapping is in `public/app/daily.json`.
+
+## Debugging
+
+- `window.__rng`/`__SEED__` – seeded RNG function & seed.
+- `window.__questionIds` / `__questionDebug` – available under `?test=1`.
+- `window.versionDebug.stats()/clear()` – inspect/clear version TTL cache.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,20 @@
+# Troubleshooting
+
+## version.json shows 404 in Network
+
+Cause: SW polling the wrong path under `/app` scope.  
+Fix: The app→SW handshake sets the absolute URL; ensure you’re on the latest `sw.js` and reload/Update SW.
+
+## `window.loadVersionPublic` is undefined
+
+Cause: older `app.js`.  
+Fix: hard-reload; verify in console `typeof window.loadVersionPublic === "function"`.
+
+## YouTube embed says “動画を再生できません”
+
+Cause: the video ID disallows embeds or has region restrictions.  
+Fix: use an alternative ID; use the fallback “別ドメイン” button or “Open in YouTube” link.
+
+## Same-seed but different order?
+
+Verify you are checking after Start, and that `window.__rng` is `"function"`; use `?qp=1` and compare `window.__questionIds`.


### PR DESCRIPTION
## Summary
- add Lighthouse nightly badge and documentation links to README
- document ops runbook, query flags, CI & E2E, and troubleshooting guides

## Testing
- `npm test` *(fails: clojure not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a9e78d588324a5d5332f1388720f