### PR TITLE
Enhance SW registration handling and daily index

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,7 +20,7 @@
 
 ## SW update banner doesn’t show up
 
-- Ensure `public/app/sw_update.js` is included **after** SW registration script in `index.html`
+- The app now attaches three ways: `navigator.serviceWorker.ready`, polling `getRegistration()` for up to 30s, **and** a `window` event dispatched at registration. If any of these are missing, update `app.js` and `sw_update.js` per latest main.
 - Open DevTools → Application → Service Workers; confirm **Waiting** state appears on update
 - As a quick test, do an empty commit to trigger deploy (see Ops Runbook), keep the old tab open, and watch for the banner
 

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1283,6 +1283,7 @@ window.addEventListener('DOMContentLoaded', () => {
     } else {
       navigator.serviceWorker.register(`./sw.js?v=${encodeURIComponent(v)}`).then(reg => {
         swRegistration = reg;
+        try { window.dispatchEvent(new CustomEvent('sw-registered', { detail: swRegistration })); } catch (_) {}
         if (swRegistration.waiting) {
           showUpdateBanner();
         }

--- a/public/app/sw_update.js
+++ b/public/app/sw_update.js
@@ -107,8 +107,37 @@
     setInterval(() => reg.update().catch(() => {}), 60 * 1000);
   }
 
+  // Wait until a registration exists (retry up to 30s)
+  function waitForRegistration(timeoutMs = 30000, interval = 1000) {
+    return new Promise((resolve) => {
+      const deadline = Date.now() + timeoutMs;
+      const tick = () => {
+        navigator.serviceWorker.getRegistration().then((reg) => {
+          if (reg) return resolve(reg);
+          if (Date.now() < deadline) setTimeout(tick, interval);
+          else resolve(null);
+        }).catch(() => {
+          if (Date.now() < deadline) setTimeout(tick, interval);
+          else resolve(null);
+        });
+      };
+      tick();
+    });
+  }
+
+  let attachedReg = null;
+  function attach(reg) {
+    if (!reg || reg === attachedReg) return;
+    attachedReg = reg;
+    listenOnRegistration(reg);
+  }
+
   // Attach to any current registration
-  navigator.serviceWorker.getRegistration().then(listenOnRegistration).catch(() => {});
+  navigator.serviceWorker.getRegistration().then(attach).catch(() => {});
+  navigator.serviceWorker.ready.then(attach).catch(() => {});
+  waitForRegistration().then(attach);
+  window.addEventListener('sw-registered', (e) => attach(e.detail));
+
   // Also watch future registrations
   navigator.serviceWorker.addEventListener('controllerchange', () => {
     // No-op here; reload is handled on button click path.

--- a/scripts/generate_daily_index.js
+++ b/scripts/generate_daily_index.js
@@ -37,9 +37,33 @@ function jstISO(d = new Date()) {
   <h1>VGM Quiz — Daily index</h1>
   <p><a href="./feed.xml">RSSフィード</a>（購読できます）</p>
   <div class="meta">today: ${today} / count: ${files.length}</div>
-  <ul>
-    ${files.map(d => `<li><a href="./${d}.html">${d}</a></li>`).join('\n    ')}
+  <label>検索: <input id="q" placeholder="YYYY-MM-DD など"></label>
+  <div id="nav"></div>
+  <ul id="list">
+    ${files.map(d => `<li data-date="${d}"><a href="./${d}.html">${d}</a></li>`).join('\n    ')}
   </ul>
+  <script>
+    (function(){
+      var q = document.getElementById("q");
+      var list = document.getElementById("list");
+      var items = [].slice.call(list.querySelectorAll("li"));
+      function apply(){
+        var v = (q.value||"").trim();
+        items.forEach(function(li){
+          var d = li.getAttribute("data-date");
+          li.style.display = (!v || d.indexOf(v) !== -1) ? "" : "none";
+        });
+      }
+      q.addEventListener("input", apply);
+      apply();
+      // prev/next (relative to latest)
+      var dates = items.map(function(li){return li.getAttribute("data-date");});
+      var latest = dates[0];
+      var prev = dates[1] || null;
+      var nav = document.getElementById("nav");
+      if (prev) nav.innerHTML = '<p><a href="./'+prev+'.html">← 前日: '+prev+'</a> ・ <a href="./latest.html">本日</a></p>';
+    })();
+  </script>
 </body></html>`;
 
   const mkLatest = (d) => `<!doctype html>


### PR DESCRIPTION
## Summary
- Poll for service worker registration and listen for a registration event to reliably show update banner
- Dispatch `sw-registered` event on registration
- Add search field and prev/next navigation to daily index
- Document new SW attachment methods

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b426b0f24083248d07b243b8ce0b2e