### PR TITLE
chore: set OGP subtitle in daily workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Generate OGP card (1200x630)
         env:
           DAILY_DATE: ""
+          OGP_SUBTITLE: "title→game"
         run: |
           node scripts/generate_ogp.js
           ls -lah public/ogp || true
@@ -76,6 +77,7 @@ jobs:
         env:
           DAILY_DATE: ""
           PUBLIC_BASE: ${{ env.PUBLIC_BASE }}
+          OGP_SUBTITLE: "title→game"
         run: |
           node scripts/generate_share_page.js
           ls -lah public/daily || true


### PR DESCRIPTION
## Summary
- ensure daily workflow sets OGP subtitle for OGP card and share page generation

## Testing
- `npm test` *(fails: clojure not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e7afca8083249ccb8a4f5dc3f0e2