### PR TITLE
feat: enhance daily share and OGP generation

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -40,6 +40,10 @@ jobs:
           TZ: Asia/Tokyo
         run: node scripts/generate_daily.js
 
+      - name: Derive OGP subtitle into daily.json
+        run: |
+          node scripts/derive_daily_meta.js
+
       - name: Prepare Playwright for OGP
         run: |
           set -eux

--- a/scripts/derive_daily_meta.js
+++ b/scripts/derive_daily_meta.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function deriveTypeLabel(daily) {
+  const pick = [
+    daily?.question?.type, daily?.type, daily?.mode,
+    daily?.q?.type, daily?.meta?.type, daily?.questionType,
+  ].find(v => typeof v === 'string' && v.trim());
+  const norm = s => String(s).toLowerCase().replace(/[\s_-]+/g,'');
+  const decide = (s) => {
+    const n = norm(s);
+    if (/^(title|song|track).*game/.test(n)) return 'title→game';
+    if (/^game.*composer/.test(n)) return 'game→composer';
+    if (/^(title|song|track).*composer/.test(n)) return 'title→composer';
+    return null;
+  };
+  let label = pick && decide(pick);
+  if (label) return label;
+  // 構造探索（浅め）
+  const hint = (x) => {
+    const v = String(x || '').toLowerCase();
+    if (['title','song','track','name'].includes(v)) return 'title';
+    if (['game','series'].includes(v)) return 'game';
+    if (['composer','artist'].includes(v)) return 'composer';
+    return null;
+  };
+  const dfs = (obj, depth=0) => {
+    if (!obj || typeof obj !== 'object' || depth > 3) return null;
+    let from = null, to = null;
+    for (const [k,v] of Object.entries(obj)) {
+      if (typeof v === 'string') {
+        if (!from) from = hint(v);
+        if (!to) to = hint(v);
+      } else if (typeof v === 'object') {
+        const r = dfs(v, depth+1);
+        if (r) return r;
+      }
+      if (typeof v === 'string' && /^(from|ask)$/i.test(k)) from = hint(v) || from;
+      if (typeof v === 'string' && /^(to|answer)$/i.test(k)) to = hint(v) || to;
+      if (from && to) break;
+    }
+    if (from && to) {
+      if (from==='title' && to==='game') return 'title→game';
+      if (from==='game'  && to==='composer') return 'game→composer';
+      if (from==='title' && to==='composer') return 'title→composer';
+    }
+    return null;
+  };
+  return dfs(daily) || null;
+}
+
+(async () => {
+  const root = process.cwd();
+  const fp = path.join(root, 'public', 'app', 'daily.json');
+  let json = JSON.parse(fs.readFileSync(fp, 'utf8'));
+  const label = deriveTypeLabel(json);
+  json.ogp = json.ogp || {};
+  if (label) json.ogp.subtitle = label;
+  // 変更があるときのみ書き戻し
+  const next = JSON.stringify(json, null, 2) + '\n';
+  const prev = fs.readFileSync(fp, 'utf8');
+  if (next !== prev) {
+    fs.writeFileSync(fp, next);
+    console.log(`[derive_meta] ogp.subtitle = "${label || ''}"`);
+  } else {
+    console.log('[derive_meta] no change');
+  }
+})();
+

--- a/scripts/generate_ogp.js
+++ b/scripts/generate_ogp.js
@@ -80,11 +80,11 @@ function deriveTypeLabel(daily) {
   const outDir = path.join(repoRoot, 'public', 'ogp');
   fs.mkdirSync(outDir, { recursive: true });
 
-  // daily.json から出題タイプを推定（失敗したら "Daily Question"）
+  // daily.json からサブタイトルを取得（優先順位: ogp.subtitle > 推定 > 既定）
   let subtitle = 'Daily Question';
   try {
     const dailyJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'public', 'app', 'daily.json'), 'utf8'));
-    const label = deriveTypeLabel(dailyJson);
+    const label = dailyJson?.ogp?.subtitle || deriveTypeLabel(dailyJson);
     if (label) subtitle = label;
   } catch (_) { /* noop */ }
 
@@ -98,5 +98,5 @@ function deriveTypeLabel(daily) {
   await page.screenshot({ path: outPath });
   await browser.close();
 
-  console.log(`OGP generated: ${path.relative(repoRoot, outPath)}`);
+  console.log(`OGP generated: ${path.relative(repoRoot, outPath)}  (subtitle="${subtitle}")`);
 })();

--- a/scripts/generate_share_page.js
+++ b/scripts/generate_share_page.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 
 function jstDateString(d = new Date()) {
   const fmt = new Intl.DateTimeFormat('en-CA', {
@@ -77,6 +78,13 @@ function jstDateString(d = new Date()) {
   const appUrl = `${base}/app/?daily=${date}`;
   const ogpUrl = `${base}/ogp/daily-${date}.png`;
   const pageUrl = `${base}/daily/${date}.html`;
+  // daily.json の内容ハッシュ（変更があれば share HTML も確実に変わる）
+  let dailyHash = '';
+  try {
+    const buf = fs.readFileSync(path.join(repoRoot, 'public', 'app', 'daily.json'));
+    dailyHash = crypto.createHash('sha1').update(buf).digest('hex').slice(0, 12);
+  } catch (_) { /* noop */ }
+  const ogpUrlWithV = dailyHash ? `${ogpUrl}?v=${dailyHash}` : ogpUrl;
   // タイプ推定（失敗時は空→後で置換）
   let typeLabel = '';
   try {
@@ -99,10 +107,11 @@ function jstDateString(d = new Date()) {
   <meta property="og:site_name" content="VGM Quiz">
   <meta property="og:title" content="${ogTitle}">
   <meta property="og:description" content="${ogDesc}">
-  <meta property="og:image" content="${ogpUrl}">
+  <meta property="og:image" content="${ogpUrlWithV}">
   <meta property="og:url" content="${pageUrl}">
   <meta name="twitter:card" content="summary_large_image">
   <meta http-equiv="refresh" content="0; url=${appUrl}">
+  <!-- daily-hash:${dailyHash} -->
 </head>
 <body>
   <p>Redirecting to <a href="${appUrl}">VGM Quiz — Daily ${date}</a> …</p>


### PR DESCRIPTION
## Summary
- cache-bust daily share page using hash of `daily.json`
- prefer `ogp.subtitle` for OGP generation and log subtitle
- add script to derive `ogp.subtitle` and run it in daily workflow

## Testing
- `node --check scripts/generate_share_page.js scripts/generate_ogp.js scripts/derive_daily_meta.js`
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e372ab008324a7912fe98318c0ed