### PR TITLE
feat: add daily share override and E2E test

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [smoke, a11y, footer]
+        suite: [smoke, a11y, footer, share]
     steps:
       - uses: actions/checkout@v4
 
@@ -56,6 +56,7 @@ jobs:
             smoke)  node e2e/test.js ;;
             a11y)   node e2e/test_free_aria.js ;;
             footer) node e2e/test_footer_version.js ;;
+            share)  node e2e/test_share.js ;;
             *) echo "unknown suite"; exit 1 ;;
           esac
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -77,14 +77,18 @@ clojure -M:test
 ### ワークフロー
 - ファイル: `.github/workflows/e2e-matrix.yml`
 - トリガ: **manual (`workflow_dispatch`)** 導入 → 問題なければ夜間スケジュールへ移行可能。
-- マトリクス: `smoke`（`e2e/test.js`）、`a11y`（`e2e/test_free_aria.js`）、`footer`（`e2e/test_footer_version.js`）
+- マトリクス: `smoke`（`e2e/test.js`）、`a11y`（`e2e/test_free_aria.js`）、`footer`（`e2e/test_footer_version.js`）、`share`（`e2e/test_share.js`）
+`share` は:
+- アプリの共有ボタンでコピーされるURLが **`/daily/YYYY-MM-DD.html`** であること
+- 共有ページ（存在すれば）のHTMLに **OGP画像** と **`/app/?daily=...`** への meta refresh があること  
+（手動実行で当日の共有ページ未生成の場合は 404 を許容）
 - 共通環境:
   - `APP_URL=https://nantes-rfli.github.io/vgm-quiz/app/`
   - `E2E_BASE_URL=https://nantes-rfli.github.io/vgm-quiz/app/?test=1`
 
 ### 使い方
 1. Actions → **E2E (matrix)** → **Run workflow**。
-2. 3 本のジョブが並列に走る（smoke/a11y/footer）。
+2. 4 本のジョブが並列に走る（smoke/a11y/footer/share）。
 3. 失敗したスイートのアーティファクト（`e2e/*.log` / `e2e/screenshots`）をダウンロードして確認。
 
 ### 既存の夜間 E2E との関係
@@ -96,7 +100,7 @@ clojure -M:test
   - `daily.json`（JST 00:00）と **Lighthouse (03:10 JST)** の後に走るため、衝突や帯域競合を回避。
 - 失敗時の確認手順:
   1. Actions → **E2E (matrix)** の当日実行を開く
-  2. 赤いスイートだけを見る（smoke / a11y / footer）
+  2. 赤いスイートだけを見る（smoke / a11y / footer / share）
   3. 右上 “Artifacts” から `e2e-<suite>-artifacts` を取得（ログ/スクショ）
   4. `docs/troubleshooting.md` の該当節へ
 

