### PR TITLE
ci: conditionally install deps in e2e-matrix workflow

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -25,10 +25,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
-
-      - name: Install deps
-        run: npm ci || npm i
+      
+      - name: Install deps (only if package.json exists)
+        if: ${{ hashFiles('**/package.json') != '' }}
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci
+          else
+            npm install
+          fi
 
       - name: Env
         run: |


### PR DESCRIPTION
## Summary
- avoid npm cache for setup-node
- only install dependencies when package.json exists, using npm ci when a lockfile is present

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c07181a0832493b04eef59cdb2a3