### PR TITLE
feat: add daily feed generation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -52,6 +52,11 @@ jobs:
         with:
           cli: latest
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Clean
         run: clojure -T:build clean || true
 
@@ -91,6 +96,19 @@ jobs:
       - name: Ensure .nojekyll
         run: |
           touch public/.nojekyll
+
+      - name: Generate daily index (idempotent)
+        run: |
+          if [ -f scripts/generate_daily_index.js ]; then
+            node scripts/generate_daily_index.js
+          fi
+
+      - name: Generate daily RSS feed (idempotent)
+        run: |
+          if [ -f scripts/generate_daily_feed.js ]; then
+            node scripts/generate_daily_feed.js
+          fi
+
       - name: Upload artifact (entire public)
         uses: actions/upload-pages-artifact@v3
         with:

--- a/scripts/generate_daily_index.js
+++ b/scripts/generate_daily_index.js
@@ -26,6 +26,7 @@ function jstISO(d = new Date()) {
   <title>VGM Quiz — Daily index</title>
   <meta name="robots" content="index,follow">
   <link rel="canonical" href="./index.html">
+  <link rel="alternate" type="application/rss+xml" title="VGM Quiz — Daily" href="./feed.xml">
   <style>
     body{font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial;margin:24px;line-height:1.6;}
     h1{font-size:20px;margin:0 0 12px} ul{padding-left:18px;margin:0}
@@ -34,6 +35,7 @@ function jstISO(d = new Date()) {
   </style>
 </head><body>
   <h1>VGM Quiz — Daily index</h1>
+  <p><a href="./feed.xml">RSSフィード</a>（購読できます）</p>
   <div class="meta">today: ${today} / count: ${files.length}</div>
   <ul>
     ${files.map(d => `<li><a href="./${d}.html">${d}</a></li>`).join('\n    ')}


### PR DESCRIPTION
## Summary
- generate daily index and RSS feed in pages workflow
- expose RSS feed link on daily index page

## Testing
- `npm test` *(fails: clojure: not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*
- `npm run smoke` *(fails: Cannot find module 'cheerio')*

------
https://chatgpt.com/codex/tasks/task_e_68b40322159c8324bf4c1113eb19e42b