--- a/e2e/test_share.js
+++ b/e2e/test_share.js
@@ -1,0 +1,50 @@
+// E2E: デイリーページの共有URLと共有HTMLのOGP/リダイレクトを検証
+const { chromium } = require('playwright');
+
+function jstISO() {
+  const fmt = new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Tokyo', year: 'numeric', month: '2-digit', day: '2-digit' });
+  const p = Object.fromEntries(fmt.formatToParts(new Date()).map(x => [x.type, x.value]));
+  return `${p.year}-${p.month}-${p.day}`;
+}
+
+(async () => {
+  const APP_URL = process.env.APP_URL;
+  if (!APP_URL) throw new Error('APP_URL env is required');
+  const date = jstISO();
+  const appUrl = `${APP_URL}?daily=${date}&test=1&autostart=0`;
+  const publicBase = APP_URL.replace(/\/app\/?.*$/, '');
+  const shareUrl = `${publicBase}/daily/${date}.html`;
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  const page = await context.newPage();
+
+  // 1) アプリから共有ボタンでコピーされるURLが /daily/YYYY-MM-DD.html であること
+  await page.goto(appUrl, { waitUntil: 'domcontentloaded' });
+  const sel = '[data-testid="share-btn"], #share-btn, button.share-btn';
+  await page.click(sel);
+  const clip = await page.evaluate(() => navigator.clipboard.readText());
+  if (!clip.includes(`/daily/${date}.html`)) {
+    throw new Error(`[share] clipboard mismatch. expected suffix /daily/${date}.html, got: ${clip}`);
+  }
+
+  // 2) 共有ページの静的HTMLにOGタグがあり、meta refresh先が /app/?daily=... であること
+  const resp = await page.request.get(shareUrl);
+  if (resp.status() === 200) {
+    const html = await resp.text();
+    const ogImgOk = html.includes(`/ogp/daily-${date}.png`);
+    const refreshOk = html.includes(`/app/?daily=${date}`);
+    if (!ogImgOk || !refreshOk) {
+      throw new Error(`[share] share HTML missing tags: og:image ok? ${ogImgOk}, refresh ok? ${refreshOk}`);
+    }
+  } else if (resp.status() === 404) {
+    // 当日の daily.yml がまだ走ってない手動実行ケースはスキップ
+    console.warn(`[share] share page 404 (ok for manual runs before daily). url=${shareUrl}`);
+  } else {
+    throw new Error(`[share] unexpected HTTP ${resp.status()} for ${shareUrl}`);
+  }
+
+  await browser.close();
+  console.log('[E2E share] OK');
+})();

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -138,4 +138,7 @@ E2E uses ?test=1, but should still load mc.js (logic helpers live there). -->
   // app entry
 </script>
 <script src="app.js" type="module"></script>
+  <!-- デイリーモード時の共有URL上書き（/daily/YYYY-MM-DD.html をコピー） -->
+  <script src="./share_patch.js"></script>
+</body>
 </html>

--- a/public/app/share_patch.js
+++ b/public/app/share_patch.js
@@ -1,0 +1,46 @@
+// デイリーモードでの共有URLを /daily/YYYY-MM-DD.html に置き換えるパッチ。
+// 既存の copyToClipboard を安全に横取りし、トースト等の挙動は既存ロジックに委ねる。
+(function () {
+  function getQP(k) {
+    try { return new URLSearchParams(location.search).get(k); } catch { return null; }
+  }
+  function resolveDailyDate() {
+    const q = getQP('daily');
+    return (q && /^\d{4}-\d{2}-\d{2}$/.test(q)) ? q : null;
+  }
+  function publicBase() {
+    // /vgm-quiz/app/... -> /vgm-quiz
+    const m = location.pathname.match(/^(.*)\/app(?:\/.*)?$/);
+    const basePath = m ? m[1] : '';
+    return location.origin + basePath;
+  }
+  function buildDailyShareUrl(date) {
+    return `${publicBase()}/daily/${date}.html`;
+  }
+  function applyOverride() {
+    const date = resolveDailyDate();
+    if (!date) return; // 非デイリー時は何もしない
+    const original = window.copyToClipboard;
+    window.copyToClipboard = async function (text) {
+      const url = buildDailyShareUrl(date);
+      if (typeof original === 'function') {
+        return original(url); // 既存のトースト/通知はそのまま活用
+      }
+      // フォールバック
+      try {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(url);
+        } else {
+          const ta = document.createElement('textarea');
+          ta.value = url; document.body.appendChild(ta);
+          ta.select(); document.execCommand('copy'); document.body.removeChild(ta);
+        }
+      } catch (e) { console.error('share_patch copy failed', e); }
+    };
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyOverride, { once: true });
+  } else {
+    applyOverride();
+  }
+})();


### PR DESCRIPTION
## Summary
- Override clipboard share URL to `/daily/YYYY-MM-DD.html` during daily mode
- Add E2E test for share URL and daily share page
- Include share suite in E2E matrix workflow and document it

## Testing
- `npm test` *(fails: clojure: not found)*
- `APP_URL="http://127.0.0.1:8080/app/" node e2e/test_share.js` *(fails: Cannot find module 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68b3d6a00fc88324aaeaa84539b29b4b