### PR TITLE
feat: include type label in daily OGP

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 ### Daily OGP
-- 自動生成された OGP 画像は `public/ogp/daily-YYYY-MM-DD.png`
+- 自動生成された OGP 画像は `public/ogp/daily-YYYY-MM-DD.png`（**出題タイプ**：title→game / game→composer / title→composer を表示。判定できない場合は “Daily Question”）
 - 画像は GitHub Pages からも配信可能（例: `/vgm-quiz/ogp/daily-YYYY-MM-DD.png`）
 - 今は日付のみのシンプル版。後続で楽曲名・出題タイプなどを載せる拡張が可能です。
 

--- a/scripts/generate_ogp.js
+++ b/scripts/generate_ogp.js
@@ -18,6 +18,59 @@ function jstDateString(d = new Date()) {
   return `${parts.year}-${parts.month}-${parts.day}`;
 }
 
+function deriveTypeLabel(daily) {
+  // まずは素直に代表的なキーを参照
+  const candidates = [
+    daily?.question?.type, daily?.type, daily?.mode,
+    daily?.q?.type, daily?.meta?.type, daily?.questionType,
+  ].filter(v => typeof v === 'string' && v.trim().length);
+  let raw = candidates[0] || null;
+  // 正規化判定（よくある表記ゆれを吸収）
+  const norm = s => String(s).toLowerCase().replace(/[\s_-]+/g,'');
+  const decide = (s) => {
+    const n = norm(s);
+    if (/^(title|song|track).*game/.test(n)) return 'title→game';
+    if (/^game.*composer/.test(n)) return 'game→composer';
+    if (/^(title|song|track).*composer/.test(n)) return 'title→composer';
+    return null;
+  };
+  let label = raw && decide(raw);
+  if (label) return label;
+  // ネストをざっくり探索（from/to式や ask/answer式があれば拾う）
+  const hint = (x) => {
+    const v = String(x || '').toLowerCase();
+    if (['title','song','track','name'].includes(v)) return 'title';
+    if (['game','series'].includes(v)) return 'game';
+    if (['composer','artist'].includes(v)) return 'composer';
+    return null;
+  };
+  const dfs = (obj, depth=0) => {
+    if (!obj || typeof obj !== 'object' || depth > 3) return null;
+    let from = null, to = null;
+    for (const [k,v] of Object.entries(obj)) {
+      if (typeof v === 'string') {
+        if (!from) from = hint(v);
+        if (!to) to = hint(v);
+      } else if (typeof v === 'object') {
+        const r = dfs(v, depth+1);
+        if (r) return r;
+      }
+      // key 名が from/to/ask/answer ぽい場合
+      if (typeof v === 'string' && /^(from|ask)$/i.test(k)) from = hint(v) || from;
+      if (typeof v === 'string' && /^(to|answer)$/i.test(k)) to = hint(v) || to;
+      if (from && to) break;
+    }
+    if (from && to) {
+      if (from==='title' && to==='game') return 'title→game';
+      if (from==='game'  && to==='composer') return 'game→composer';
+      if (from==='title' && to==='composer') return 'title→composer';
+    }
+    return null;
+  };
+  label = dfs(daily);
+  return label || null;
+}
+
 (async () => {
   // DAILY_DATE が未指定なら JST の ISO 文字列を採用
   const date = process.env.DAILY_DATE && /^\d{4}-\d{2}-\d{2}$/.test(process.env.DAILY_DATE)
@@ -27,8 +80,16 @@ function jstDateString(d = new Date()) {
   const outDir = path.join(repoRoot, 'public', 'ogp');
   fs.mkdirSync(outDir, { recursive: true });
 
+  // daily.json から出題タイプを推定（失敗したら "Daily Question"）
+  let subtitle = 'Daily Question';
+  try {
+    const dailyJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'public', 'app', 'daily.json'), 'utf8'));
+    const label = deriveTypeLabel(dailyJson);
+    if (label) subtitle = label;
+  } catch (_) { /* noop */ }
+
   const fileUrl = 'file://' + path.join(repoRoot, 'tools', 'ogp', 'daily.html');
-  const url = `${fileUrl}?date=${encodeURIComponent(date)}`;
+  const url = `${fileUrl}?date=${encodeURIComponent(date)}&subtitle=${encodeURIComponent(subtitle)}`;
   const outPath = path.join(outDir, `daily-${date}.png`);
 
   const browser = await chromium.launch();

--- a/scripts/generate_share_page.js
+++ b/scripts/generate_share_page.js
@@ -14,6 +14,57 @@ function jstDateString(d = new Date()) {
   return `${parts.year}-${parts.month}-${parts.day}`;
 }
 
