### PR TITLE
feat(daily): add index & latest generator

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -82,6 +82,11 @@ jobs:
           node scripts/generate_share_page.js
           ls -lah public/daily || true
 
+      - name: Generate Daily index & latest
+        run: |
+          node scripts/generate_daily_index.js
+          ls -lah public/daily || true
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 ### Share page
 - 毎日の共有用静的ページ: `public/daily/YYYY-MM-DD.html`
 - そのURLをSNSに貼ると、上記 OGP 画像のプレビューとともに **`/app/?daily=YYYY-MM-DD`** へ自動リダイレクトします。
+- 一覧: `/daily/index.html`（過去分のリンク集）
+- 常に当日: `/daily/latest.html`（メタリフレッシュで当日の share page へ）
 
   A small quiz app for video game music. Runs on GitHub Pages.
 

--- a/e2e/test_share.js
+++ b/e2e/test_share.js
@@ -14,6 +14,7 @@ function jstISO() {
   const appUrl = `${APP_URL}?daily=${date}&test=1&autostart=0`;
   const publicBase = APP_URL.replace(/\/app\/?.*$/, '');
   const shareUrl = `${publicBase}/daily/${date}.html`;
+  const latestUrl = `${publicBase}/daily/latest.html`;
   const sharePatchUrl = `${publicBase}/app/share_patch.js`;
 
   const browser = await chromium.launch();
@@ -73,6 +74,18 @@ function jstISO() {
     console.warn(`[share] share page 404 (ok for manual runs before daily). url=${shareUrl}`);
   } else {
     throw new Error(`[share] unexpected HTTP ${resp.status()} for ${shareUrl}`);
+  }
+
+  // 4) latest.html は常に当日へ meta refresh（手動でも生成される想定）
+  const respLatest = await page.request.get(latestUrl);
+  if (respLatest.status() === 200) {
+    const html = await respLatest.text();
+    const refreshToday = new RegExp(`http-equiv=["']refresh["'][^>]+url=\\./${date}\\.html`).test(html);
+    if (!refreshToday) {
+      throw new Error(`[share] latest.html does not redirect to today (${date})`);
+    }
+  } else {
+    console.warn(`[share] latest.html HTTP ${respLatest.status()} (unexpected); url=${latestUrl}`);
   }
 
   // 3) ?daily=1 でも同様に当日(JST)のURLがコピーされる

--- a/scripts/generate_daily_index.js
+++ b/scripts/generate_daily_index.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function jstISO(d = new Date()) {
+  const fmt = new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Tokyo', year: 'numeric', month: '2-digit', day: '2-digit' });
+  const p = Object.fromEntries(fmt.formatToParts(d).map(x => [x.type, x.value]));
+  return `${p.year}-${p.month}-${p.day}`;
+}
+
+(async () => {
+  const root = process.cwd();
+  const outDir = path.join(root, 'public', 'daily');
+  fs.mkdirSync(outDir, { recursive: true });
+
+  // 既存の daily/*.html を列挙
+  const files = fs.readdirSync(outDir)
+    .filter(f => /^\d{4}-\d{2}-\d{2}\.html$/.test(f))
+    .map(f => f.replace(/\.html$/, ''));
+  files.sort((a,b) => a < b ? 1 : (a > b ? -1 : 0)); // 降順
+
+  const today = jstISO();
+  const mkIndex = () => `<!doctype html>
+<html lang="ja"><head>
+  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>VGM Quiz — Daily index</title>
+  <meta name="robots" content="index,follow">
+  <link rel="canonical" href="./index.html">
+  <style>
+    body{font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial;margin:24px;line-height:1.6;}
+    h1{font-size:20px;margin:0 0 12px} ul{padding-left:18px;margin:0}
+    li{margin:4px 0} a{color:#0366d6;text-decoration:none} a:hover{text-decoration:underline}
+    .meta{opacity:.7;font-size:12px;margin:6px 0 16px}
+  </style>
+</head><body>
+  <h1>VGM Quiz — Daily index</h1>
+  <div class="meta">today: ${today} / count: ${files.length}</div>
+  <ul>
+    ${files.map(d => `<li><a href="./${d}.html">${d}</a></li>`).join('\n    ')}
+  </ul>
+</body></html>`;
+
+  const mkLatest = (d) => `<!doctype html>
+<html lang="ja"><head>
+  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>VGM Quiz — Daily latest</title>
+  <meta http-equiv="refresh" content="0; url=./${d}.html">
+</head><body>
+  <p>Redirecting to <a href="./${d}.html">${d}</a> …</p>
+</body></html>`;
+
+  fs.writeFileSync(path.join(outDir, 'index.html'), mkIndex());
+  fs.writeFileSync(path.join(outDir, 'latest.html'), mkLatest(today));
+  console.log(`daily index generated: ${files.length} items, latest -> ${today}`);
+})();


### PR DESCRIPTION
## Summary
- add generator script for daily index and latest redirects
- extend daily workflow to produce index and latest
- check latest daily redirect in E2E share test
- document daily index and latest pages in README

## Testing
- `npm test` *(fails: clojure: not found)*
- `APP_URL=http://127.0.0.1:8080/app/ node e2e/test_share.js` *(fails: Cannot find module 'playwright'; package install 403)*


------
https://chatgpt.com/codex/tasks/task_e_68b3f15cdc14832492b4640758fcfc8f