### PR TITLE
feat(daily): add per-day type for OGP

### DIFF
--- a/public/app/daily.json
+++ b/public/app/daily.json
@@ -3,13 +3,16 @@
   "tz": "Asia/Tokyo",
   "map": {
     "2000-01-01": {
-      "title": "Stickerbrush Symphony"
+      "title": "Stickerbrush Symphony",
+      "type": "title→game"
     },
     "2025-08-30": {
-      "title": "Stickerbrush Symphony"
+      "title": "Stickerbrush Symphony",
+      "type": "title→game"
     },
     "2025-08-31": {
-      "title": "Megalovania"
+      "title": "Megalovania",
+      "type": "title→game"
     }
   },
   "ogp": {}

--- a/scripts/generate_daily.js
+++ b/scripts/generate_daily.js
@@ -19,6 +19,9 @@ const path = require('path');
 const DATASET_URL = process.env.DATASET_URL || 'https://nantes-rfli.github.io/vgm-quiz/build/dataset.json';
 const OUTPUT_PATH = process.env.OUTPUT_PATH || path.join('public', 'app', 'daily.json');
 const AVOID_DAYS = parseInt(process.env.AVOID_DAYS || '30', 10);
+// Question type for the day's share/OGP. Defaults to title→game.
+// You can override via env DAILY_TYPE=game→composer (or title→composer).
+const DEFAULT_TYPE = process.env.DAILY_TYPE || 'title→game';
 
 function todayJST() {
   try {
@@ -160,7 +163,8 @@ function daysBetween(a, b) {
   }
 
   // 5) Update map and write file
-  daily.map[DATE] = { title };
+  // Keep backward compatibility: include title and new type field.
+  daily.map[DATE] = { title, type: DEFAULT_TYPE };
 
   // Ensure directory exists
   const dir = path.dirname(OUTPUT_PATH);

--- a/scripts/generate_ogp.js
+++ b/scripts/generate_ogp.js
@@ -3,6 +3,29 @@ const fs = require('fs');
 const path = require('path');
 const { chromium } = require('playwright');
 
+// Prefer daily.json.type; fallback to env OGP_SUBTITLE for backward compatibility.
+const OGP_SUBTITLE_ENV = process.env.OGP_SUBTITLE;
+
+function loadDailyMap() {
+  const p = path.join(__dirname, '..', 'public', 'app', 'daily.json');
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8')).map || {};
+  } catch (_) {
+    return {};
+  }
+}
+
+function typeToSubtitle(t) {
+  switch (t) {
+    case 'title→game': return 'Title → Game';
+    case 'game→composer': return 'Game → Composer';
+    case 'title→composer': return 'Title → Composer';
+    default: return OGP_SUBTITLE_ENV || 'Title → Game';
+  }
+}
+
+const DAILY_MAP = loadDailyMap();
+
 function jstDateString(d = new Date()) {
   // en-CA は ISO っぽい 4桁年-2桁月-2桁日 を返す
   const fmt = new Intl.DateTimeFormat('en-CA', {
@@ -18,59 +41,6 @@ function jstDateString(d = new Date()) {
   return `${parts.year}-${parts.month}-${parts.day}`;
 }
 
-function deriveTypeLabel(daily) {
-  // まずは素直に代表的なキーを参照
-  const candidates = [
-    daily?.question?.type, daily?.type, daily?.mode,
-    daily?.q?.type, daily?.meta?.type, daily?.questionType,
-  ].filter(v => typeof v === 'string' && v.trim().length);
-  let raw = candidates[0] || null;
-  // 正規化判定（よくある表記ゆれを吸収）
-  const norm = s => String(s).toLowerCase().replace(/[\s_-]+/g,'');
-  const decide = (s) => {
-    const n = norm(s);
-    if (/^(title|song|track).*game/.test(n)) return 'title→game';
-    if (/^game.*composer/.test(n)) return 'game→composer';
-    if (/^(title|song|track).*composer/.test(n)) return 'title→composer';
-    return null;
-  };
-  let label = raw && decide(raw);
-  if (label) return label;
-  // ネストをざっくり探索（from/to式や ask/answer式があれば拾う）
-  const hint = (x) => {
-    const v = String(x || '').toLowerCase();
-    if (['title','song','track','name'].includes(v)) return 'title';
-    if (['game','series'].includes(v)) return 'game';
-    if (['composer','artist'].includes(v)) return 'composer';
-    return null;
-  };
-  const dfs = (obj, depth=0) => {
-    if (!obj || typeof obj !== 'object' || depth > 3) return null;
-    let from = null, to = null;
-    for (const [k,v] of Object.entries(obj)) {
-      if (typeof v === 'string') {
-        if (!from) from = hint(v);
-        if (!to) to = hint(v);
-      } else if (typeof v === 'object') {
-        const r = dfs(v, depth+1);
-        if (r) return r;
-      }
-      // key 名が from/to/ask/answer ぽい場合
-      if (typeof v === 'string' && /^(from|ask)$/i.test(k)) from = hint(v) || from;
-      if (typeof v === 'string' && /^(to|answer)$/i.test(k)) to = hint(v) || to;
-      if (from && to) break;
-    }
-    if (from && to) {
-      if (from==='title' && to==='game') return 'title→game';
-      if (from==='game'  && to==='composer') return 'game→composer';
-      if (from==='title' && to==='composer') return 'title→composer';
-    }
-    return null;
-  };
-  label = dfs(daily);
-  return label || null;
-}
-
 (async () => {
   // DAILY_DATE が未指定なら JST の ISO 文字列を採用
   const date = process.env.DAILY_DATE && /^\d{4}-\d{2}-\d{2}$/.test(process.env.DAILY_DATE)
@@ -80,15 +50,8 @@ function deriveTypeLabel(daily) {
   const outDir = path.join(repoRoot, 'public', 'ogp');
   fs.mkdirSync(outDir, { recursive: true });
 
-  // サブタイトル優先順位: 環境変数 OGP_SUBTITLE > daily.json の ogp.subtitle > 推定 > 既定
-  let subtitle = process.env.OGP_SUBTITLE || 'Daily Question';
-  try {
-    const dailyJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'public', 'app', 'daily.json'), 'utf8'));
-    if (!process.env.OGP_SUBTITLE) {
-      const label = dailyJson?.ogp?.subtitle || deriveTypeLabel(dailyJson);
-      if (label) subtitle = label;
-    }
-  } catch (_) { /* noop */ }
+  const chosenType = (DAILY_MAP[date] && DAILY_MAP[date].type) || OGP_SUBTITLE_ENV || 'title→game';
+  const subtitle = typeToSubtitle(chosenType);
 
   const fileUrl = 'file://' + path.join(repoRoot, 'tools', 'ogp', 'daily.html');
   const url = `${fileUrl}?date=${encodeURIComponent(date)}&subtitle=${encodeURIComponent(subtitle)}`;

--- a/scripts/generate_share_page.js
+++ b/scripts/generate_share_page.js
@@ -3,6 +3,29 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 
+// Prefer daily.json.type; fallback to env OGP_SUBTITLE for backward compatibility.
+const OGP_SUBTITLE_ENV = process.env.OGP_SUBTITLE;
+
+function loadDailyMap() {
+  const p = path.join(__dirname, '..', 'public', 'app', 'daily.json');
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8')).map || {};
+  } catch (_) {
+    return {};
+  }
+}
+
+function typeToSubtitle(t) {
+  switch (t) {
+    case 'title→game': return 'Title → Game';
+    case 'game→composer': return 'Game → Composer';
+    case 'title→composer': return 'Title → Composer';
+    default: return OGP_SUBTITLE_ENV || 'Title → Game';
+  }
+}
+
+const DAILY_MAP = loadDailyMap();
+
 function jstDateString(d = new Date()) {
   const fmt = new Intl.DateTimeFormat('en-CA', {
     timeZone: 'Asia/Tokyo',
@@ -14,57 +37,6 @@ function jstDateString(d = new Date()) {
   }, {});
   return `${parts.year}-${parts.month}-${parts.day}`;
 }
-
-(function attachHelpers(){
-  // daily.json からタイプを推定（generate_ogp.js と同ロジックの軽量版）
-  function deriveTypeLabel(daily) {
-    const candidates = [
-      daily?.question?.type, daily?.type, daily?.mode,
-      daily?.q?.type, daily?.meta?.type, daily?.questionType,
-    ].filter(v => typeof v === 'string' && v.trim().length);
-    const norm = s => String(s).toLowerCase().replace(/[\s_-]+/g,'');
-    const decide = (s) => {
-      const n = norm(s);
-      if (/^(title|song|track).*game/.test(n)) return 'title→game';
-      if (/^game.*composer/.test(n)) return 'game→composer';
-      if (/^(title|song|track).*composer/.test(n)) return 'title→composer';
-      return null;
-    };
-    let label = (candidates[0] && decide(candidates[0])) || null;
-    if (label) return label;
-    const hint = (x) => {
-      const v = String(x || '').toLowerCase();
-      if (['title','song','track','name'].includes(v)) return 'title';
-      if (['game','series'].includes(v)) return 'game';
-      if (['composer','artist'].includes(v)) return 'composer';
-      return null;
-    };
-    const dfs = (obj, depth=0) => {
-      if (!obj || typeof obj !== 'object' || depth > 3) return null;
-      let from = null, to = null;
-      for (const [k,v] of Object.entries(obj)) {
-        if (typeof v === 'string') {
-          if (!from) from = hint(v);
-          if (!to) to = hint(v);
-        } else if (typeof v === 'object') {
-          const r = dfs(v, depth+1);
-          if (r) return r;
-        }
-        if (typeof v === 'string' && /^(from|ask)$/i.test(k)) from = hint(v) || from;
-        if (typeof v === 'string' && /^(to|answer)$/i.test(k)) to = hint(v) || to;
-        if (from && to) break;
-      }
-      if (from && to) {
-        if (from==='title' && to==='game') return 'title→game';
-        if (from==='game'  && to==='composer') return 'game→composer';
-        if (from==='title' && to==='composer') return 'title→composer';
-      }
-      return null;
-    };
-    return dfs(daily) || null;
-  }
-  module.exports = { deriveTypeLabel };
-})();
 
 (async () => {
   const date = process.env.DAILY_DATE && /^\d{4}-\d{2}-\d{2}$/.test(process.env.DAILY_DATE)
@@ -85,17 +57,10 @@ function jstDateString(d = new Date()) {
     dailyHash = crypto.createHash('sha1').update(buf).digest('hex').slice(0, 12);
   } catch (_) { /* noop */ }
   const ogpUrlWithV = dailyHash ? `${ogpUrl}?v=${dailyHash}` : ogpUrl;
-  // サブタイトル優先順位: 環境変数 OGP_SUBTITLE > daily.json 推定 > 空
-  let typeLabel = process.env.OGP_SUBTITLE || '';
-  try {
-    if (!process.env.OGP_SUBTITLE) {
-      const dailyJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'public', 'app', 'daily.json'), 'utf8'));
-      const { deriveTypeLabel } = module.exports;
-      typeLabel = deriveTypeLabel(dailyJson) || '';
-    }
-  } catch (_) { /* noop */ }
-  const ogTitle = typeLabel ? `VGM Quiz — Daily ${date} — ${typeLabel}` : `VGM Quiz — Daily ${date}`;
-  const ogDesc  = typeLabel ? `1日1問のVGMクイズ（${typeLabel}）。今日の問題に挑戦！` : `1日1問のVGMクイズ。今日の問題に挑戦！`;
+  const chosenType = (DAILY_MAP[date] && DAILY_MAP[date].type) || OGP_SUBTITLE_ENV || 'title→game';
+  const subtitle = typeToSubtitle(chosenType);
+  const ogTitle = `VGM Quiz — Daily ${date} — ${subtitle}`;
+  const ogDesc  = `1日1問のVGMクイズ（${subtitle}）。今日の問題に挑戦！`;
 
   const html = `<!doctype html>
 <html lang="en">

--- a/scripts/smoke-daily.js
+++ b/scripts/smoke-daily.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 const repoRoot = process.cwd();
 const dailyDir = path.join(repoRoot, 'public', 'daily');
+const appDailyJson = path.join(repoRoot, 'public', 'app', 'daily.json');
 
 if (!fs.existsSync(dailyDir)) {
   console.error('Missing directory: public/daily');
@@ -23,6 +24,20 @@ const days = (fs.readdirSync(dailyDir).filter(f => /^\d{4}-\d{2}-\d{2}\.html$/.t
 if (days.length === 0) {
   console.error('No daily pages found (public/daily/YYYY-MM-DD.html)');
   process.exit(1);
+}
+
+let missingType = 0;
+try {
+  const dailyJson = JSON.parse(fs.readFileSync(appDailyJson, 'utf8'));
+  const map = dailyJson && typeof dailyJson === 'object' ? (dailyJson.map || dailyJson) : {};
+  for (const [d, v] of Object.entries(map)) {
+    if (!v || typeof v.type !== 'string') missingType++;
+  }
+} catch (e) {
+  console.warn('[smoke-daily] WARN: cannot parse daily.json: ' + e.message);
+}
+if (missingType > 0) {
+  console.warn(`[smoke-daily] WARN: ${missingType} entries in daily.json have no 'type'. (Will default to 'title→game')`);
 }
 
 console.log('Daily pages OK. Count=', days.length, 'Example=', days.slice(-3).join(', '));


### PR DESCRIPTION
## Summary
- record quiz type with each day in `daily.json`
- generate share page and OGP image subtitles from stored type or env fallback
- warn when daily entries are missing `type`

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository InRelease is not signed)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b3fc608bd48324895c3c9b3b140022