### PR TITLE
fix: quote daily workflow labels and commit message

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: chore(daily): update daily.json
+          commit-message: "chore(daily): update daily.json"
           title: "chore(daily): update daily.json"
           body: |
             Automated update of `public/app/daily.json` (JST).
@@ -42,7 +42,5 @@ jobs:
           delete-branch: true
           add-paths: |
             public/app/daily.json
-          labels: |
-            automation
-            daily
+          labels: "automation,daily"
           signoff: true


### PR DESCRIPTION
## Summary
- quote commit message and label list in daily workflow

## Testing
- `npm test` *(fails: clojure: not found)*
- `npm run smoke` *(fails: Cannot find module 'cheerio')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cheerio)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ee19a0848324bc59d85976ecd359