### PR TITLE
docs: refresh workflows and daily feed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,20 @@
   <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/ci-fast.yml">
     <img alt="CI Fast (main)" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/ci-fast.yml/badge.svg?branch=main">
   </a>
+  <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/ci-fast-pr.yml">
+    <img alt="CI Fast (PR)" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/ci-fast-pr.yml/badge.svg">
+  </a>
   <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e-matrix.yml">
     <img alt="E2E (matrix)" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e-matrix.yml/badge.svg">
   </a>
   <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml">
     <img alt="Lighthouse (nightly)" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse.yml/badge.svg">
   </a>
+  <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/json-validate.yml">
+    <img alt="JSON Validate" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/json-validate.yml/badge.svg">
+  </a>
   <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/pages.yml">
-    <img alt="Pages (deploy on main)" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/pages.yml/badge.svg?branch=main">
+    <img alt="Pages" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/pages.yml/badge.svg?branch=main">
   </a>
 </p>
 
@@ -29,8 +35,11 @@
 
   A small quiz app for video game music. Runs on GitHub Pages.
 
-- **Live:** https://nantes-rfli.github.io/vgm-quiz/app/
-- **Repo:** https://github.com/nantes-rfli/vgm-quiz
+- Production: https://nantes-rfli.github.io/vgm-quiz/app/
+- Daily index: https://nantes-rfli.github.io/vgm-quiz/daily/index.html
+- Daily latest redirect: https://nantes-rfli.github.io/vgm-quiz/daily/latest.html
+- Daily RSS feed: https://nantes-rfli.github.io/vgm-quiz/daily/feed.xml
+- Repo: https://github.com/nantes-rfli/vgm-quiz
 
 ## Quick start (local)
 
