### PR TITLE
feat(daily): generate share page

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -61,16 +61,32 @@ jobs:
           # "年" を含む誤命名ファイルを削除（過去の誤作成ぶんも除去）
           find public/ogp -maxdepth 1 -type f -name 'daily-*年*' -delete || true
 
+      - name: Compute PUBLIC_BASE for GitHub Pages
+        run: |
+          set -eux
+          owner="${GITHUB_REPOSITORY%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+          echo "PUBLIC_BASE=https://${owner}.github.io/${repo}" >> $GITHUB_ENV
+
+      - name: Generate Daily share page
+        env:
+          DAILY_DATE: ""
+          PUBLIC_BASE: ${{ env.PUBLIC_BASE }}
+        run: |
+          node scripts/generate_share_page.js
+          ls -lah public/daily || true
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.DAILY_PR_PAT }}
           branch: bot/daily
-          commit-message: "chore(daily): update daily.json (JST) and OGP"
-          title: "chore(daily): update daily.json (JST) and OGP"
+          commit-message: "chore(daily): update daily.json (JST), OGP, and share page"
+          title: "chore(daily): update daily.json (JST), OGP, and share page"
           add-paths: |
             public/app/daily.json
             public/ogp/*.png
+            public/daily/*.html
           delete-branch: true
           signoff: true
           labels: "automation,daily"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@
 - 画像は GitHub Pages からも配信可能（例: `/vgm-quiz/ogp/daily-YYYY-MM-DD.png`）
 - 今は日付のみのシンプル版。後続で楽曲名・出題タイプなどを載せる拡張が可能です。
 
+### Share page
+- 毎日の共有用静的ページ: `public/daily/YYYY-MM-DD.html`
+- そのURLをSNSに貼ると、上記 OGP 画像のプレビューとともに **`/app/?daily=YYYY-MM-DD`** へ自動リダイレクトします。
+
   A small quiz app for video game music. Runs on GitHub Pages.
 
 - **Live:** https://nantes-rfli.github.io/vgm-quiz/app/

--- a/scripts/generate_share_page.js
+++ b/scripts/generate_share_page.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function jstDateString(d = new Date()) {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  });
+  const parts = fmt.formatToParts(d).reduce((acc, p) => {
+    if (p.type === 'year' || p.type === 'month' || p.type === 'day') acc[p.type] = p.value;
+    return acc;
+  }, {});
+  return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+(async () => {
+  const date = process.env.DAILY_DATE && /^\d{4}-\d{2}-\d{2}$/.test(process.env.DAILY_DATE)
+    ? process.env.DAILY_DATE
+    : jstDateString();
+  const base = process.env.PUBLIC_BASE || '';
+  const repoRoot = process.cwd();
+  const outDir = path.join(repoRoot, 'public', 'daily');
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const appUrl = `${base}/app/?daily=${date}`;
+  const ogpUrl = `${base}/ogp/daily-${date}.png`;
+  const pageUrl = `${base}/daily/${date}.html`;
+
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>VGM Quiz — Daily ${date}</title>
+  <meta name="robots" content="index,follow">
+  <link rel="canonical" href="${appUrl}">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="VGM Quiz">
+  <meta property="og:title" content="VGM Quiz — Daily ${date}">
+  <meta property="og:description" content="1日1問のVGMクイズ。今日の問題に挑戦！">
+  <meta property="og:image" content="${ogpUrl}">
+  <meta property="og:url" content="${pageUrl}">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta http-equiv="refresh" content="0; url=${appUrl}">
+</head>
+<body>
+  <p>Redirecting to <a href="${appUrl}">VGM Quiz — Daily ${date}</a> …</p>
+  <noscript><a href="${appUrl}">Click here if you are not redirected.</a></noscript>
+</body>
+</html>`;
+
+  const outPath = path.join(outDir, `${date}.html`);
+  fs.writeFileSync(outPath, html);
+  console.log(`Share page generated: ${path.relative(repoRoot, outPath)}`);
+})();


### PR DESCRIPTION
## Summary
- add Node script to generate redirecting share page with OGP tags
- extend daily workflow to build share page
- document daily share page in README

## Testing
- `node scripts/generate_share_page.js`
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d241a0508324abdca63f34e3a754