+(function attachHelpers(){
+  // daily.json からタイプを推定（generate_ogp.js と同ロジックの軽量版）
+  function deriveTypeLabel(daily) {
+    const candidates = [
+      daily?.question?.type, daily?.type, daily?.mode,
+      daily?.q?.type, daily?.meta?.type, daily?.questionType,
+    ].filter(v => typeof v === 'string' && v.trim().length);
+    const norm = s => String(s).toLowerCase().replace(/[\s_-]+/g,'');
+    const decide = (s) => {
+      const n = norm(s);
+      if (/^(title|song|track).*game/.test(n)) return 'title→game';
+      if (/^game.*composer/.test(n)) return 'game→composer';
+      if (/^(title|song|track).*composer/.test(n)) return 'title→composer';
+      return null;
+    };
+    let label = (candidates[0] && decide(candidates[0])) || null;
+    if (label) return label;
+    const hint = (x) => {
+      const v = String(x || '').toLowerCase();
+      if (['title','song','track','name'].includes(v)) return 'title';
+      if (['game','series'].includes(v)) return 'game';
+      if (['composer','artist'].includes(v)) return 'composer';
+      return null;
+    };
+    const dfs = (obj, depth=0) => {
+      if (!obj || typeof obj !== 'object' || depth > 3) return null;
+      let from = null, to = null;
+      for (const [k,v] of Object.entries(obj)) {
+        if (typeof v === 'string') {
+          if (!from) from = hint(v);
+          if (!to) to = hint(v);
+        } else if (typeof v === 'object') {
+          const r = dfs(v, depth+1);
+          if (r) return r;
+        }
+        if (typeof v === 'string' && /^(from|ask)$/i.test(k)) from = hint(v) || from;
+        if (typeof v === 'string' && /^(to|answer)$/i.test(k)) to = hint(v) || to;
+        if (from && to) break;
+      }
+      if (from && to) {
+        if (from==='title' && to==='game') return 'title→game';
+        if (from==='game'  && to==='composer') return 'game→composer';
+        if (from==='title' && to==='composer') return 'title→composer';
+      }
+      return null;
+    };
+    return dfs(daily) || null;
+  }
+  module.exports = { deriveTypeLabel };
+})();
+
 (async () => {
   const date = process.env.DAILY_DATE && /^\d{4}-\d{2}-\d{2}$/.test(process.env.DAILY_DATE)
     ? process.env.DAILY_DATE
@@ -26,19 +77,28 @@ function jstDateString(d = new Date()) {
   const appUrl = `${base}/app/?daily=${date}`;
   const ogpUrl = `${base}/ogp/daily-${date}.png`;
   const pageUrl = `${base}/daily/${date}.html`;
+  // タイプ推定（失敗時は空→後で置換）
+  let typeLabel = '';
+  try {
+    const dailyJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'public', 'app', 'daily.json'), 'utf8'));
+    const { deriveTypeLabel } = module.exports;
+    typeLabel = deriveTypeLabel(dailyJson) || '';
+  } catch (_) { /* noop */ }
+  const ogTitle = typeLabel ? `VGM Quiz — Daily ${date} — ${typeLabel}` : `VGM Quiz — Daily ${date}`;
+  const ogDesc  = typeLabel ? `1日1問のVGMクイズ（${typeLabel}）。今日の問題に挑戦！` : `1日1問のVGMクイズ。今日の問題に挑戦！`;
 
   const html = `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>VGM Quiz — Daily ${date}</title>
+  <title>${ogTitle}</title>
   <meta name="robots" content="index,follow">
   <link rel="canonical" href="${appUrl}">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="VGM Quiz">
-  <meta property="og:title" content="VGM Quiz — Daily ${date}">
-  <meta property="og:description" content="1日1問のVGMクイズ。今日の問題に挑戦！">
+  <meta property="og:title" content="${ogTitle}">
+  <meta property="og:description" content="${ogDesc}">
   <meta property="og:image" content="${ogpUrl}">
   <meta property="og:url" content="${pageUrl}">
   <meta name="twitter:card" content="summary_large_image">

--- a/tools/ogp/daily.html
+++ b/tools/ogp/daily.html
@@ -27,8 +27,10 @@
   <script>
     function getQP(name, d='') { try { return new URLSearchParams(location.search).get(name) || d; } catch { return d; } }
     const date = getQP('date', '');
+    const subtitle = getQP('subtitle', 'Daily Question');
     document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('ogp-date').textContent = date;
+      document.getElementById('ogp-subtitle').textContent = subtitle;
     });
   </script>
   </head>
@@ -36,7 +38,7 @@
   <div class="ogp">
     <div class="card">
       <div class="title">VGM QUIZ</div>
-      <div class="subtitle">Daily Question</div>
+      <div class="subtitle" id="ogp-subtitle">Daily Question</div>
       <div class="date" id="ogp-date">YYYY-MM-DD</div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- render custom subtitle on the daily OGP template
- estimate question type from daily.json when generating OGP and share page
- document that daily OGP now shows the question type

## Testing
- `node --check scripts/generate_ogp.js`
- `node --check scripts/generate_share_page.js`
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3dfa128f483249f376d40de171f5e