### PR TITLE
docs: add pipeline and release guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VGM Quiz
 
-[![Lighthouse nightly](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml/badge.svg?branch=main)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml)
+[![Lighthouse nightly](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml/badge.svg?branch=main)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml) [![E2E](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e.yml) [![Pages](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/pages.yml/badge.svg?branch=main)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/pages.yml)
 
 A small quiz app for video game music. Runs on GitHub Pages.
 
@@ -114,5 +114,7 @@ MIT
 - [Ops Runbook](./docs/ops-runbook.md)
 - [Query Flags](./docs/flags.md)
 - [CI & E2E](./docs/ci.md)
+- [Data Pipeline](./docs/pipeline.md)
+- [Release & Deployment](./docs/release.md)
 - [Troubleshooting](./docs/troubleshooting.md)
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,0 +1,48 @@
+# Data Pipeline Overview
+
+This document describes the **data contracts** and artifacts produced for the app.
+It focuses on *what the app expects* rather than the internal implementation details.
+
+## Build artifacts (consumed by the app)
+
+- `public/build/dataset.json` — quiz tracks and metadata
+- `public/build/aliases.json` — normalization aliases (merged with `public/app/aliases_local.json` if present)
+- `public/build/version.json` — deployment metadata used by the footer & SW
+
+### `version.json` (contract)
+
+```json
+{
+  "dataset": "v1",
+  "commit": "abcdef1",
+  "content_hash": "sha256:...",
+  "generated_at": "2025-08-30T06:39:00Z"
+}
+```
+
+**App behavior**
+
+- Footer shows `Dataset: v1 • commit: abcdef1 • updated: YYYY-MM-DD HH:mm` (local time)
+- The app uses 8s timeout, in-flight sharing, and 60s TTL when fetching `version.json`
+- The app exposes `window.loadVersionPublic()` (TTL/in-flight適用) and `window.loadVersionForce()` (強制)
+
+### Aliases
+
+- App loads `../build/aliases.json`
+- If present, `./aliases_local.json` is merged **on top** (local overrides → easy small PRs)
+
+### Mock dataset
+
+- For development and CI, `?mock=1` routes the app to `public/app/mock/dataset.json`
+- Media previews are stubbed under `?test=1` / `?lhci=1` / `?nomedia=1`
+
+## Deterministic ordering (RNG & pipeline)
+
+- `?seed=...` → deterministic RNG (`window.__rng` is exposed under `?test=1`)
+- `?qp=1` → year-bucket pipeline for better spread
+
+## Daily mapping
+
+- `public/app/daily.json` maps dates to a single track (by `id` or `title`)
+- `?daily=1` uses **today (JST)**; `?daily=YYYY-MM-DD` uses a fixed date
+

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,39 @@
+# Release & Deployment
+
+This project is deployed via **GitHub Pages**. `main` → Pages auto-deploy.
+
+## Fast path (no tag)
+
+1. Open a PR → Merge to `main`
+2. **Pages** workflow publishes `/app/`
+3. Verify on production:
+   - Footer shows `Dataset: vN • commit: abcdefg • updated: YYYY-MM-DD HH:mm`
+   - E2E in CI: green
+   - (Optional) Lighthouse nightly will re-check
+
+## Formal release (tagged)
+
+> The repository includes `release.yml` for releases. Triggers may be **tag push** and/or **workflow_dispatch**.
+> Check the workflow file if unsure. Typical options:
+
+**A. Tag push**
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+**B. Manual dispatch**
+
+- Actions → `release.yml` → **Run workflow**
+
+## Pre- and post-release checklist
+
+- [ ] Merge `main` green (CI/E2E passed)
+- [ ] If dataset changed, confirm `public/build/version.json` has updated `generated_at`/`commit`
+- [ ] Production sanity checks:
+  - [ ] `/app/?test=1&autostart=0` loads
+  - [ ] Media stubbed under `?test=1` / `?lhci=1`
+  - [ ] `window.__rng` is `"function"` and `console.table(window.__questionDebug)` works
+- [ ] Create release notes (link to CHANGELOG)
+


### PR DESCRIPTION
## Summary
- document app data pipeline and build artifacts
- add release checklist and deployment instructions
- surface e2e/pages workflow badges and link to new docs in README

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ac8c96048324adab3e74a95ed2e6