### PR TITLE
ci: setup playwright runtime in e2e matrix

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -25,15 +25,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      
-      - name: Install deps (only if package.json exists)
-        if: ${{ hashFiles('**/package.json') != '' }}
+
+      - name: Prepare Playwright runtime (no repo deps)
         run: |
-          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
-            npm ci
-          else
-            npm install
+          set -eux
+          # このワークフロー専用の仮 package.json を作成して Playwright を入れる
+          if [ ! -f package.json ]; then
+            npm init -y
           fi
+          npm i -D playwright
+          # ブラウザ本体とOS依存パッケージもインストール
+          npx playwright install --with-deps
 
       - name: Env
         run: |


### PR DESCRIPTION
## Summary
- install a dedicated Playwright runtime without depending on repository packages

## Testing
- `npm test` *(fails: clojure not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c1d01a5c8324b1f61c2bad0aeade