### PR TITLE
Add mock normalization API and E2E tests

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [smoke, a11y, footer, share]
+        suite: [smoke, a11y, footer, share, normalize, lives]
     steps:
       - uses: actions/checkout@v4
 
@@ -57,6 +57,8 @@ jobs:
             a11y)   node e2e/test_free_aria.js ;;
             footer) node e2e/test_footer_version.js ;;
             share)  node e2e/test_share.js ;;
+            normalize) node e2e/test_normalize.js ;;
+            lives) node e2e/test_lives.js ;;
             *) echo "unknown suite"; exit 1 ;;
           esac
 

--- a/e2e/test_lives.js
+++ b/e2e/test_lives.js
@@ -1,0 +1,37 @@
+const { chromium } = require('playwright');
+
+async function run() {
+  const APP_URL = process.env.E2E_BASE_URL || process.env.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/';
+  const url = `${APP_URL}?test=1&mock=1&lives=3&autostart=0`;
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+
+  // Try to find an answer input in a generic way
+  const input = await page.locator('input[type="text"], input[role="textbox"], [contenteditable="true"]').first();
+  await input.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
+
+  // Submit 3 obviously wrong answers. We keep this generic to avoid tight UI coupling.
+  for (let i = 0; i < 3; i++) {
+    await input.fill(`totally-wrong-${i}`);
+    await page.keyboard.press('Enter');
+    // small delay for state update
+    await page.waitForTimeout(500);
+  }
+
+  // Expect a result modal or game-over indicator to exist after lives exhaust.
+  // We check for a dialog role or common game-over keywords.
+  const gotDialog = await page.locator('[role="dialog"]').first().isVisible().catch(() => false);
+  const bodyText = (await page.locator('body').innerText().catch(() => '')) || '';
+  if (!gotDialog && !/game over|結果|スコア|summary/i.test(bodyText)) {
+    throw new Error('lives test did not detect game-over state after 3 wrong answers');
+  }
+
+  await browser.close();
+  console.log('[E2E lives] PASS');
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/e2e/test_normalize.js
+++ b/e2e/test_normalize.js
@@ -1,0 +1,42 @@
+const { chromium } = require('playwright');
+
+async function run() {
+  const APP_URL = process.env.E2E_BASE_URL || process.env.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/';
+  const url = `${APP_URL}?test=1&mock=1&autostart=0`;
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+
+  // Wait for __testAPI to be ready
+  await page.waitForFunction(() => window.__testAPI && window.__testAPI.ready);
+
+  async function ok(a, b, msg) {
+    const match = await page.evaluate(([x, y]) => window.__testAPI.normalizeMatch(x, y), [a, b]);
+    if (!match) {
+      throw new Error(`normalize mismatch: ${msg} :: "${a}" vs "${b}"`);
+    }
+    console.log('[OK]', msg);
+  }
+
+  await ok('Ｍｅｇａｌｏｍａｎｉａ', 'Megalomania', 'NFKC fold full-width');
+  await ok('Pokemon', 'Pokémon', 'diacritics fold');
+  await ok('キングダムハーツ', 'キングダムハーツ', 'NFKC vs NFD combine');
+  await ok('Final Fantasy IV', 'Final Fantasy 4', 'Roman↔Arabic (1–20)');
+  await ok('The Legend of Zelda', 'Legend of Zelda', 'Articles ignored');
+  await ok('Baba & You', 'Baba and You', '& → and');
+  await ok('Chrono Trigger — Corridors of Time', 'Chrono Trigger Corridors of Time', 'punctuation/spaces/choonpu');
+
+  // Alias: if aliases map contains known pairs, try one generic probe.
+  // We can't depend on specific content, but we can validate that normalization runs without error and returns strings.
+  const norm = await page.evaluate(() => window.__testAPI.normalize('Megalovania'));
+  if (typeof norm !== 'string') throw new Error('normalize must return string');
+  console.log('[OK] normalize returns string');
+
+  await browser.close();
+  console.log('[E2E normalize] PASS');
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -10,6 +10,18 @@
 <link rel="manifest" href="manifest.webmanifest">
 <!-- ESM の事前解決は modulepreload を使う。credentials 警告回避に crossorigin を明示 -->
 <link rel="modulepreload" href="app.js" crossorigin="anonymous">
+  <script>
+    // Conditionally load test API when ?mock=1
+    (function() {
+      var p = new URLSearchParams(location.search);
+      if (p.get("mock") === "1") {
+        var s = document.createElement("script");
+        s.src = "./mock_api.js";
+        s.defer = true;
+        document.head.appendChild(s);
+      }
+    })();
+  </script>
 <!-- Open Graph (optional but useful for previews) -->
 <meta property="og:title" content="VGM Quiz">
 <meta property="og:description" content="Play a fast, browser-based Video Game Music quiz with multiple modes and composers/titles matching.">

--- a/public/app/mock_api.js
+++ b/public/app/mock_api.js
@@ -1,0 +1,101 @@
+// Simple test API loaded only when ?mock=1 is in the URL.
+// Provides normalization consistent with spec v1.2 and alias loading.
+// Exposes window.__testAPI = { normalize, normalizeMatch, ready }.
+(() => {
+  try {
+    const params = new URLSearchParams(location.search);
+    if (params.get('mock') !== '1') return;
+  } catch (_) {
+    // no-op
+    return;
+  }
+
+  const aliasUrls = [
+    '/vgm-quiz/public/build/aliases.json', // GitHub Pages base path
+    '/vgm-quiz/public/app/aliases_local.json',
+    // Fallbacks for local runs (served from repo root or app/)
+    '/public/build/aliases.json',
+    '/public/app/aliases_local.json'
+  ];
+
+  const romanToArabic = Object.fromEntries([
+    [1,'I'],[2,'II'],[3,'III'],[4,'IV'],[5,'V'],[6,'VI'],[7,'VII'],[8,'VIII'],[9,'IX'],[10,'X'],
+    [11,'XI'],[12,'XII'],[13,'XIII'],[14,'XIV'],[15,'XV'],[16,'XVI'],[17,'XVII'],[18,'XVIII'],[19,'XIX'],[20,'XX']
+  ].map(([n,r]) => [r, String(n)]));
+
+  function nfkcLower(s) {
+    return s.normalize('NFKC').toLowerCase();
+  }
+
+  function stripPunctSpacesLongDash(s) {
+    // remove punctuation, spaces, and Japanese choonpu "ー"
+    return s.replace(/[\s\u3000\u30FC\-\u2010-\u2015_.,:;!?"'’‘“”\/\\(){}\[\]<>@#\$%^&~`+=|•··…]/g, '');
+  }
+
+  function andAmp(s) {
+    return s.replace(/\&/g, 'and');
+  }
+
+  function romanToArabicFold(s) {
+    // Replace standalone roman numerals I..XX to arabic 1..20
+    return s.replace(/\b(?:X|IX|IV|V|I|VI|VII|VIII|XI|XII|XIII|XIV|XV|XVI|XVII|XVIII|XIX|XX)\b/gi, (m) => {
+      const u = m.toUpperCase();
+      return romanToArabic[u] || m;
+    });
+  }
+
+  function dropArticles(s) {
+    return s.replace(/\b(the|a|an)\b/gi, '');
+  }
+
+  function normalizeCore(s) {
+    return stripPunctSpacesLongDash(andAmp(dropArticles(romanToArabicFold(nfkcLower(s)))));
+  }
+
+  async function loadAliases() {
+    const out = {};
+    for (const u of aliasUrls) {
+      try {
+        const res = await fetch(u, { cache: 'no-store' });
+        if (!res.ok) continue;
+        const m = await res.json();
+        for (const [k, arr] of Object.entries(m || {})) {
+          if (!out[k]) out[k] = new Set();
+          for (const v of arr) out[k].add(v);
+        }
+      } catch (_) {}
+    }
+    // Convert sets to arrays
+    const map = {};
+    for (const [k, set] of Object.entries(out)) map[k] = Array.from(set);
+    return map;
+  }
+
+  function normalizeWithAliases(s, aliasesMap) {
+    const base = normalizeCore(s);
+    // If base matches any alias key or value, fold to the key's normalized form.
+    // Build a normalized lookup.
+    const normMap = new Map(); // normalized string -> canonical normalized
+    for (const [canon, list] of Object.entries(aliasesMap || {})) {
+      const nCanon = normalizeCore(canon);
+      normMap.set(nCanon, nCanon);
+      for (const v of (list || [])) {
+        normMap.set(normalizeCore(v), nCanon);
+      }
+    }
+    if (normMap.has(base)) return normMap.get(base);
+    return base;
+  }
+
+  const ready = (async () => {
+    const aliases = await loadAliases();
+    function normalize(s) {
+      return normalizeWithAliases(String(s || ''), aliases);
+    }
+    function normalizeMatch(a, b) {
+      return normalize(a) === normalize(b);
+    }
+    window.__testAPI = { normalize, normalizeMatch, ready: Promise.resolve(true) };
+    return true;
+  })();
+})();


### PR DESCRIPTION
## Summary
- add mock API that normalizes text per spec and handles aliases when `?mock=1`
- load the mock API automatically during tests
- add Playwright E2E tests for normalization cases and lives exhaustion
- extend e2e workflow matrix to run new test suites

## Testing
- `npm test` *(fails: clojure not found)*
- `node e2e/test_normalize.js` *(fails: Cannot find module 'playwright')*
- `node e2e/test_lives.js` *(fails: Cannot find module 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68b40b47b93083249e16d1bff303d7e8