### PR TITLE
docs: add ops runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@
   </a>
 </p>
 
+## Operations / Runbook
+日々の運用で迷いやすいポイントは **[docs/ops.md](docs/ops.md)** に集約しています。
+- SW更新確認フロー（waiting→更新バナー）
+- Required ジョブ名の注意・Checks が待機のままの対処
+- DAILY_PR_PAT の期限切れ兆候と対処
+- Actions からの手動実行（json-validate / Pages 再配信）
+
 ### Daily OGP
 - 自動生成された OGP 画像は `public/ogp/daily-YYYY-MM-DD.png`（**出題タイプ**：title→game / game→composer / title→composer を表示。判定できない場合は “Daily Question”）
 - 画像は GitHub Pages からも配信可能（例: `/vgm-quiz/ogp/daily-YYYY-MM-DD.png`）
@@ -81,5 +88,5 @@ See [docs/pipeline.md](./docs/pipeline.md).
 
 ## Operations
 
-See [docs/ops-runbook.md](./docs/ops-runbook.md) and [docs/troubleshooting.md](./docs/troubleshooting.md).
+See [docs/ops.md](./docs/ops.md) and [docs/troubleshooting.md](./docs/troubleshooting.md).
 Admin guide for PAT/Rulesets/Pages is in [docs/github-admin.md](./docs/github-admin.md).

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -1,0 +1,53 @@
+# 運用 Runbook（vgm-quiz）
+
+## 1) SW 更新確認（更新バナーを出す手順）
+仕様：**新SWが `waiting` になった時だけ**更新バナーを表示します。
+手順：
+1. `public/app/sw.js` にコメント1行追加 → push（Pages配信）
+2. 既存タブでコンソール実行：
+   ```js
+   navigator.serviceWorker.getRegistration().then(r => r && r.update())
+   ```
+3. バナー表示→「更新」をクリック（リロード）
+
+## 2) Required チェックが「待機」のまま
+- ルールセット上の Required 名：`pages-pr-build` / `ci-fast-pr-build`
+- PRブランチに該当のYAMLが未反映の場合：**Update branch** または 空コミット
+- `github-actions[bot]` が PR author → **DAILY_PR_PAT** 未設定 or 期限切れの可能性
+
+## 3) DAILY_PR_PAT 期限切れの兆候
+- Daily PR の author が `github-actions[bot]`
+- Checks が走らない／保留が解けない
+対処：
+1. PAT 設定を再確認（権限：`repo`、期限）
+2. Actions Secrets の値を更新
+3. 次回スケジュール or 手動トリガで再検証
+
+## 4) /daily の生成物
+- `scripts/generate_daily.js`：JST・FNV1a・直近30日重複回避 → `public/app/daily.json`
+- `scripts/generate_daily_index.js` → `/daily/index.html`
+- `scripts/generate_daily_feed.js` → `/daily/feed.xml`
+- `/daily/latest.html` は当日へのリダイレクト
+- Pages 配信直前にも **保険**として index / feed を再生成（`pages.yml`）
+
+## 5) JSON バリデータ（手動実行）
+Actions → **json-validate** → **Run workflow**  
+成功時：Run Summary に「✅ JSON validate passed」  
+失敗時：ログに重複・衝突の詳細（aliases正規化キー／dataset正規化一致）
+
+## 6) Pages が反映されない
+- `pages.yml` の配信パス：`public/` を確認
+- Actions → Pages → **Run workflow**（手動再配信）
+
+## 7) E2E が不安定
+- SW キャッシュの影響 or UI変更
+- `?test=1&mock=1&seed=...&nomedia=1` のフォールバックで緩和済み
+
+## 8) よく使うコマンド
+```bash
+clojure -T:build publish   # build/ を生成
+clojure -M:test            # テスト
+node scripts/generate_daily_index.js
+node scripts/generate_daily_feed.js
+```
+


### PR DESCRIPTION
## Summary
- document operations runbook with guidance for daily tasks
- link README to operations runbook

## Testing
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4402d029c832496ada40755389ed7