### PR TITLE
feat(ogp): add daily OGP generation

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -40,15 +40,30 @@ jobs:
           TZ: Asia/Tokyo
         run: node scripts/generate_daily.js
 
+      - name: Prepare Playwright for OGP
+        run: |
+          set -eux
+          npm init -y
+          npm i -D playwright
+          npx playwright install --with-deps
+
+      - name: Generate OGP card (1200x630)
+        env:
+          DAILY_DATE: ""
+        run: |
+          node scripts/generate_ogp.js
+          ls -lah public/ogp || true
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.DAILY_PR_PAT }}
           branch: bot/daily
-          commit-message: "chore(daily): update daily.json"
-          title: "chore(daily): update daily.json"
+          commit-message: "chore(daily): update daily.json (JST) and OGP"
+          title: "chore(daily): update daily.json (JST) and OGP"
           add-paths: |
             public/app/daily.json
+            public/ogp/*.png
           delete-branch: true
           signoff: true
           labels: "automation,daily"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@
   </a>
 </p>
 
-A small quiz app for video game music. Runs on GitHub Pages.
+### Daily OGP
+- 自動生成された OGP 画像は `public/ogp/daily-YYYY-MM-DD.png`
+- 画像は GitHub Pages からも配信可能（例: `/vgm-quiz/ogp/daily-YYYY-MM-DD.png`）
+- 今は日付のみのシンプル版。後続で楽曲名・出題タイプなどを載せる拡張が可能です。
+
+  A small quiz app for video game music. Runs on GitHub Pages.
 
 - **Live:** https://nantes-rfli.github.io/vgm-quiz/app/
 - **Repo:** https://github.com/nantes-rfli/vgm-quiz

--- a/scripts/generate_ogp.js
+++ b/scripts/generate_ogp.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require('playwright');
+
+function jstDateString(d = new Date()) {
+  const tz = 'Asia/Tokyo';
+  const y = d.toLocaleString('ja-JP', { timeZone: tz, year: 'numeric' });
+  const m = d.toLocaleString('ja-JP', { timeZone: tz, month: '2-digit' });
+  const dd = d.toLocaleString('ja-JP', { timeZone: tz, day: '2-digit' });
+  return `${y}-${m}-${dd}`;
+}
+
+(async () => {
+  const date = process.env.DAILY_DATE || jstDateString();
+  const repoRoot = process.cwd();
+  const outDir = path.join(repoRoot, 'public', 'ogp');
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const fileUrl = 'file://' + path.join(repoRoot, 'tools', 'ogp', 'daily.html');
+  const url = `${fileUrl}?date=${encodeURIComponent(date)}`;
+  const outPath = path.join(outDir, `daily-${date}.png`);
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1200, height: 630 } });
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.screenshot({ path: outPath });
+  await browser.close();
+
+  console.log(`OGP generated: ${path.relative(repoRoot, outPath)}`);
+})();

--- a/tools/ogp/daily.html
+++ b/tools/ogp/daily.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>VGM Quiz — Daily</title>
+  <style>
+    html,body { margin:0; padding:0; }
+    .ogp {
+      width: 1200px; height: 630px;
+      display: grid; place-items: center;
+      background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0ea5e9 100%);
+      color: #fff; font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial;
+      letter-spacing: .5px;
+    }
+    .card {
+      width: 1080px; height: 510px; border-radius: 24px;
+      background: rgba(0,0,0,.25); backdrop-filter: blur(4px);
+      display:flex; flex-direction:column; justify-content:center; align-items:center;
+      box-shadow: 0 10px 40px rgba(0,0,0,.35);
+      text-align:center;
+    }
+    .title { font-size: 72px; font-weight: 800; margin: 0 24px 12px; }
+    .subtitle { font-size: 32px; opacity: .9; margin: 0 24px; }
+    .date { margin-top: 28px; font-size: 40px; font-weight: 700; }
+  </style>
+  <script>
+    function getQP(name, d='') { try { return new URLSearchParams(location.search).get(name) || d; } catch { return d; } }
+    const date = getQP('date', '');
+    document.addEventListener('DOMContentLoaded', () => {
+      document.getElementById('ogp-date').textContent = date;
+    });
+  </script>
+  </head>
+<body>
+  <div class="ogp">
+    <div class="card">
+      <div class="title">VGM QUIZ</div>
+      <div class="subtitle">Daily Question</div>
+      <div class="date" id="ogp-date">YYYY-MM-DD</div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add HTML template for daily OGP card
- add Playwright script to render OGP PNG
- generate and commit OGP card via daily workflow
- document daily OGP location and usage

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c626c2a0832488440993c44b0d6f