### PR TITLE
Improve daily daily index tool accessibility and search UX

### DIFF
--- a/public/daily/index-tools.js
+++ b/public/daily/index-tools.js
@@ -3,30 +3,108 @@
   'use strict';
   const $ = (s, p = document) => p.querySelector(s);
   const $$ = (s, p = document) => Array.from(p.querySelectorAll(s));
+  const isTextLike = el => el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable);
+
   function jstDateString(delta = 0) {
     const now = new Date();
-    const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+    const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000); // UTC→JST
     jst.setUTCHours(0, 0, 0, 0);
     jst.setUTCDate(jst.getUTCDate() + delta);
     return jst.toISOString().slice(0, 10);
   }
-  function jumpTo(dateStr) { location.href = `./${dateStr}.html`; }
+  function jumpTo(dateStr) {
+    location.href = `./${dateStr}.html`;
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
-    const list = $('#daily-list') || $('main ul') || $('ul') || $('ol');
+    let list =
+      $('#daily-list') ||
+      $('main ul') ||
+      $('ul') ||
+      $('ol');
     const lis = list ? $$('li', list) : [];
-    const wrap = document.createElement('div'); wrap.id = 'daily-tools'; wrap.style.marginTop = '1.5rem';
-    const input = document.createElement('input'); input.type = 'search'; input.placeholder = '検索（タイトル/ゲーム/作曲者/日付）'; input.setAttribute('aria-label','検索'); input.style.padding='0.5rem'; input.style.minWidth='280px';
-    const todayBtn = document.createElement('button'); todayBtn.textContent='本日';
-    const prevBtn = document.createElement('button'); prevBtn.textContent='前日';
-    [todayBtn, prevBtn].forEach(b => { b.style.marginLeft='0.5rem'; b.style.padding='0.5rem 0.75rem'; });
-    wrap.append(input, todayBtn, prevBtn); document.body.appendChild(wrap);
+
+    // UI
+    const wrap = document.createElement('div');
+    wrap.id = 'daily-tools';
+    wrap.style.marginTop = '1.5rem';
+    wrap.setAttribute('role', 'region');
+    wrap.setAttribute('aria-label', '日別一覧ツール');
+
+    const input = document.createElement('input');
+    input.type = 'search';
+    input.placeholder = '検索（タイトル/ゲーム/作曲者/日付）';
+    input.setAttribute('aria-label', '検索');
+    input.style.padding = '0.5rem';
+    input.style.minWidth = '280px';
+
+    const todayBtn = document.createElement('button');
+    todayBtn.textContent = '本日';
+    const prevBtn = document.createElement('button');
+    prevBtn.textContent = '前日';
+    [todayBtn, prevBtn].forEach(b => {
+      b.style.marginLeft = '0.5rem';
+      b.style.padding = '0.5rem 0.75rem';
+    });
+
+    wrap.append(input, todayBtn, prevBtn);
+    // リストの直前に差し込む（なければ <main> or body の末尾）
+    const main = $('main') || document.body;
+    if (list && list.parentNode) {
+      list.parentNode.insertBefore(wrap, list);
+    } else {
+      main.appendChild(wrap);
+    }
+    // リストIDと aria-controls
+    if (list && !list.id) {
+      list.id = 'daily-list';
+    }
+    if (list) {
+      input.setAttribute('aria-controls', list.id);
+    }
+
+    // 検索
     const norm = s => (s || '').toLowerCase();
     input.addEventListener('input', () => {
       const term = norm(input.value.trim());
       if (!list) return;
-      lis.forEach(li => { const t = norm(li.textContent); li.style.display = term ? (t.includes(term) ? '' : 'none') : ''; });
+      lis.forEach(li => {
+        const t = norm(li.textContent);
+        li.style.display = term ? (t.includes(term) ? '' : 'none') : '';
+      });
     });
+
+    // ナビ
     todayBtn.addEventListener('click', () => jumpTo(jstDateString(0)));
     prevBtn.addEventListener('click', () => jumpTo(jstDateString(-1)));
+
+    // 事前フィルタ (?q=...) を反映
+    const pre = new URL(location.href).searchParams.get('q');
+    if (pre) {
+      input.value = pre;
+      input.dispatchEvent(new Event('input'));
+    }
+
+    // ショートカット: "/" で検索にフォーカス
+    document.addEventListener('keydown', (e) => {
+      if (e.key === '/' && !e.altKey && !e.ctrlKey && !e.metaKey) {
+        if (!isTextLike(document.activeElement)) {
+          e.preventDefault();
+          input.focus();
+          input.select();
+        }
+      }
+    });
+
+    // Enter: 一件のみヒットならそのリンクへ
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        const visible = lis.filter(li => li.style.display !== 'none');
+        if (visible.length === 1) {
+          const a = visible[0].querySelector('a');
+          if (a && a.href) location.href = a.href;
+        }
+      }
+    });
   });
 })();


### PR DESCRIPTION
## Summary
- Refactor daily index tools script for better accessibility and semantics
- Add keyboard shortcuts, pre-filled search and single result navigation
- Ensure daily list and tools have proper ARIA roles and labels

## Testing
- `npm install` *(fails: 403 Forbidden for cheerio)*
- `npm test` *(fails: clojure: not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*
- `npm run smoke` *(fails: Cannot find module 'cheerio')*


------
https://chatgpt.com/codex/tasks/task_e_68b440965e8083249da44bf06e1bb11c