### PR TITLE
docs: clarify PR checks and CI workflow

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -22,3 +22,49 @@ node e2e/test_results_modal_a11y.mjs
 node e2e/test_lives_rule_end.mjs
 node e2e/test_normalize_cases.mjs
 ```
+
+---
+
+## Current workflow set (clean baseline)
+
+- **CI Fast (PR)** — `.github/workflows/ci-fast-pr.yml`  
+  Event: `pull_request` (with `paths: ['**']`)  
+  Job name: **`ci-fast-pr-build`** (Required)
+- **Pages (PR shim)** — `.github/workflows/pages-pr-build.yml`  
+  Event: `pull_request`  
+  Job name: **`pages-pr-build`** (Required)
+- **CI Fast (main)** — `.github/workflows/ci-fast.yml`  
+  Event: `push: main`  
+  Job name: `ci-fast-main-build`  
+  **Runs `clojure -T:build publish` before tests** to render `public/build/dataset.json`.
+- **Pages (deploy)** — `.github/workflows/pages.yml`  
+  Event: `push: main` (never on PR)
+- **daily.json generator (JST)** — `.github/workflows/daily.yml`  
+  Creates PR with **PAT** (`DAILY_PR_PAT`) at 00:00 JST.
+- **E2E (nightly)** — `.github/workflows/e2e-nightly.yml` (optional)  
+  Heavy Playwright suites on a schedule or manual.
+- **Lighthouse (nightly)** — `.github/workflows/lighthouse.yml`
+
+### Required status checks
+
+Register **job names** in Rulesets (not display strings):
+
+- `pages-pr-build`
+- `ci-fast-pr-build`
+
+### Clojure tests need the dataset
+
+Tests read `public/build/dataset.json`.  
+On `main` CI, run before tests:
+
+```bash
+clojure -T:build publish
+clojure -M:test
+```
+
+### Guidelines
+
+- Prefer `pull_request` over `pull_request_target` unless absolutely necessary.
+- Give jobs stable, unique `name:` values; if you rename jobs, update Rulesets together.
+- Keep PR checks light; shift heavy suites to nightly or `workflow_dispatch`.
+

--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -61,3 +61,40 @@ This document captures day‑to‑day operations for **vgm-quiz**.
 - `window.__rng`/`__SEED__` – seeded RNG function & seed.
 - `window.__questionIds` / `__questionDebug` – available under `?test=1`.
 - `window.versionDebug.stats()/clear()` – inspect/clear version TTL cache.
+
+---
+
+## PR checks & branch protection (definitive rules)
+
+- **Required status checks are evaluated against *job names***, not the UI display string.
+  - Register these two **job names** in Rulesets → *Status checks that are required*:
+    - `pages-pr-build`
+    - `ci-fast-pr-build`
+- `pages.yml` (deploy) **must not** run on PRs. Keep it scoped to `push: main` only.
+- `ci-fast.yml` runs on `push: main`; `ci-fast-pr.yml` runs on `pull_request`.
+
+### 5‑minute verification (after any CI change or PAT rotation)
+
+**GUI**
+1. Actions → **daily.json generator (JST)** → *Run workflow* (branch: `main`).
+2. A PR from `bot/daily` opens. Confirm **Author = your account** (PAT owner), not `github-actions[bot]`.
+3. In **Checks**, ensure only:
+   - **Pages / pages-pr-build**
+   - **CI Fast / ci-fast-pr-build**
+   appear and are green → PR auto‑merges → Pages deploy runs.
+
+**CLI**
+```bash
+gh pr list -R nantes-rfli/vgm-quiz --search "head:bot/daily" -L 1 --json number,author,url
+gh pr checks <PR#> -R nantes-rfli/vgm-quiz
+```
+
+### Daily PR author (PAT)
+
+- `daily.yml` must create PRs with: `token: ${{ secrets.DAILY_PR_PAT }}` (Fine‑grained; repo‑scoped; **Contents: RW**, **Pull requests: RW**).
+- Verify author:
+```bash
+gh pr view <PR#> -R nantes-rfli/vgm-quiz --json author | jq -r '.author.login'
+# => should be your username (not github-actions[bot])
+```
+

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,3 +18,33 @@ Fix: use an alternative ID; use the fallback “別ドメイン” button or “
 ## Same-seed but different order?
 
 Verify you are checking after Start, and that `window.__rng` is `"function"`; use `?qp=1` and compare `window.__questionIds`.
+
+---
+
+## PR stuck at “Expected — waiting for status to be reported”
+
+**Likely causes & fixes**
+
+- **PR created with `GITHUB_TOKEN`** (author shows `github-actions[bot]`)  
+  → Use a Fine‑grained PAT and set `token: ${{ secrets.DAILY_PR_PAT }}` in `daily.yml`.  
+  Verify:
+  ```bash
+  gh pr view <PR#> -R nantes-rfli/vgm-quiz --json author | jq -r '.author.login'
+  ```
+
+- **Required checks mismatch** (registered the UI string like “CI Fast / build (pull_request)” instead of the **job name**)  
+  → In Rulesets, require **`pages-pr-build`** and **`ci-fast-pr-build`** (job names).
+
+- **Workflows missing on the PR branch**  
+  → Click **Update branch** or push an empty commit to refresh checks:
+  ```bash
+  git commit --allow-empty -m "chore: refresh checks"
+  git push
+  ```
+
+- **Two “Pages / build” entries** on PRs  
+  → Ensure `pages.yml` does **not** have `pull_request:` (deploy runs only on `push: main`). PR uses the shim `pages-pr-build.yml`.
+
+- **PR CI skipped by path filters**  
+  → Ensure `ci-fast-pr.yml` has `paths: ['**']`.
+


### PR DESCRIPTION
## Summary
- document required job names for PR status checks and daily PR verification
- outline current GitHub Actions workflows and dataset pretest step
- add troubleshooting guide for missing status checks or misconfigured PATs

## Testing
- `clojure -T:build publish` *(fails: command not found)*
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b2e5dff883249fd03df8e5af22f0