### PR TITLE
feat: support ?daily=1 share URL and test

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -82,6 +82,7 @@ clojure -M:test
 - アプリの共有ボタンでコピーされるURLが **`/daily/YYYY-MM-DD.html`** であること
 - 共有ページ（存在すれば）のHTMLに **OGP画像** と **`/app/?daily=...`** への meta refresh があること  
 （手動実行で当日の共有ページ未生成の場合は 404 を許容）
+- `?daily=1`（当日JST指定）でも **同じ共有URL** がコピーされることを検証します。
 - 共通環境:
   - `APP_URL=https://nantes-rfli.github.io/vgm-quiz/app/`
   - `E2E_BASE_URL=https://nantes-rfli.github.io/vgm-quiz/app/?test=1`

--- a/e2e/test_share.js
+++ b/e2e/test_share.js
@@ -51,6 +51,21 @@ function jstISO() {
     throw new Error(`[share] unexpected HTTP ${resp.status()} for ${shareUrl}`);
   }
 
+  // 3) ?daily=1 でも同様に当日(JST)のURLがコピーされる
+  const appUrlToday = `${APP_URL}?daily=1&test=1&autostart=0`;
+  await page.goto(appUrlToday, { waitUntil: 'domcontentloaded' });
+  await page.evaluate(async () => {
+    if (typeof window.copyToClipboard === 'function') {
+      await window.copyToClipboard('dummy');
+    } else {
+      throw new Error('copyToClipboard is not defined');
+    }
+  });
+  const clip2 = await page.evaluate(() => navigator.clipboard.readText());
+  if (!clip2.includes(`/daily/${date}.html`)) {
+    throw new Error(`[share] (?daily=1) clipboard mismatch. expected suffix /daily/${date}.html, got: ${clip2}`);
+  }
+
   await browser.close();
   console.log('[E2E share] OK');
 })();

--- a/public/app/share_patch.js
+++ b/public/app/share_patch.js
@@ -4,9 +4,16 @@
   function getQP(k) {
     try { return new URLSearchParams(location.search).get(k); } catch { return null; }
   }
+  function jstISO(d = new Date()) {
+    const fmt = new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Tokyo', year: 'numeric', month: '2-digit', day: '2-digit' });
+    const parts = Object.fromEntries(fmt.formatToParts(d).map(p => [p.type, p.value]));
+    return `${parts.year}-${parts.month}-${parts.day}`;
+  }
   function resolveDailyDate() {
     const q = getQP('daily');
-    return (q && /^\d{4}-\d{2}-\d{2}$/.test(q)) ? q : null;
+    if (!q) return null;
+    if (q === '1') return jstISO(); // 当日(JST)
+    return (/^\d{4}-\d{2}-\d{2}$/.test(q)) ? q : null;
   }
   function publicBase() {
     // /vgm-quiz/app/... -> /vgm-quiz


### PR DESCRIPTION
## Summary
- allow `?daily=1` to resolve current JST date and generate daily share URL
- verify the `?daily=1` behavior in the E2E share test
- note this additional check in CI documentation

## Testing
- `npm test` *(fails: clojure not found)*
- `APP_URL=https://nantes-rfli.github.io/vgm-quiz/app/ node e2e/test_share.js` *(fails: Cannot find module 'playwright')*
- `npm install playwright` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b3db0b7cf08324998976b5ebb7e71f