### PR TITLE
Add daily smoke test and Pages nojekyll step

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -88,6 +88,9 @@ jobs:
 
       # Contract checks have moved to CI Fast; this workflow handles deploy only.
 
+      - name: Ensure .nojekyll
+        run: |
+          touch public/.nojekyll
       - name: Upload artifact (entire public)
         uses: actions/upload-pages-artifact@v3
         with:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "test": "clojure -M:test",
     "e2e": "node e2e/test.js",
-    "smoke": "node scripts/smoke-html.js"
+    "smoke": "node scripts/smoke-html.js && node scripts/smoke-daily.js"
   },
   "devDependencies": {
     "cheerio": "1.0.0"

--- a/scripts/smoke-daily.js
+++ b/scripts/smoke-daily.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = process.cwd();
+const dailyDir = path.join(repoRoot, 'public', 'daily');
+
+if (!fs.existsSync(dailyDir)) {
+  console.error('Missing directory: public/daily');
+  process.exit(1);
+}
+
+const must = ['index.html', 'latest.html'];
+for (const f of must) {
+  const p = path.join(dailyDir, f);
+  if (!fs.existsSync(p)) {
+    console.error('Missing file: ' + path.relative(repoRoot, p));
+    process.exit(1);
+  }
+}
+
+const days = (fs.readdirSync(dailyDir).filter(f => /^\d{4}-\d{2}-\d{2}\.html$/.test(f))).sort();
+if (days.length === 0) {
+  console.error('No daily pages found (public/daily/YYYY-MM-DD.html)');
+  process.exit(1);
+}
+
+console.log('Daily pages OK. Count=', days.length, 'Example=', days.slice(-3).join(', '));


### PR DESCRIPTION
## Summary
- add smoke-daily.js to verify daily HTML pages exist
- extend `npm run smoke` to include daily check
- ensure GitHub Pages deploy includes a `.nojekyll` file

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cheerio)*
- `npm test` *(fails: sh: 1: clojure: not found)*
- `npm run smoke` *(fails: Cannot find module 'cheerio')*
- `node scripts/smoke-daily.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3fa842f048324941c471bae12af1b