### PR TITLE
ci: name PR workflows

### DIFF
--- a/.github/workflows/ci-fast-pr.yml
+++ b/.github/workflows/ci-fast-pr.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   build:  # ← ラベルが「CI Fast / build (pull_request)」になる
+    name: ci-fast-pr-build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pages-pr-build.yml
+++ b/.github/workflows/pages-pr-build.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   build:
+    name: pages-pr-build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- give ci-fast PR workflow an explicit job name
- give pages PR workflow an explicit job name

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b32a1190e88324ab30795b4257fa30