@@ -42,104 +51,35 @@ npx http-server -p 8080 -c-1 .    # or any static server
 http://127.0.0.1:8080/app/?test=1&mock=1&autostart=0
 ```
 
-## Core features
+## Features
 
-- Quiz modes: Multiple Choice / Free-form; types: **title→game / game→composer / title→composer**
-- Deterministic ordering: **seeded RNG** (`?seed=abc`) + **year-bucket pipeline** (`?qp=1`)
-- HUD & A11y: lives HUD (`Misses: x/y`), score bar (role=progressbar), timer (`aria-live="polite"`), focus management
-- Results modal: **accessible dialog** (initial focus, Tab trap, Escape to close), **share** & **copy** (toast auto disappears in ~2s)
-- Media preview: **YouTube** (nocookie first → fallback domain / "Open in YouTube" link); fully **stubbed in tests** (`?test=1` / `?lhci=1` / `?nomedia=1`)
-- Daily: **1‑question daily** via `?daily=1` (JST) or `?daily=YYYY-MM-DD` (map in `public/app/daily.json`)
-- Lives rule (optional): `?lives=on` (or `?lives=5`) → **on reaching limit, finish immediately** (default is display‑only)
+ - Quiz modes: Multiple Choice / Free-form; types: **title→game / game→composer / title→composer**
+ - Deterministic ordering: **seeded RNG** (`?seed=abc`) + **year-bucket pipeline** (`?qp=1`)
+ - HUD & A11y: lives HUD (`Misses: x/y`), score bar (role="progressbar"), timer (`aria-live="polite"`), focus management
+ - Results modal: **accessible dialog** (initial focus, Tab trap, Escape to close), **share** & **copy** (toast auto disappears in ~2s)
+ - Media: **YouTube** (nocookie first → fallback domain / "Open in YouTube" link); fully **stubbed in tests** (`?test=1` / `?lhci=1` / `?nomedia=1`)
+ - Daily: **1-question daily** via `?daily=1` (JST) or `?daily=YYYY-MM-DD` (map in `public/app/daily.json`)
+ - Lives rule (optional): `?lives=on` (or `?lives=5`) → **on reaching limit, finish immediately** (default is display-only)
+ - Answer normalization v1.2: NFKC + lowercase, **diacritics folding**, ignore punctuation/long sound mark/spaces, Roman↔Arabic (1–20), ignore articles, `&→and`, alias dictionary
+ - **Daily feed**: static RSS (`/daily/feed.xml`) generated from `public/app/daily.json`
+ - **SW update banner**: in-app banner (accessible) prompts reload; `skipWaiting → controllerchange → reload`
 
-## Ops runbook
+## CI & Workflows
 
-### Useful URLs
-- Normal: `/app/`
-- Test (no SW registration): `/app/?test=1`
-- Mock dataset: `/app/?test=1&mock=1`
-- Deterministic: `/app/?test=1&seed=demo`
-- Year-bucket pipeline: add `&qp=1`
-- Daily (today JST): add `&daily=1` (or `&daily=YYYY-MM-DD`)
-- Disable media embeds: `&nomedia=1`
-- Lighthouse audit: `/app/?test=1&lhci=1`
+See [docs/ci.md](./docs/ci.md) for full details.
 
-### Footer (version)
-Footer shows: **`Dataset: vN • commit: abcdefg • updated: YYYY-MM-DD HH:mm`** (local time).
-`loadVersion()` uses **8s timeout, in‑flight sharing, 60s TTL** to avoid redundant fetches.
+- `ci-fast.yml` (main) / `ci-fast-pr.yml` (PR)
+- `e2e-matrix.yml` (smoke/a11y/footer/share/**normalize**/**lives**)
+- `lighthouse.yml` (nightly desktop, `?test=1&lhci=1` stubs)
+- `json-validate.yml` (daily/aliases/dataset lightweight validation)
+- `pages.yml` (deploy `public/`) / `pages-pr-build.yml` (PR shim)
+- `daily.yml` (00:00 JST bot PR)
 
-#### Debug helpers
-- `window.__rng` / `window.__SEED__` – seeded RNG (function) / seed string
-- `window.__questionIds` – string of track IDs/titles (when `?test=1`)
-- `window.__questionDebug` – array of `{{ title, year, type }}` (when `?test=1`)
-- `window.loadVersionPublic()` – non‑force refresh (TTL/in‑flight適用)
-- `window.loadVersionForce()` – force refresh (即取得)
-- `window.versionDebug.stats()` / `.clear()` – TTLキャッシュの確認/クリア
+## Data pipeline
 
-### Service Worker
-- SW polls `version.json` ~every 60s to notify updates.
-- **Handshake:** app sends the absolute `version.json` URL to SW at startup; SW uses it (prevents 404 on scoped paths).
+See [docs/pipeline.md](./docs/pipeline.md).
 
-### Query flags (summary)
-`test, mock, seed, qp, daily, autostart, lhci, nomedia, lives`
+## Operations
 
-| Flag | Example | Purpose |
-|---|---|---|
-| `test` | `?test=1` | No SW registration; expose debug vars; stub media |
-| `mock` | `?mock=1` | Use mock dataset for fast/dev checks |
-| `seed` | `?seed=alpha` | Deterministic RNG |
-| `qp` | `?qp=1` | Enable year‑bucket order pipeline |
-| `daily` | `?daily=1` / `?daily=2000-01-01` | 1‑question daily mode (JST or fixed date) |
-| `autostart` | `?autostart=0` | Require manual Start |
-| `lhci` | `?lhci=1` | Stub media for Lighthouse |
-| `nomedia` | `?nomedia=1` | Manually stub media |
-| `lives` | `?lives=on` / `?lives=5` | End immediately when misses reach limit |
-
-## Data & pipeline (overview)
-
-- Clojure/CLJC pipeline exports: `public/build/dataset.json`, `aliases.json`, `version.json`.
-- Aliases: app merges `../build/aliases.json` with optional `./aliases_local.json` (**local overrides** → easy PRs).
-
-## Development & tests
-
-### E2E (Playwright)
-We run in CI and locally. Local quick run:
-
-```bash
-node e2e/test.js
-node e2e/test_free_aria.js
-node e2e/test_footer_version.js
-node e2e/test_results_share.mjs
-node e2e/test_lives_visual.mjs
-node e2e/test_pipeline_flag.mjs
-node e2e/test_media_button.mjs
-node e2e/test_results_modal_a11y.mjs
-node e2e/test_lives_rule_end.mjs
-node e2e/test_normalize_cases.mjs   # Node-only assertions for normalize v1.2
-```
-
-### CI workflows (GitHub Actions)
-- `ci.yml` / `ci-fast.yml` – Clojure + JS basic tests
-- `e2e.yml` – Playwright end‑to‑end
-- `pages.yml` – auto deploy to Pages on `main`
-- `release.yml` – release
-- `lighthouse.yml` – nightly Lighthouse CI against production (`?test=1&lhci=1`)
-
-## Answer normalization v1.2
-
-- Base: NFKC + lower; ignore punctuation/elongation/whitespace; roman ↔ arabic numerals
-- **v1.2 adds:** leading English articles ignored (`the|a|an`), dash/hyphen normalization, `&/＆ → and`, stronger roman numeral handling (word‑boundary; I–XX).
-
-## License
-
-MIT
-
-## Documentation
-
-- [Ops Runbook](./docs/ops-runbook.md)
-- [Query Flags](./docs/flags.md)
-- [CI & E2E](./docs/ci.md)
-- [Data Pipeline](./docs/pipeline.md)
-- [Release & Deployment](./docs/release.md)
-- [Troubleshooting](./docs/troubleshooting.md)
-
+See [docs/ops-runbook.md](./docs/ops-runbook.md) and [docs/troubleshooting.md](./docs/troubleshooting.md).
+Admin guide for PAT/Rulesets/Pages is in [docs/github-admin.md](./docs/github-admin.md).

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -2,11 +2,14 @@
 
 ## Workflows
 
-- `ci.yml` / `ci-fast.yml` – Clojure + JS basics
-- `e2e.yml` – Playwright E2E suite
-- `pages.yml` – Deploy to GitHub Pages on `main`
-- `release.yml` – Release flow
-- `lighthouse.yml` – Nightly Lighthouse CI against production (`?test=1&lhci=1`)
+- **`ci-fast.yml`** – main branch: `clojure -T:build publish` → `clojure -M:test`
+- **`ci-fast-pr.yml`** – PR軽量チェック（Required: `ci-fast-pr-build`）
+- **`pages.yml`** – main への push / 手動で `public/` を GitHub Pages に配信（配信前に **daily index/RSS** を再生成）
+- **`pages-pr-build.yml`** – PR用 Pages シム（Required: `pages-pr-build`）
+- **`daily.yml`** – 00:00 JST に `public/app/daily.json` と `/daily/*.html` と `/daily/feed.xml` を含む **bot PR** を作成
+- **`e2e-matrix.yml`** – Playwright E2E（smoke / a11y / footer / share / **normalize** / **lives**）手動＋Nightly(JST 04:40)
+- **`lighthouse.yml`** – Nightly Lighthouse CI（`?test=1&lhci=1`、**budgets** + **asserts**）
+- **`json-validate.yml`** – `daily.json` / `aliases.json` / `dataset.json` の軽量バリデーション
 
 ## E2E Suite
 
@@ -14,96 +17,23 @@
 node e2e/test.js
 node e2e/test_free_aria.js
 node e2e/test_footer_version.js
-node e2e/test_results_share.mjs
-node e2e/test_lives_visual.mjs
-node e2e/test_pipeline_flag.mjs
-node e2e/test_media_button.mjs
-node e2e/test_results_modal_a11y.mjs
-node e2e/test_lives_rule_end.mjs
-node e2e/test_normalize_cases.mjs
+node e2e/test_share.js
+node e2e/test_normalize.js  # ?mock=1 の normalize API を直接検証
+node e2e/test_lives.js      # lives=on の汎用検証（入力/MCQ/Enter のフォールバック）
 ```
-
----
-
-## Current workflow set (clean baseline)
-
-- **CI Fast (PR)** — `.github/workflows/ci-fast-pr.yml`  
-  Event: `pull_request` (with `paths: ['**']`)  
-  Job name: **`ci-fast-pr-build`** (Required)
-- **Pages (PR shim)** — `.github/workflows/pages-pr-build.yml`  
-  Event: `pull_request`  
-  Job name: **`pages-pr-build`** (Required)
-- **CI Fast (main)** — `.github/workflows/ci-fast.yml`  
-  Event: `push: main`  
-  Job name: `ci-fast-main-build`  
-  **Runs `clojure -T:build publish` before tests** to render `public/build/dataset.json`.
-- **Pages (deploy)** — `.github/workflows/pages.yml`  
-  Event: `push: main` (never on PR)
-- **daily.json generator (JST)** — `.github/workflows/daily.yml`  
-  Creates PR with **PAT** (`DAILY_PR_PAT`) at 00:00 JST.
-- **E2E (nightly)** — `.github/workflows/e2e-nightly.yml` (optional)  
-  Heavy Playwright suites on a schedule or manual.
-- **Lighthouse (nightly)** — `.github/workflows/lighthouse.yml`
-
-### Required status checks
-
-Register **job names** in Rulesets (not display strings):
-
-- `pages-pr-build`
-- `ci-fast-pr-build`
-
-### Clojure tests need the dataset
-
-Tests read `public/build/dataset.json`.  
-On `main` CI, run before tests:
-
-```bash
-clojure -T:build publish
-clojure -M:test
-```
-
-### Guidelines
-
-- Prefer `pull_request` over `pull_request_target` unless absolutely necessary.
-- Give jobs stable, unique `name:` values; if you rename jobs, update Rulesets together.
-- Keep PR checks light; shift heavy suites to nightly or `workflow_dispatch`.
-
-## E2E（並列マトリクス版）
-
-### 目的
-- どの観点で落ちたか（smoke/a11y/footer）を **一発で特定**。
-- 並列化で **実行時間短縮**、失敗時は該当スイートだけログ確認。
-
-### ワークフロー
-- ファイル: `.github/workflows/e2e-matrix.yml`
-- トリガ: **manual (`workflow_dispatch`)** 導入 → 問題なければ夜間スケジュールへ移行可能。
-- マトリクス: `smoke`（`e2e/test.js`）、`a11y`（`e2e/test_free_aria.js`）、`footer`（`e2e/test_footer_version.js`）、`share`（`e2e/test_share.js`）
-`share` は:
-- アプリの共有ボタンでコピーされるURLが **`/daily/YYYY-MM-DD.html`** であること
-- 共有ページ（存在すれば）のOGタグ・Twitterカード・画像サイズ・meta refreshを検証
-（手動実行で当日の共有ページ未生成の場合は 404 を許容）
-- `?daily=1`（当日JST指定）でも **同じ共有URL** がコピーされることを検証します。
-- 共通環境:
-  - `APP_URL=https://nantes-rfli.github.io/vgm-quiz/app/`
-  - `E2E_BASE_URL=https://nantes-rfli.github.io/vgm-quiz/app/?test=1`
-
-### 使い方
-1. Actions → **E2E (matrix)** → **Run workflow**。
-2. 4 本のジョブが並列に走る（smoke/a11y/footer/share）。
-3. 失敗したスイートのアーティファクト（`e2e/*.log` / `e2e/screenshots`）をダウンロードして確認。
-
-### 既存の夜間 E2E との関係
-- 当面は **併存**（既存は夜間/手動、matrix は手動のみ）。
-- 安定確認後に、`e2e-matrix.yml` に `schedule` を追加し、旧ワークフローの夜間実行を停止（`on.schedule`を外す/ファイル削除）するとよい。
 
 ### Nightly スケジュール（導入済み）
-- 実行時刻: **JST 04:40**（= UTC 19:40）  
-  - `daily.json`（JST 00:00）と **Lighthouse (03:10 JST)** の後に走るため、衝突や帯域競合を回避。
-- 失敗時の確認手順:
-  1. Actions → **E2E (matrix)** の当日実行を開く
-  2. 赤いスイートだけを見る（smoke / a11y / footer / share）
-  3. 右上 “Artifacts” から `e2e-<suite>-artifacts` を取得（ログ/スクショ）
-  4. `docs/troubleshooting.md` の該当節へ
+- 実行時刻: **JST 04:40**（UTC 19:40）
+- 失敗時は該当スイートのアーティファクトを確認
 
 ### Artifact 保持
 - E2E のログ/スクショは **7日間** 保持（`upload-artifact@v4` の `retention-days: 7`）。
+
+## Lighthouse CI（budgets + asserts）
+- コンフィグ: `tools/lighthouse/lighthouserc.ci.json`（categories: performance/a11y/seo は warn しきい値で開始）
+- **パフォーマンス予算**: `tools/lighthouse/budgets.json`（FCP/LCP/TBT/CLS/bytesなど）。初期はゆるめ→安定後に引き締め。
+- レポートURL: ワークフローが **Job Summary にURLを出力**、さらに **HTMLをartifact保存**（7日）
+
+## Required checks（Rulesets）
+- **`pages-pr-build` / `ci-fast-pr-build`** の2本が PR の Required。
+  - ジョブ名がズレると PR が永遠に「waiting」になるため、変更時は Rulesets 側も必ず更新。

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -5,7 +5,7 @@ Common flags you can combine in the URL.
 | Flag | Example | Purpose |
 |---|---|---|
 | `test` | `?test=1` | Disable SW registration; expose debug vars; stub media |
-| `mock` | `?mock=1` | Force mock dataset |
+| `mock` | `?mock=1` | Test API & mocks (enables `window.__testAPI.normalize`) |
 | `seed` | `?seed=alpha` | Deterministic RNG |
 | `qp` | `?qp=1` | Year-bucket order pipeline |
 | `daily` | `?daily=1` / `?daily=2000-01-01` | 1-question mode (JST or fixed date) |

--- a/docs/github-admin.md
+++ b/docs/github-admin.md
@@ -1,0 +1,43 @@
+# GitHub Admin Guide
+
+This guide gathers all repository admin tasks (PAT, Rulesets, Pages) in one place.
+
+## Required checks (Rulesets)
+
+PRs are required to pass these **job names**:
+
+- `pages-pr-build`
+- `ci-fast-pr-build`
+
+If you rename jobs or workflows, update Rulesets so PRs don’t get stuck in “waiting…”.  
+(Settings → Rules → Rulesets → Edit → **Require workflows**)
+
+## Secrets
+
+- `DAILY_PR_PAT` – Personal Access Token (classic), **repo** scope is enough. Used by `daily.yml` to author PRs as you.
+  - Renew before it expires; if it expires the PR author becomes `github-actions[bot]` and the daily PR may fail.
+
+## Pages
+
+- Deployed from `public/` via `pages.yml` (push to `main` or manual **Run workflow**).
+- Safety steps re-generate **`/daily/index.html`** and **`/daily/feed.xml`** just before deploy.
+
+**Manual redeploy** (useful for SW update tests):
+
+```bash
+git switch main && git pull --ff-only
+git commit --allow-empty -m "chore(pages): redeploy"
+git push origin main
+```
+
+## Nightly jobs
+
+- `daily.yml` – 00:00 JST: creates daily PR (includes `public/app/daily.json`, `/daily/*.html`, `/daily/feed.xml`)
+- `lighthouse.yml` – around 03:10 JST: budgets/asserts, report URL to Summary, HTML artifact saved for 7 days
+- `e2e-matrix.yml` – 04:40 JST: smoke/a11y/footer/share/normalize/lives suites
+
+## Verifications
+
+- `/daily/index.html` and `/daily/latest.html` return 200; latest redirects to `/app/?daily=YYYY-MM-DD`
+- `/daily/feed.xml` returns 200
+- App footer shows latest `commit` and `updated` after deploy

--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -1,100 +1,44 @@
 # Ops Runbook
 
-This document captures day‑to‑day operations for **vgm-quiz**.
+## Manual deploy (Pages)
 
-## Canonical URLs
+Open **Actions → Pages → Run workflow** (branch: `main`) to redeploy `public/`.
 
-- Normal: `/app/`
-- Test (no SW registration): `/app/?test=1`
-- Mock dataset: `/app/?test=1&mock=1`
-- Deterministic: add `&seed=alpha`
-- Year-bucket pipeline: add `&qp=1`
-- Daily: `&daily=1` (today JST) or `&daily=YYYY-MM-DD`
-- Disable media: `&nomedia=1`
-- Lighthouse: `/app/?test=1&lhci=1`
+## Daily PR at 00:00 JST
 
-## Footer / Version fetch
+Check **Actions → daily.json generator (JST)**. The PR should include:
 
-- Footer: `Dataset: vN • commit: abcdefg • updated: YYYY-MM-DD HH:mm` (local time).
-- Fetch policy: **8s timeout**, **in-flight sharing**, **60s TTL**.
-- Helpers: `window.loadVersionPublic()` (TTL/in-flight適用), `window.loadVersionForce()` (強制).
+- `public/app/daily.json`
+- `public/daily/*.html`
+- `public/daily/feed.xml`
 
-## Service Worker handshake
+Author must be **you** (PAT owner), not `github-actions[bot]`. If bot appears:
 
-- App posts the absolute `version.json` URL to SW on startup.
-- SW polls ~60s using that URL (prevents 404 under `/app/` scope).
-- Stop SW (for testing): run in console `navigator.serviceWorker.getRegistrations().then(rs => rs.forEach(r => r.unregister()))` then reload.
+- Update `DAILY_PR_PAT` secret (create a fresh PAT; repo scope)
+- Re-run the workflow.
 
-## Media preview
+## Empty deploy (to test SW update)
 
-- YouTube: prefer `youtube-nocookie.com`, fallback to `youtube.com`, plus "Open in YouTube" link.
-- Tests and Lighthouse automatically **stub** the player (`?test=1`/`?lhci=1`/`?nomedia=1`).
-
-## Lives rule
-
-- Default: display-only HUD `Misses: x/y`.
-- Opt-in: `?lives=on` (or `?lives=5`) → **finish immediately** when misses reach the limit.
-
-## Daily 1 question
-
-- `?daily=1` uses *today (JST)*. `?daily=YYYY-MM-DD` for fixed day.
-- Mapping is in `public/app/daily.json`.
-
-## Daily 1-question (automation)
-
-- Source of truth: `public/app/daily.json`
-  ```json
-  { "version": 1, "tz": "Asia/Tokyo", "map": { "YYYY-MM-DD": { "title": "..." } } }
-  ```
-- Update policy: **nightly (00:00 JST)** via GitHub Actions → `.github/workflows/daily.yml`  
-  The generator selects 1 title deterministically from the current dataset based on the date (JST).
-- Manual run (local):
-  ```bash
-  node scripts/generate_daily.js               # for today (JST)
-  DAILY_DATE=2025-09-01 node scripts/generate_daily.js
-  DATASET_URL=https://nantes-rfli.github.io/vgm-quiz/build/dataset.json node scripts/generate_daily.js
-  ```
-- Notes: selection avoids repeating the same title within the last **30 days** (configurable via `AVOID_DAYS`).
-
-## Debugging
-
-- `window.__rng`/`__SEED__` – seeded RNG function & seed.
-- `window.__questionIds` / `__questionDebug` – available under `?test=1`.
-- `window.versionDebug.stats()/clear()` – inspect/clear version TTL cache.
-
----
-
-## PR checks & branch protection (definitive rules)
-
-- **Required status checks are evaluated against *job names***, not the UI display string.
-  - Register these two **job names** in Rulesets → *Status checks that are required*:
-    - `pages-pr-build`
-    - `ci-fast-pr-build`
-- `pages.yml` (deploy) **must not** run on PRs. Keep it scoped to `push: main` only.
-- `ci-fast.yml` runs on `push: main`; `ci-fast-pr.yml` runs on `pull_request`.
-
-### 5‑minute verification (after any CI change or PAT rotation)
-
-**GUI**
-1. Actions → **daily.json generator (JST)** → *Run workflow* (branch: `main`).
-2. A PR from `bot/daily` opens. Confirm **Author = your account** (PAT owner), not `github-actions[bot]`.
-3. In **Checks**, ensure only:
-   - **Pages / pages-pr-build**
-   - **CI Fast / ci-fast-pr-build**
-   appear and are green → PR auto‑merges → Pages deploy runs.
-
-**CLI**
 ```bash
-gh pr list -R nantes-rfli/vgm-quiz --search "head:bot/daily" -L 1 --json number,author,url
-gh pr checks <PR#> -R nantes-rfli/vgm-quiz
+git switch main && git pull --ff-only
+git commit --allow-empty -m "chore(pages): redeploy"
+git push origin main
 ```
 
-### Daily PR author (PAT)
+## Health checks (5-min)
 
-- `daily.yml` must create PRs with: `token: ${{ secrets.DAILY_PR_PAT }}` (Fine‑grained; repo‑scoped; **Contents: RW**, **Pull requests: RW**).
-- Verify author:
-```bash
-gh pr view <PR#> -R nantes-rfli/vgm-quiz --json author | jq -r '.author.login'
-# => should be your username (not github-actions[bot])
-```
+- `/daily/index.html` → **200**
+- `/daily/latest.html` → **200** and redirects to `/app/?daily=YYYY-MM-DD`
+- `/daily/feed.xml` → **200**
+- Footer (commit / updated) reflects latest deploy
 
+## E2E (matrix)
+
+Suites: `smoke`, `a11y`, `footer`, `share`, **`normalize`**, **`lives`**
+
+## Lighthouse
+
+Nightly run (desktop). Budgets & asserts enabled.
+
+- View the job **Summary** for the temporary-public report URL.
+- Artifact **lighthouse-report/report.html** is saved for 7 days.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,48 +1,58 @@
 # Data Pipeline Overview
 
-This document describes the **data contracts** and artifacts produced for the app.
-It focuses on *what the app expects* rather than the internal implementation details.
+This document covers dataset generation and daily scheduling.
 
-## Build artifacts (consumed by the app)
+## Build
 
-- `public/build/dataset.json` — quiz tracks and metadata
-- `public/build/aliases.json` — normalization aliases (merged with `public/app/aliases_local.json` if present)
-- `public/build/version.json` — deployment metadata used by the footer & SW
+Run:
 
-### `version.json` (contract)
+```bash
+clojure -T:build publish
+```
+
+Generates `public/build/dataset.json` and related artifacts; tests assume these are present.
+
+## Daily generation
+
+`scripts/generate_daily.js` (JST-based, FNV1a; avoids duplicates in last 30 days) writes:
 
 ```json
 {
-  "dataset": "v1",
-  "commit": "abcdef1",
-  "content_hash": "sha256:...",
-  "generated_at": "2025-08-30T06:39:00Z"
+  "YYYY-MM-DD": { "title": "...", "type": "title→game | game→composer | title→composer" },
+  "...": "..."
 }
 ```
 
-**App behavior**
+`scripts/generate_daily_index.js` outputs:
 
-- Footer shows `Dataset: v1 • commit: abcdef1 • updated: YYYY-MM-DD HH:mm` (local time)
-- The app uses 8s timeout, in-flight sharing, and 60s TTL when fetching `version.json`
-- The app exposes `window.loadVersionPublic()` (TTL/in-flight適用) and `window.loadVersionForce()` (強制)
+- `public/daily/index.html` (descending list)
+- `public/daily/latest.html` (redirect to `/app/?daily=YYYY-MM-DD`)
 
-### Aliases
+`scripts/generate_daily_feed.js` outputs:
 
-- App loads `../build/aliases.json`
-- If present, `./aliases_local.json` is merged **on top** (local overrides → easy small PRs)
+- `public/daily/feed.xml` (RSS 2.0, JST midnight as pubDate, newest 60 entries)
 
-### Mock dataset
+`daily.yml` (00:00 JST) creates a PR including:
 
-- For development and CI, `?mock=1` routes the app to `public/app/mock/dataset.json`
-- Media previews are stubbed under `?test=1` / `?lhci=1` / `?nomedia=1`
+- `public/app/daily.json`
+- `public/daily/*.html`
+- `public/daily/feed.xml`
 
-## Deterministic ordering (RNG & pipeline)
+Pages deploy (`pages.yml`) also regenerates index/feed as a safety net.
 
-- `?seed=...` → deterministic RNG (`window.__rng` is exposed under `?test=1`)
-- `?qp=1` → year-bucket pipeline for better spread
+## Sharing / OGP
 
-## Daily mapping
+`scripts/generate_share_page.js` and `scripts/generate_ogp.js` produce per-day static share HTML and OGP images.
+Subtitle selection:
 
-- `public/app/daily.json` maps dates to a single track (by `id` or `title`)
-- `?daily=1` uses **today (JST)**; `?daily=YYYY-MM-DD` uses a fixed date
+1. Prefer `public/app/daily.json[date].type` → `"Title → Game" / "Game → Composer" / "Title → Composer"`
+2. Fallback to env `OGP_SUBTITLE` (for backward compatibility)
 
+## Service Worker
+
+Version handshake via `version.json`. SW polls roughly every 60 seconds for updates.
+
+- `public/app/sw_update.js` listens to registration (`updatefound`/`waiting`) and shows an accessible banner.
+- Clicking “更新” sends `{type: 'SKIP_WAITING'}` to SW; on `controllerchange` the page reloads.
+- SW handles `message: SKIP_WAITING` and calls `clients.claim()` on `activate`.
+- Legacy in-app banner in `app.js` is **deprecated** and no-op.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,64 +1,34 @@
 # Troubleshooting
 
-## version.json shows 404 in Network
+## Pages deploy doesn’t reflect changes
 
-Cause: SW polling the wrong path under `/app` scope.  
-Fix: The app→SW handshake sets the absolute URL; ensure you’re on the latest `sw.js` and reload/Update SW.
+- Ensure `pages.yml` uploads **`public/`** (with `.nojekyll`)
+- Check **Deployments → github-pages** and verify the deployed commit matches `main` HEAD
+- Run **Actions → Pages → Run workflow** (branch: `main`) to force redeploy
 
-## `window.loadVersionPublic` is undefined
+## /daily/index.html or /daily/latest.html returns 404
 
-Cause: older `app.js`.  
-Fix: hard-reload; verify in console `typeof window.loadVersionPublic === "function"`.
+- Ensure `scripts/generate_daily_index.js` runs in `daily.yml` and **`pages.yml`** (pre-deploy safety)
+- In `daily.yml`, include `public/daily/*.html` in `create-pull-request` `add-paths`
+- After merging the PR, re-run **Pages** deploy (or push an empty commit)
 
-## YouTube embed says “動画を再生できません”
+## /daily/feed.xml returns 404
 
-Cause: the video ID disallows embeds or has region restrictions.  
-Fix: use an alternative ID; use the fallback “別ドメイン” button or “Open in YouTube” link.
+- Confirm `scripts/generate_daily_feed.js` is invoked by `daily.yml` **and** by `pages.yml` (pre-deploy safety)
+- In the daily PR, verify `public/daily/feed.xml` is included
+- After merging, run **Pages** to publish the file
 
-## Same-seed but different order?
+## SW update banner doesn’t show up
 
-Verify you are checking after Start, and that `window.__rng` is `"function"`; use `?qp=1` and compare `window.__questionIds`.
+- Ensure `public/app/sw_update.js` is included **after** SW registration script in `index.html`
+- Open DevTools → Application → Service Workers; confirm **Waiting** state appears on update
+- As a quick test, do an empty commit to trigger deploy (see Ops Runbook), keep the old tab open, and watch for the banner
 
----
+## Required checks keep “waiting…” on PR
 
-## よくある症状と対処
+- Rulesets require **job names** `pages-pr-build` / `ci-fast-pr-build`
+- If you renamed jobs or workflows, update Rulesets accordingly
 
-### daily.json generator が開始直後に失敗する（Missing/Invalid DAILY_PR_PAT）
-**症状**    
-ワークフロー最初のステップ `Validate DAILY_PR_PAT token` で失敗し、ログに  
-`Missing DAILY_PR_PAT` または `Invalid/expired DAILY_PR_PAT` が出る。
+## Daily PR authored by github-actions[bot]
 
-**原因**    
-`DAILY_PR_PAT` が未設定・期限切れ・またはスコープ不足（repo:contents write / pull_requests write など）。
-
-**対処**    
-1. Fine-grained PAT を発行（対象 repo に限定、Contents: Read/Write、Pull requests: Read/Write）  
-2. リポジトリ Secrets に `DAILY_PR_PAT` として登録（既存がある場合は置き換え）  
-3. Actions → daily.json generator (JST) を手動実行して回復を確認
-
-### “Expected: waiting…” のまま進まない
-**Likely causes & fixes**
-
-- **PR created with `GITHUB_TOKEN`** (author shows `github-actions[bot]`)
-  → Use a Fine‑grained PAT and set `token: ${{ secrets.DAILY_PR_PAT }}` in `daily.yml`.
-  Verify:
-  ```bash
-  gh pr view <PR#> -R nantes-rfli/vgm-quiz --json author | jq -r '.author.login'
-  ```
-
-- **Required checks mismatch** (registered the UI string like “CI Fast / build (pull_request)” instead of the **job name**)
-  → In Rulesets, require **`pages-pr-build`** and **`ci-fast-pr-build`** (job names).
-
-- **Workflows missing on the PR branch**
-  → Click **Update branch** or push an empty commit to refresh checks:
-  ```bash
-  git commit --allow-empty -m "chore: refresh checks"
-  git push
-  ```
-
-- **Two “Pages / build” entries** on PRs
-  → Ensure `pages.yml` does **not** have `pull_request:` (deploy runs only on `push: main`). PR uses the shim `pages-pr-build.yml`.
-
-- **PR CI skipped by path filters**
-  → Ensure `ci-fast-pr.yml` has `paths: ['**']`.
-
+- `DAILY_PR_PAT` is missing/expired. Create a new PAT and update repo secrets.


### PR DESCRIPTION
## Summary
- document new CI workflows and required checks
- outline daily index, RSS feed, and SW update banner
- add GitHub admin guide

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b41ed4583483249398b81f835af063