### PR TITLE
feat(ci): add matrix e2e workflow

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -1,0 +1,59 @@
+name: E2E (matrix, manual)
+
+on:
+  workflow_dispatch: {}
+
+concurrency:
+  group: e2e-matrix-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: ${{ matrix.suite }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [smoke, a11y, footer]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install deps
+        run: npm ci || npm i
+
+      - name: Env
+        run: |
+          echo "APP_URL=https://nantes-rfli.github.io/vgm-quiz/app/" >> $GITHUB_ENV
+          echo "E2E_BASE_URL=https://nantes-rfli.github.io/vgm-quiz/app/?test=1" >> $GITHUB_ENV
+
+      - name: Run E2E (${{ matrix.suite }})
+        env:
+          APP_URL: ${{ env.APP_URL }}
+          E2E_BASE_URL: ${{ env.E2E_BASE_URL }}
+        run: |
+          set -euxo pipefail
+          case "${{ matrix.suite }}" in
+            smoke)  node e2e/test.js ;;
+            a11y)   node e2e/test_free_aria.js ;;
+            footer) node e2e/test_footer_version.js ;;
+            *) echo "unknown suite"; exit 1 ;;
+          esac
+
+      - name: Upload artifacts (logs/screenshots if any)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-${{ matrix.suite }}-artifacts
+          path: |
+            e2e/*.log
+            e2e/screenshots/**
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # VGM Quiz
 
+<!-- Status badges -->
+<p>
+  <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/ci-fast.yml">
+    <img alt="CI Fast (main)" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/ci-fast.yml/badge.svg?branch=main">
+  </a>
+  <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e-matrix.yml">
+    <img alt="E2E (matrix)" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e-matrix.yml/badge.svg">
+  </a>
+</p>
+
 [![Lighthouse nightly](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml/badge.svg?branch=main)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml) [![E2E](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e.yml) [![Pages](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/pages.yml/badge.svg?branch=main)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/pages.yml)
 
 A small quiz app for video game music. Runs on GitHub Pages.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -68,3 +68,25 @@ clojure -M:test
 - Give jobs stable, unique `name:` values; if you rename jobs, update Rulesets together.
 - Keep PR checks light; shift heavy suites to nightly or `workflow_dispatch`.
 
+## E2E（並列マトリクス版）
+
+### 目的
+- どの観点で落ちたか（smoke/a11y/footer）を **一発で特定**。
+- 並列化で **実行時間短縮**、失敗時は該当スイートだけログ確認。
+
+### ワークフロー
+- ファイル: `.github/workflows/e2e-matrix.yml`
+- トリガ: **manual (`workflow_dispatch`)** 導入 → 問題なければ夜間スケジュールへ移行可能。
+- マトリクス: `smoke`（`e2e/test.js`）、`a11y`（`e2e/test_free_aria.js`）、`footer`（`e2e/test_footer_version.js`）
+- 共通環境:
+  - `APP_URL=https://nantes-rfli.github.io/vgm-quiz/app/`
+  - `E2E_BASE_URL=https://nantes-rfli.github.io/vgm-quiz/app/?test=1`
+
+### 使い方
+1. Actions → **E2E (matrix, manual)** → **Run workflow**。
+2. 3 本のジョブが並列に走る（smoke/a11y/footer）。
+3. 失敗したスイートのアーティファクト（`e2e/*.log` / `e2e/screenshots`）をダウンロードして確認。
+
+### 既存の夜間 E2E との関係
+- 当面は **併存**（既存は夜間/手動、matrix は手動のみ）。
+- 安定確認後に、`e2e-matrix.yml` に `schedule` を追加し、旧ワークフローの夜間実行を停止（`on.schedule`を外す/ファイル削除）するとよい。


### PR DESCRIPTION
## Summary
- add manual matrix workflow to run E2E suites in parallel
- document matrix workflow and add status badges

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bf08e4388324811f09d1cf9ab24d