### PR TITLE
feat: add normalize parity test and workflows

### DIFF
--- a/.github/workflows/candidates-harvest.yml
+++ b/.github/workflows/candidates-harvest.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Harvest from dataset
         run: node scripts/harvest_candidates.js --out public/app/daily_candidates.jsonl
 
+      - name: Summary details
+        run: |
+          node -e "const fs=require('fs');const f='public/app/daily_candidates.jsonl';const lines=fs.readFileSync(f,'utf-8').trim().split(/\n+/);const N=lines.length;const pick=(i)=>{try{return JSON.parse(lines[i])}catch(e){return null}};const s=[];s.push('### candidates (harvest) details');s.push(`- count: **${N}**`);for(let i=0;i<Math.min(3,N);i++){const o=pick(i);if(o){s.push(`- sample${i+1}: ${o.title} / ${o.game} / ${o.composer}`)}};fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,s.join('\n')+'\n');"
+
       - name: Upload candidates artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/daily-auto.yml
+++ b/.github/workflows/daily-auto.yml
@@ -59,6 +59,10 @@ jobs:
           name: daily-auto-json
           path: public/app/daily_auto.json
 
+      - name: Summary details
+        run: |
+          node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('public/app/daily_auto.json','utf-8'));const entries=Object.entries(j.by_date||{});const last=entries[entries.length-1];const s=[];s.push('### daily (auto) details');if(last){const [d,v]=last;s.push(`- date: **${d}**`);s.push(`- pick: ${v.title} / ${v.game} / ${v.composer} (diff=${v.difficulty||'n/a'})`);}fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,s.join('\n')+'\n');"
+
       - name: Create PR (optional)
         if: ${{ github.event.inputs.apply_to_main == 'true' }}
         uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/normalize-parity.yml
+++ b/.github/workflows/normalize-parity.yml
@@ -1,0 +1,19 @@
+name: normalize (parity)
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run parity test
+        run: node scripts/test_normalize_parity.js
+

--- a/scripts/pipeline/normalize.js
+++ b/scripts/pipeline/normalize.js
@@ -1,22 +1,26 @@
 'use strict';
 // Lightweight normalizer (v1.2相当の縮約版) for Node-side scripts
-const ROMAN = [
+// ローマ数字は「単独トークン」のみ数値化（単語中の v/i/x は置換しない）
+const ROMAN_MAP_ENTRIES = [
   ["xx",20],["xix",19],["xviii",18],["xvii",17],["xvi",16],["xv",15],["xiv",14],["xiii",13],["xii",12],["xi",11],
   ["x",10],["ix",9],["viii",8],["vii",7],["vi",6],["v",5],["iv",4],["iii",3],["ii",2],["i",1]
 ];
+const ROMAN_MAP = new Map(ROMAN_MAP_ENTRIES);
+const ROMAN_TOKEN_RE = new RegExp(
+  "\\b(?:" + ROMAN_MAP_ENTRIES.map(([r]) => r).join("|") + ")\\b",
+  "g"
+);
 function toNFKC(s){ return s.normalize ? s.normalize('NFKC') : s; }
 function stripDiacritics(s){ return s.normalize('NFD').replace(/[\u0300-\u036f]/g,''); }
-function romanToArabic(s){
-  let out=s;
-  for(const [r,n] of ROMAN){ out=out.replace(new RegExp(r,'g'), String(n)); }
-  return out;
+function romanToArabicTokensOnly(s){
+  return s.replace(ROMAN_TOKEN_RE, (m) => String(ROMAN_MAP.get(m)));
 }
 function normalizeAnswer(s){
   if(!s) return '';
   let t = toNFKC(String(s)).toLowerCase();
   t = stripDiacritics(t);
   t = t.replace(/&/g,' and ');
-  t = romanToArabic(t);
+  t = romanToArabicTokensOnly(t);
   t = t.replace(/[\p{P}\p{S}\s\u30FC\-]/gu,''); // punctuation/symbols/spaces/長音/ハイフン
   return t;
 }

--- a/scripts/test_normalize_parity.js
+++ b/scripts/test_normalize_parity.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * Compare Node-side normalize (scripts/pipeline/normalize.js) with
+ * browser-side normalize (public/app/normalize.mjs).
+ * Exits non-zero if mismatches exist. Writes a short summary when run in GitHub Actions.
+ */
+const fs = require('fs');
+const path = require('path');
+const { normalizeAnswer: normalizeNode } = require('./pipeline/normalize');
+
+async function loadBrowserNormalize() {
+  const mPath = path.resolve(__dirname, '../public/app/normalize.mjs');
+  const mod = await import('file://' + mPath);
+  const fn =
+    mod.normalizeAnswer ||
+    mod.normalize ||
+    (mod.default && (mod.default.normalizeAnswer || mod.default.normalize)) ||
+    mod.default;
+  if (typeof fn !== 'function') {
+    throw new Error('normalize.mjs does not export normalize function');
+  }
+  return fn;
+}
+
+function writeSummary(lines) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  fs.appendFileSync(summaryPath, lines.join('\n') + '\n');
+}
+
+async function main() {
+  const normalizeBrowser = await loadBrowserNormalize();
+  const samples = [
+    'Megalovania',
+    'Toby Fox',
+    'Final Fantasy X',
+    'Street Fighter II',
+    'Rockman X2',
+    'Chrono Trigger',
+    'ゼルダの伝説',
+    'Pokémon Red & Blue',
+    'NieR:Automata',
+    'Castlevania IV',
+  ];
+  let mismatches = [];
+  for (const s of samples) {
+    const a = normalizeNode(s);
+    const b = normalizeBrowser(s);
+    if (a !== b) {
+      mismatches.push({ s, node: a, browser: b });
+    }
+  }
+  if (mismatches.length === 0) {
+    console.log('PARITY OK: Node normalize matches browser normalize on samples.');
+    writeSummary([
+      '### normalize parity',
+      '- Result: **OK** (Node === Browser)',
+      `- Samples: ${samples.length}`,
+    ]);
+    return;
+  } else {
+    console.error('PARITY MISMATCHES:');
+    for (const m of mismatches) {
+      console.error(`- ${m.s}: node="${m.node}" browser="${m.browser}"`);
+    }
+    writeSummary([
+      '### normalize parity',
+      '- Result: **MISMATCH**',
+      `- Count: ${mismatches.length} / ${samples.length}`,
+      '',
+      '#### Examples',
+      ...mismatches.slice(0, 5).map(m => `- ${m.s}: node=\`${m.node}\`, browser=\`${m.browser}\``)
+    ]);
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(2);
+});
+


### PR DESCRIPTION
## Summary
- convert Roman numerals only when they appear as standalone tokens in Node normalizer
- add script & GitHub Action to compare Node and browser normalization
- include result summaries in candidate harvest and daily-auto workflows

## Testing
- `node scripts/test_normalize_parity.js` (fails: PARITY MISMATCHES)
- `npm test` (fails: clojure: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b44ec9e8808324849d4ebb0f63ebc3