### PR TITLE
ci: enable pages build for pull requests

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,9 @@ on:
   # 通常ルート: main に入れば必ず実行
   push:
     branches: [ main ]
+  # PR でも build チェックを出す（ブランチ保護の "build" 対応用）
+  pull_request:
+    branches: [ "**" ]
   # 保険ルート: CI Fast が成功で完了したら実行（重複は concurrency で抑止）
   workflow_run:
     workflows: [ "CI Fast" ]
@@ -94,6 +97,8 @@ jobs:
           path: public
 
   deploy:
+    # PR ではデプロイしない（build チェックだけにする）
+    if: ${{ github.event_name != 'pull_request' }}
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary
- run Pages workflow for pull requests to surface build checks
- skip GitHub Pages deployment during PR builds

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: repository 403 errors while attempting to install clojure)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f17ac97c832491ba3d6f6061c680