### PR TITLE
ci: specify PAT for daily workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.DAILY_PR_PAT }}
           commit-message: "chore(daily): update daily.json"
           title: "chore(daily): update daily.json"
           body: |


### PR DESCRIPTION
## Summary
- add fine-grained PAT secret to the daily workflow for PR creation

## Testing
- `npm test` *(fails: clojure not found)*
- `apt-get update` *(403: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3219cf71c832485635aa71b9a113a