### PR TITLE
Normalize diacritics and start lives test generically

### DIFF
--- a/e2e/test_lives.js
+++ b/e2e/test_lives.js
@@ -7,9 +7,37 @@ async function run() {
   const page = await browser.newPage();
   await page.goto(url, { waitUntil: 'domcontentloaded' });
 
-  // Try to find an answer input in a generic way
-  const input = await page.locator('input[type="text"], input[role="textbox"], [contenteditable="true"]').first();
-  await input.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
+  // Ensure the quiz is started if there's a start screen
+  async function ensureStarted() {
+    // If input already visible, we're good
+    const maybeInput = page.locator('input[data-testid="answer"], input[type="text"], input[role="textbox"], [contenteditable="true"]').first();
+    if (await maybeInput.isVisible().catch(() => false)) return;
+
+    // Try to click a visible start-like button
+    const btns = page.locator('button, [role="button"]');
+    const n = await btns.count();
+    const re = /start|begin|play|go|quiz|開始|スタート|はじめる/i;
+    for (let i = 0; i < n; i++) {
+      const b = btns.nth(i);
+      if (!(await b.isVisible().catch(() => false))) continue;
+      const txt = (await b.innerText().catch(() => '')).trim();
+      if (re.test(txt)) {
+        await b.click().catch(() => {});
+        await page.waitForTimeout(400);
+        break;
+      }
+    }
+
+    // Fallback: press Enter to start
+    await page.keyboard.press('Enter').catch(() => {});
+    await page.waitForTimeout(400);
+  }
+
+  await ensureStarted();
+
+  // Try to find an answer input in a generic way (after starting)
+  const input = await page.locator('input[data-testid="answer"], input[type="text"], input[role="textbox"], [contenteditable="true"]').first();
+  await input.waitFor({ state: 'visible', timeout: 8000 });
 
   // Submit 3 obviously wrong answers. We keep this generic to avoid tight UI coupling.
   for (let i = 0; i < 3; i++) {

--- a/public/app/mock_api.js
+++ b/public/app/mock_api.js
@@ -23,8 +23,15 @@
     [11,'XI'],[12,'XII'],[13,'XIII'],[14,'XIV'],[15,'XV'],[16,'XVI'],[17,'XVII'],[18,'XVIII'],[19,'XIX'],[20,'XX']
   ].map(([n,r]) => [r, String(n)]));
 
+  function removeDiacritics(s) {
+    // Convert to NFKD and strip combining marks (accents/diacritics)
+    // \p{M} matches all marks; requires Unicode flag.
+    return s.normalize('NFKD').replace(/\p{M}+/gu, '');
+  }
+
   function nfkcLower(s) {
-    return s.normalize('NFKC').toLowerCase();
+    // Normalize to NFKC and lowercase first, then remove diacritics to fold "é" -> "e"
+    return removeDiacritics(s.normalize('NFKC').toLowerCase());
   }
 
   function stripPunctSpacesLongDash(s) {


### PR DESCRIPTION
## Summary
- Normalize input by stripping diacritics after NFKC lowercasing in mock API
- Improve lives E2E test to auto-start quiz and locate answer input reliably

## Testing
- `npm test` *(fails: clojure: not found)*
- `node e2e/test_lives.js` *(fails: Cannot find module 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68b40e1f0f1c8324b9b16386984599a0