### PR TITLE
feat: prioritize OGP_SUBTITLE for subtitle

### DIFF
--- a/scripts/generate_ogp.js
+++ b/scripts/generate_ogp.js
@@ -80,12 +80,14 @@ function deriveTypeLabel(daily) {
   const outDir = path.join(repoRoot, 'public', 'ogp');
   fs.mkdirSync(outDir, { recursive: true });
 
-  // daily.json からサブタイトルを取得（優先順位: ogp.subtitle > 推定 > 既定）
-  let subtitle = 'Daily Question';
+  // サブタイトル優先順位: 環境変数 OGP_SUBTITLE > daily.json の ogp.subtitle > 推定 > 既定
+  let subtitle = process.env.OGP_SUBTITLE || 'Daily Question';
   try {
     const dailyJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'public', 'app', 'daily.json'), 'utf8'));
-    const label = dailyJson?.ogp?.subtitle || deriveTypeLabel(dailyJson);
-    if (label) subtitle = label;
+    if (!process.env.OGP_SUBTITLE) {
+      const label = dailyJson?.ogp?.subtitle || deriveTypeLabel(dailyJson);
+      if (label) subtitle = label;
+    }
   } catch (_) { /* noop */ }
 
   const fileUrl = 'file://' + path.join(repoRoot, 'tools', 'ogp', 'daily.html');

--- a/scripts/generate_share_page.js
+++ b/scripts/generate_share_page.js
@@ -85,12 +85,14 @@ function jstDateString(d = new Date()) {
     dailyHash = crypto.createHash('sha1').update(buf).digest('hex').slice(0, 12);
   } catch (_) { /* noop */ }
   const ogpUrlWithV = dailyHash ? `${ogpUrl}?v=${dailyHash}` : ogpUrl;
-  // タイプ推定（失敗時は空→後で置換）
-  let typeLabel = '';
+  // サブタイトル優先順位: 環境変数 OGP_SUBTITLE > daily.json 推定 > 空
+  let typeLabel = process.env.OGP_SUBTITLE || '';
   try {
-    const dailyJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'public', 'app', 'daily.json'), 'utf8'));
-    const { deriveTypeLabel } = module.exports;
-    typeLabel = deriveTypeLabel(dailyJson) || '';
+    if (!process.env.OGP_SUBTITLE) {
+      const dailyJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'public', 'app', 'daily.json'), 'utf8'));
+      const { deriveTypeLabel } = module.exports;
+      typeLabel = deriveTypeLabel(dailyJson) || '';
+    }
   } catch (_) { /* noop */ }
   const ogTitle = typeLabel ? `VGM Quiz — Daily ${date} — ${typeLabel}` : `VGM Quiz — Daily ${date}`;
   const ogDesc  = typeLabel ? `1日1問のVGMクイズ（${typeLabel}）。今日の問題に挑戦！` : `1日1問のVGMクイズ。今日の問題に挑戦！`;


### PR DESCRIPTION
## Summary
- allow overriding daily subtitle with `OGP_SUBTITLE` env variable
- propagate the same subtitle to share page generation

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ea4e7e7c83249a6daad0a55b72e1