### PR TITLE
ci: create PR for daily.json updates

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,14 +29,20 @@ jobs:
         run: |
           node scripts/generate_daily.js
 
-      - name: Commit & Push if changed
-        run: |
-          if [[ -n "$(git status --porcelain)" ]]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add public/app/daily.json
-            git commit -m "chore(daily): update daily.json [skip e2e]"
-            git push
-          else
-            echo "No changes in daily.json"
-          fi
+      # Create a PR instead of pushing to main (branch protection requires checks)
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: chore(daily): update daily.json
+          title: "chore(daily): update daily.json"
+          body: |
+            Automated update of `public/app/daily.json` (JST).
+            This PR is created by the scheduled workflow to comply with branch protection rules.
+          branch: bot/daily
+          delete-branch: true
+          add-paths: |
+            public/app/daily.json
+          labels: |
+            automation
+            daily
+          signoff: true


### PR DESCRIPTION
## Summary
- ensure daily workflow opens a PR instead of directly pushing

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2eb3854b48324ae278f0832811f72