### PR TITLE
Add SVG app icon and clarify dataset metadata checks

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -22,10 +22,13 @@
 
 ## Pages deploy verification
 1. Confirm **Pages** workflow ran automatically on push to `main` (or via `workflow_run` from **CI Fast**).  
-2. Check `build.json` responses (should show latest `short_sha`):  
+2. Check `build.json` responses (CI metadata: should show latest `short_sha`):
+   - Note: dataset/version metadata is served from `public/build/version.json`. For sanity check, open:
+   - `/build/version.json` (dataset_version, commit, generated_at)
+   - `/app/../build/version.json` (same; SW handshake ensures correct path)  
    - `/build.json?ts=NOW`  
    - `/app/build.json?ts=NOW`  
-3. Footer should show: `Dataset vX • <content_hash> • <generated_at> • commit: <short_sha>`
+3. Footer should show: `Dataset: vN • commit: abcdefg • updated: YYYY-MM-DD HH:mm`
 
 ## E2E artifacts (for failures)
 - Artifacts directory: `artifacts/`

--- a/public/app/icons/app-icon.svg
+++ b/public/app/icons/app-icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" ry="64" fill="#111"/>
+  <g fill="#fff">
+    <circle cx="128" cy="192" r="32"/>
+    <circle cx="384" cy="192" r="32"/>
+    <rect x="160" y="288" width="192" height="32" rx="16"/>
+  </g>
+  <text x="256" y="112" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="64" fill="#fff">VGM</text>
+</svg>
+

--- a/public/app/manifest.webmanifest
+++ b/public/app/manifest.webmanifest
@@ -7,8 +7,7 @@
   "theme_color": "#111",
   "background_color": "#111",
   "icons": [
-    { "src": "icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "icons/app-icon.svg", "sizes": "any", "type": "image/svg+xml" }
   ]
 }
 


### PR DESCRIPTION
## Summary
- replace raster icons with a single scalable SVG app icon
- document where Pages build metadata is served and adjust footer format

## Testing
- `npm test` *(fails: clojure: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b2b53e40c08324948506ce0834f57b