### PR TITLE
feat: validate DAILY_PR_PAT token

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -15,6 +15,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Validate DAILY_PR_PAT token
+        env:
+          DAILY_PR_PAT: ${{ secrets.DAILY_PR_PAT }}
+        run: |
+          if [ -z "${DAILY_PR_PAT}" ]; then
+            echo "::error title=Missing DAILY_PR_PAT::The DAILY_PR_PAT secret is empty or not configured. Create a fine-grained PAT (repo:contents write, pull_requests write) and add it as a repository secret."
+            exit 1
+          fi
+          code=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: token ${DAILY_PR_PAT}" https://api.github.com/user)
+          if [ "$code" -ne 200 ]; then
+            echo "::error title=Invalid/expired DAILY_PR_PAT::GitHub API /user returned HTTP ${code}. The token may be expired or lacks scopes. Re-issue the PAT and update the secret."
+            exit 1
+          fi
+
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,30 +21,44 @@ Verify you are checking after Start, and that `window.__rng` is `"function"`; us
 
 ---
 
-## PR stuck at “Expected — waiting for status to be reported”
+## よくある症状と対処
 
+### daily.json generator が開始直後に失敗する（Missing/Invalid DAILY_PR_PAT）
+**症状**    
+ワークフロー最初のステップ `Validate DAILY_PR_PAT token` で失敗し、ログに  
+`Missing DAILY_PR_PAT` または `Invalid/expired DAILY_PR_PAT` が出る。
+
+**原因**    
+`DAILY_PR_PAT` が未設定・期限切れ・またはスコープ不足（repo:contents write / pull_requests write など）。
+
+**対処**    
+1. Fine-grained PAT を発行（対象 repo に限定、Contents: Read/Write、Pull requests: Read/Write）  
+2. リポジトリ Secrets に `DAILY_PR_PAT` として登録（既存がある場合は置き換え）  
+3. Actions → daily.json generator (JST) を手動実行して回復を確認
+
+### “Expected: waiting…” のまま進まない
 **Likely causes & fixes**
 
-- **PR created with `GITHUB_TOKEN`** (author shows `github-actions[bot]`)  
-  → Use a Fine‑grained PAT and set `token: ${{ secrets.DAILY_PR_PAT }}` in `daily.yml`.  
+- **PR created with `GITHUB_TOKEN`** (author shows `github-actions[bot]`)
+  → Use a Fine‑grained PAT and set `token: ${{ secrets.DAILY_PR_PAT }}` in `daily.yml`.
   Verify:
   ```bash
   gh pr view <PR#> -R nantes-rfli/vgm-quiz --json author | jq -r '.author.login'
   ```
 
-- **Required checks mismatch** (registered the UI string like “CI Fast / build (pull_request)” instead of the **job name**)  
+- **Required checks mismatch** (registered the UI string like “CI Fast / build (pull_request)” instead of the **job name**)
   → In Rulesets, require **`pages-pr-build`** and **`ci-fast-pr-build`** (job names).
 
-- **Workflows missing on the PR branch**  
+- **Workflows missing on the PR branch**
   → Click **Update branch** or push an empty commit to refresh checks:
   ```bash
   git commit --allow-empty -m "chore: refresh checks"
   git push
   ```
 
-- **Two “Pages / build” entries** on PRs  
+- **Two “Pages / build” entries** on PRs
   → Ensure `pages.yml` does **not** have `pull_request:` (deploy runs only on `push: main`). PR uses the shim `pages-pr-build.yml`.
 
-- **PR CI skipped by path filters**  
+- **PR CI skipped by path filters**
   → Ensure `ci-fast-pr.yml` has `paths: ['**']`.
 


### PR DESCRIPTION
## Summary
- fail early if DAILY_PR_PAT secret is missing or invalid
- document how to recover from missing/expired PAT in daily workflow

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bb8682848324a153fd07a984edb7