### PR TITLE
fix: ensure JST ISO dates and cleanup OGP

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -54,6 +54,13 @@ jobs:
           node scripts/generate_ogp.js
           ls -lah public/ogp || true
 
+      - name: Cleanup legacy JP-named OGP files (once)
+        run: |
+          set -eux
+          mkdir -p public/ogp
+          # "年" を含む誤命名ファイルを削除（過去の誤作成ぶんも除去）
+          find public/ogp -maxdepth 1 -type f -name 'daily-*年*' -delete || true
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:

--- a/scripts/generate_ogp.js
+++ b/scripts/generate_ogp.js
@@ -4,15 +4,25 @@ const path = require('path');
 const { chromium } = require('playwright');
 
 function jstDateString(d = new Date()) {
-  const tz = 'Asia/Tokyo';
-  const y = d.toLocaleString('ja-JP', { timeZone: tz, year: 'numeric' });
-  const m = d.toLocaleString('ja-JP', { timeZone: tz, month: '2-digit' });
-  const dd = d.toLocaleString('ja-JP', { timeZone: tz, day: '2-digit' });
-  return `${y}-${m}-${dd}`;
+  // en-CA は ISO っぽい 4桁年-2桁月-2桁日 を返す
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const parts = fmt.formatToParts(d).reduce((acc, p) => {
+    if (p.type === 'year' || p.type === 'month' || p.type === 'day') acc[p.type] = p.value;
+    return acc;
+  }, {});
+  return `${parts.year}-${parts.month}-${parts.day}`;
 }
 
 (async () => {
-  const date = process.env.DAILY_DATE || jstDateString();
+  // DAILY_DATE が未指定なら JST の ISO 文字列を採用
+  const date = process.env.DAILY_DATE && /^\d{4}-\d{2}-\d{2}$/.test(process.env.DAILY_DATE)
+    ? process.env.DAILY_DATE
+    : jstDateString();
   const repoRoot = process.cwd();
   const outDir = path.join(repoRoot, 'public', 'ogp');
   fs.mkdirSync(outDir, { recursive: true });


### PR DESCRIPTION
## Summary
- use Intl.DateTimeFormat to generate JST ISO date strings in OGP generator
- validate `DAILY_DATE` and ensure fallback to JST ISO
- remove legacy Japanese-named OGP files in workflow

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: The repository is not signed)*


------
https://chatgpt.com/codex/tasks/task_e_68b3d083e2b883248fd10100b0d24705