### PR TITLE
feat: expand share page meta tags

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -80,7 +80,7 @@ clojure -M:test
 - マトリクス: `smoke`（`e2e/test.js`）、`a11y`（`e2e/test_free_aria.js`）、`footer`（`e2e/test_footer_version.js`）、`share`（`e2e/test_share.js`）
 `share` は:
 - アプリの共有ボタンでコピーされるURLが **`/daily/YYYY-MM-DD.html`** であること
-- 共有ページ（存在すれば）のHTMLに **OGP画像** と **`/app/?daily=...`** への meta refresh があること  
+- 共有ページ（存在すれば）のOGタグ・Twitterカード・画像サイズ・meta refreshを検証
 （手動実行で当日の共有ページ未生成の場合は 404 を許容）
 - `?daily=1`（当日JST指定）でも **同じ共有URL** がコピーされることを検証します。
 - 共通環境:

--- a/e2e/test_share.js
+++ b/e2e/test_share.js
@@ -53,8 +53,15 @@ function jstISO() {
     const html = await resp.text();
     const ogImgOk = html.includes(`/ogp/daily-${date}.png`);
     const refreshOk = html.includes(`/app/?daily=${date}`);
-    if (!ogImgOk || !refreshOk) {
-      throw new Error(`[share] share HTML missing tags: og:image ok? ${ogImgOk}, refresh ok? ${refreshOk}`);
+    const ogW = /property=["']og:image:width["'][^>]+content=["']1200["']/.test(html);
+    const ogH = /property=["']og:image:height["'][^>]+content=["']630["']/.test(html);
+    const twTitle = /name=["']twitter:title["'][^>]+content=["'][^"']*Daily\s+${date}[^"']*["']/.test(html);
+    const twImage = /name=["']twitter:image["'][^>]+content=["'][^"']*\/ogp\/daily-${date}\.png/.test(html);
+    if (!ogImgOk || !refreshOk || !ogW || !ogH || !twTitle || !twImage) {
+      throw new Error(
+        `[share] share HTML meta check failed. og:image:${ogImgOk} refresh:${refreshOk} ` +
+        `og:w:${ogW} og:h:${ogH} tw:title:${twTitle} tw:image:${twImage}`
+      );
     }
   } else if (resp.status() === 404) {
     // 当日の daily.yml がまだ走ってない手動実行ケースはスキップ

--- a/scripts/generate_share_page.js
+++ b/scripts/generate_share_page.js
@@ -105,13 +105,20 @@ function jstDateString(d = new Date()) {
   <title>${ogTitle}</title>
   <meta name="robots" content="index,follow">
   <link rel="canonical" href="${appUrl}">
+  <meta property="og:locale" content="ja_JP">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="VGM Quiz">
   <meta property="og:title" content="${ogTitle}">
   <meta property="og:description" content="${ogDesc}">
   <meta property="og:image" content="${ogpUrlWithV}">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
   <meta property="og:url" content="${pageUrl}">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="${ogTitle}">
+  <meta name="twitter:description" content="${ogDesc}">
+  <meta name="twitter:image" content="${ogpUrlWithV}">
+  <meta name="twitter:url" content="${pageUrl}">
   <meta http-equiv="refresh" content="0; url=${appUrl}">
   <!-- daily-hash:${dailyHash} -->
 </head>


### PR DESCRIPTION
## Summary
- expand share page with locale, Twitter card, and image size meta tags
- extend share E2E test to validate new meta tags
- document additional share page validations

## Testing
- ⚠️ `npm test` *(missing clojure: not found)*
- ⚠️ `APP_URL=http://127.0.0.1:8080/app/ node e2e/test_share.js` *(missing module 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68b3ec59dc0883248ac13f7341da825e