### PR TITLE
feat: add service worker update banner

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -22,6 +22,7 @@
       }
     })();
   </script>
+  <script defer src="./sw_update.js"></script>
 <!-- Open Graph (optional but useful for previews) -->
 <meta property="og:title" content="VGM Quiz">
 <meta property="og:description" content="Play a fast, browser-based Video Game Music quiz with multiple modes and composers/titles matching.">

--- a/public/app/sw.js
+++ b/public/app/sw.js
@@ -3,6 +3,26 @@
 self.__APP_VERSION__ = new URL(self.location).searchParams.get('v');
 const CACHE_NAME = 'vgm-quiz-' + (self.__APP_VERSION__ || 'dev');
 
+// Accept client message to activate a waiting SW immediately.
+self.addEventListener('message', (event) => {
+  try {
+    const data = event && event.data;
+    const isSkip =
+      data === 'SKIP_WAITING' ||
+      (data && typeof data === 'object' && data.type === 'SKIP_WAITING');
+    if (isSkip && self && self.skipWaiting) {
+      event.waitUntil(self.skipWaiting());
+    }
+  } catch (e) {
+    // ignore
+  }
+});
+
+// Ensure clients are controlled ASAP after activation.
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients && self.clients.claim ? self.clients.claim() : Promise.resolve());
+});
+
 let VERMETA_URL = undefined; // app側から受け取る最優先URL
 
 // app から version.json の絶対URLを受け取る

--- a/public/app/sw_update.js
+++ b/public/app/sw_update.js
@@ -1,0 +1,117 @@
+// SW update notifier & reload helper (progressive enhancement).
+// Shows a small bottom banner when a new version is available.
+// Accessible: role="status" aria-live="polite".
+(function () {
+  if (!('serviceWorker' in navigator)) return;
+
+  function createBanner(reg) {
+    const id = 'sw-update-banner';
+    if (document.getElementById(id)) return null;
+
+    const bar = document.createElement('div');
+    bar.id = id;
+    bar.setAttribute('role', 'status');
+    bar.setAttribute('aria-live', 'polite');
+    bar.setAttribute('data-testid', 'sw-update-banner');
+    Object.assign(bar.style, {
+      position: 'fixed',
+      left: '16px',
+      right: '16px',
+      bottom: '16px',
+      zIndex: 9999,
+      background: 'rgba(20,20,20,0.92)',
+      color: '#fff',
+      borderRadius: '12px',
+      padding: '12px 16px',
+      boxShadow: '0 8px 20px rgba(0,0,0,0.25)',
+      display: 'flex',
+      alignItems: 'center',
+      gap: '12px',
+      fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, Noto Sans JP, Helvetica, Arial',
+      fontSize: '14px'
+    });
+
+    const msg = document.createElement('div');
+    msg.textContent = '新しいバージョンが利用可能です。更新しますか？';
+    msg.style.flex = '1';
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = '更新';
+    btn.setAttribute('data-testid', 'sw-update-reload');
+    Object.assign(btn.style, {
+      appearance: 'none',
+      background: '#10b981', // teal-500
+      color: '#081c15',
+      border: 'none',
+      borderRadius: '10px',
+      padding: '8px 12px',
+      fontWeight: '600',
+      cursor: 'pointer'
+    });
+
+    btn.addEventListener('click', async () => {
+      try {
+        // Ask SW to skip waiting if possible, then reload on controller change.
+        if (reg && reg.waiting) {
+          reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+        }
+      } catch (_) {}
+      // If controller changes, the new SW has taken control.
+      let reloaded = false;
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        if (reloaded) return;
+        reloaded = true;
+        location.reload();
+      });
+      // Fallback: reload anyway after short delay
+      setTimeout(() => { if (!reloaded) location.reload(); }, 1500);
+    });
+
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.textContent = '後で';
+    Object.assign(close.style, {
+      appearance: 'none',
+      background: 'transparent',
+      color: '#d1d5db',
+      border: '1px solid #374151',
+      borderRadius: '10px',
+      padding: '8px 12px',
+      cursor: 'pointer'
+    });
+    close.addEventListener('click', () => bar.remove());
+
+    bar.append(msg, btn, close);
+    document.body.appendChild(bar);
+    return bar;
+  }
+
+  function listenOnRegistration(reg) {
+    if (!reg) return;
+    // If already waiting, show banner immediately.
+    if (reg.waiting) createBanner(reg);
+
+    reg.addEventListener('updatefound', () => {
+      const sw = reg.installing;
+      if (!sw) return;
+      sw.addEventListener('statechange', () => {
+        // New SW installed and waiting to activate (there is an existing controller)
+        if (sw.state === 'installed' && navigator.serviceWorker.controller) {
+          createBanner(reg);
+        }
+      });
+    });
+
+    // Periodic manual check (does nothing harmful if SW handles polling)
+    setInterval(() => reg.update().catch(() => {}), 60 * 1000);
+  }
+
+  // Attach to any current registration
+  navigator.serviceWorker.getRegistration().then(listenOnRegistration).catch(() => {});
+  // Also watch future registrations
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    // No-op here; reload is handled on button click path.
+  });
+})();
+


### PR DESCRIPTION
## Summary
- show update notification banner when a new service worker is available
- allow service worker to skip waiting and take control immediately

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b412ddbaf08324bcd2015922f720c7