### PR TITLE
feat(ci): add nightly e2e matrix schedule

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -1,7 +1,10 @@
-name: E2E (matrix, manual)
+name: E2E (matrix)
 
 on:
   workflow_dispatch: {}
+  schedule:
+    # UTC 19:40 = JST 04:40（Lighthouse 03:10の後・Pages混雑も回避）
+    - cron: "40 19 * * *"
 
 concurrency:
   group: e2e-matrix-${{ github.ref }}
@@ -14,6 +17,7 @@ jobs:
   e2e:
     name: ${{ matrix.suite }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -64,3 +68,4 @@ jobs:
             e2e/*.log
             e2e/screenshots/**
           if-no-files-found: ignore
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@
   <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e-matrix.yml">
     <img alt="E2E (matrix)" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e-matrix.yml/badge.svg">
   </a>
+  <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml">
+    <img alt="Lighthouse (nightly)" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml/badge.svg">
+  </a>
+  <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/pages.yml">
+    <img alt="Pages (deploy on main)" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/pages.yml/badge.svg?branch=main">
+  </a>
 </p>
-
-[![Lighthouse nightly](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml/badge.svg?branch=main)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml) [![E2E](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e.yml) [![Pages](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/pages.yml/badge.svg?branch=main)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/pages.yml)
 
 A small quiz app for video game music. Runs on GitHub Pages.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -83,10 +83,22 @@ clojure -M:test
   - `E2E_BASE_URL=https://nantes-rfli.github.io/vgm-quiz/app/?test=1`
 
 ### 使い方
-1. Actions → **E2E (matrix, manual)** → **Run workflow**。
+1. Actions → **E2E (matrix)** → **Run workflow**。
 2. 3 本のジョブが並列に走る（smoke/a11y/footer）。
 3. 失敗したスイートのアーティファクト（`e2e/*.log` / `e2e/screenshots`）をダウンロードして確認。
 
 ### 既存の夜間 E2E との関係
 - 当面は **併存**（既存は夜間/手動、matrix は手動のみ）。
 - 安定確認後に、`e2e-matrix.yml` に `schedule` を追加し、旧ワークフローの夜間実行を停止（`on.schedule`を外す/ファイル削除）するとよい。
+
+### Nightly スケジュール（導入済み）
+- 実行時刻: **JST 04:40**（= UTC 19:40）  
+  - `daily.json`（JST 00:00）と **Lighthouse (03:10 JST)** の後に走るため、衝突や帯域競合を回避。
+- 失敗時の確認手順:
+  1. Actions → **E2E (matrix)** の当日実行を開く
+  2. 赤いスイートだけを見る（smoke / a11y / footer）
+  3. 右上 “Artifacts” から `e2e-<suite>-artifacts` を取得（ログ/スクショ）
+  4. `docs/troubleshooting.md` の該当節へ
+
+### Artifact 保持
+- E2E のログ/スクショは **7日間** 保持（`upload-artifact@v4` の `retention-days: 7`）。


### PR DESCRIPTION
## Summary
- run E2E matrix nightly with 20 minute timeout and 7 day artifact retention
- show Lighthouse and Pages badges in README
- document nightly E2E schedule and artifact retention

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: 403 Repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c3fdbb4c8324a584b87a594ec91d