### PR TITLE
feat: enable progressbar aria in production

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1318,13 +1318,8 @@ window.addEventListener('DOMContentLoaded', () => {
     }
   }
 });
-// --- A11y shim: focus/roles/progressbar ARIA without changing visuals ---
+// --- A11y: focus/roles/progressbar（視覚は不変）を常時有効化 ---
 (() => {
-  // 本番では実行しない。E2E/LHCI等、?test=1 の時だけ有効化
-  try {
-    const params = new URLSearchParams(location.search);
-    if (params.get('test') !== '1') return;
-  } catch (_) { /* noop */ }
   const once = (fn) => {
     let done = false;
     return (...args) => { if (!done) { done = true; fn(...args); } };
@@ -1403,9 +1398,13 @@ window.addEventListener('DOMContentLoaded', () => {
     const startBtn = document.querySelector('[data-testid="start-btn"], #start-btn');
     if (startBtn) startBtn.addEventListener('click', () => setTimeout(() => focusFirstControl(), 0), { once: true });
     observeQuiz();
-  });
+    // 初期描画時にも最低限のA11yを適用
+    ensureTimerAria();
+    ensureProgressbarAria();
+    focusFirstControl();
+  }, { once: true });
 })();
-// --- /A11y shim ---
+// --- /A11y ---
 
 // デバッグ/検証用（TTL/in-flight挙動の確認に使用）
 window.loadVersionPublic = async () => { await readVersionNoStore(false); await loadVersion(); };

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -60,7 +60,15 @@
     <div id="lives" aria-label="lives" aria-live="polite" aria-atomic="true" data-testid="lives"></div>
     <div id="timer" aria-label="timer" aria-live="polite" aria-atomic="true" data-testid="timer"></div>
   </div>
-  <div id="score-bar" aria-label="score bar" aria-live="polite" aria-atomic="true" data-testid="score-bar"></div>
+  <div
+    id="score-bar"
+    role="progressbar"
+    aria-label="score bar"
+    aria-valuemin="0"
+    aria-valuemax="100"
+    aria-live="polite"
+    aria-atomic="true"
+    data-testid="score-bar"></div>
   <div id="countdown" aria-live="polite" aria-atomic="true" style="display:none; margin-top:6px;" data-testid="countdown"></div>
   <div id="media-slot" aria-label="audio preview area"></div>
   <div id="prompt" role="status" aria-live="polite" aria-atomic="true" data-testid="prompt"></div>


### PR DESCRIPTION
## Summary
- expose score progress bar as a `progressbar` with full aria attributes
- always enable progressbar/timer accessibility helpers instead of gating to `?test=1`

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b8b50d008324a70de49e18efd02d