### PR TITLE
Add daily index search tools and workflow enhancements

### DIFF
--- a/.github/workflows/json-validate.yml
+++ b/.github/workflows/json-validate.yml
@@ -1,6 +1,7 @@
 name: json-validate
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [ "main" ]
   pull_request:
@@ -16,3 +17,7 @@ jobs:
           node-version: 20
       - name: Validate JSONs (daily/aliases/dataset)
         run: node scripts/validate_json.js
+
+      - name: Step Summary (success)
+        if: success()
+        run: echo "✅ JSON validate passed" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -109,6 +109,16 @@ jobs:
             node scripts/generate_daily_feed.js
           fi
 
+      - name: Inject search/nav script into /daily/index.html
+        run: |
+          set -euo pipefail
+          f="public/daily/index.html"
+          if [ -f "$f" ]; then
+            if ! grep -q 'index-tools.js' "$f"; then
+              sed -i 's#</body>#  <script src="index-tools.js" defer></script>\n</body>#' "$f"
+            fi
+          fi
+
       - name: Upload artifact (entire public)
         uses: actions/upload-pages-artifact@v3
         with:

--- a/public/daily/index-tools.js
+++ b/public/daily/index-tools.js
@@ -1,0 +1,32 @@
+/* daily index tools: search + today/prev nav (JST) */
+(function () {
+  'use strict';
+  const $ = (s, p = document) => p.querySelector(s);
+  const $$ = (s, p = document) => Array.from(p.querySelectorAll(s));
+  function jstDateString(delta = 0) {
+    const now = new Date();
+    const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+    jst.setUTCHours(0, 0, 0, 0);
+    jst.setUTCDate(jst.getUTCDate() + delta);
+    return jst.toISOString().slice(0, 10);
+  }
+  function jumpTo(dateStr) { location.href = `./${dateStr}.html`; }
+  document.addEventListener('DOMContentLoaded', () => {
+    const list = $('#daily-list') || $('main ul') || $('ul') || $('ol');
+    const lis = list ? $$('li', list) : [];
+    const wrap = document.createElement('div'); wrap.id = 'daily-tools'; wrap.style.marginTop = '1.5rem';
+    const input = document.createElement('input'); input.type = 'search'; input.placeholder = '検索（タイトル/ゲーム/作曲者/日付）'; input.setAttribute('aria-label','検索'); input.style.padding='0.5rem'; input.style.minWidth='280px';
+    const todayBtn = document.createElement('button'); todayBtn.textContent='本日';
+    const prevBtn = document.createElement('button'); prevBtn.textContent='前日';
+    [todayBtn, prevBtn].forEach(b => { b.style.marginLeft='0.5rem'; b.style.padding='0.5rem 0.75rem'; });
+    wrap.append(input, todayBtn, prevBtn); document.body.appendChild(wrap);
+    const norm = s => (s || '').toLowerCase();
+    input.addEventListener('input', () => {
+      const term = norm(input.value.trim());
+      if (!list) return;
+      lis.forEach(li => { const t = norm(li.textContent); li.style.display = term ? (t.includes(term) ? '' : 'none') : ''; });
+    });
+    todayBtn.addEventListener('click', () => jumpTo(jstDateString(0)));
+    prevBtn.addEventListener('click', () => jumpTo(jstDateString(-1)));
+  });
+})();


### PR DESCRIPTION
## Summary
- add search box and date navigation buttons to /daily index
- inject script into /daily/index.html during pages build
- allow manual json validation trigger and summarize success

## Testing
- `npm test` *(fails: sh: clojure: not found)*
- `apt-get update` *(fails: 403 Forbidden repository access)*
- `npm run smoke` *(fails: Cannot find module 'cheerio')*


------
https://chatgpt.com/codex/tasks/task_e_68b43d44e6d483248c1b6e5520382e91