### PR TITLE
feat: enrich media start and optional daily choices

### DIFF
--- a/.github/workflows/daily-auto.yml
+++ b/.github/workflows/daily-auto.yml
@@ -7,6 +7,10 @@ on:
         description: 'Target date (YYYY-MM-DD). Default = today (JST).'
         required: false
         type: string
+      with_choices:
+        description: 'Attach multiple-choice distractors (composer/game) to output'
+        required: false
+        type: boolean
       apply_to_main:
         description: 'Create PR to update public/app/daily_auto.json'
         required: false
@@ -47,11 +51,15 @@ jobs:
       - name: Step 2/3 score
         run: node scripts/score_candidates.js --in public/app/daily_candidates.jsonl --out public/app/daily_candidates_scored.jsonl
 
+      - name: Step 2.5 enrich media start
+        run: node scripts/enrich_media_start.js --in public/app/daily_candidates_scored.jsonl --out public/app/daily_candidates_scored_enriched.jsonl
+
       - name: Step 3/3 generate (for date)
         run: |
           DATE="${{ github.event.inputs.date }}"
           if [ -z "$DATE" ]; then DATE="$(TZ=Asia/Tokyo date +%F)"; fi
-          node scripts/generate_daily_from_candidates.js --in public/app/daily_candidates_scored.jsonl --date "$DATE" --out public/app/daily_auto.json
+          WITH_CHOICES="${{ github.event.inputs.with_choices }}"
+          node scripts/generate_daily_from_candidates.js --in public/app/daily_candidates_scored_enriched.jsonl --date "$DATE" --out public/app/daily_auto.json ${WITH_CHOICES=='true' && '--with-choices' || ''}
 
       - name: Upload artifact (daily_auto.json)
         uses: actions/upload-artifact@v4
@@ -61,7 +69,7 @@ jobs:
 
       - name: Summary details
         run: |
-          node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('public/app/daily_auto.json','utf-8'));const entries=Object.entries(j.by_date||{});const last=entries[entries.length-1];const s=[];s.push('### daily (auto) details');if(last){const [d,v]=last;s.push(`- date: **${d}**`);s.push(`- pick: ${v.title} / ${v.game} / ${v.composer} (diff=${v.difficulty||'n/a'})`);}fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,s.join('\n')+'\n');"
+          node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('public/app/daily_auto.json','utf-8'));const entries=Object.entries(j.by_date||{});const last=entries[entries.length-1];const s=[];s.push('### daily (auto) details');if(last){const [d,v]=last;s.push(`- date: **${d}**`);s.push(`- pick: ${v.title} / ${v.game} / ${v.composer} (diff=${v.difficulty||'n/a'})`);if(v.choices){s.push(`- choices: composer[${v.choices.composer.join(', ')}], game[${v.choices.game.join(', ')}]`);}}fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,s.join('\n')+'\n');"
 
       - name: Create PR (optional)
         if: ${{ github.event.inputs.apply_to_main == 'true' }}

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -11,7 +11,7 @@
    ```bash
    node scripts/harvest_candidates.js --out public/app/daily_candidates.jsonl
    ```
-2. 難易度付与（score）  
+2. 難易度付与（score）
    ```bash
    node scripts/score_candidates.js --in public/app/daily_candidates.jsonl --out public/app/daily_candidates_scored.jsonl
    ```
@@ -19,6 +19,21 @@
    ```bash
    node scripts/generate_daily_from_candidates.js --in public/app/daily_candidates_scored.jsonl --date 2025-09-01 --out public/app/daily_auto.json
    ```
+
+4. （任意）メディア開始秒の精度を上げる（enrich）  
+   ```bash
+   node scripts/enrich_media_start.js --in public/app/daily_candidates_scored.jsonl --out public/app/daily_candidates_scored_enriched.jsonl
+   ```
+
+5. （任意）ディストラクタを付与して出力（with-choices）  
+   ```bash
+   node scripts/generate_daily_from_candidates.js --in public/app/daily_candidates_scored_enriched.jsonl --date 2025-09-01 --out public/app/daily_auto.json --with-choices
+   ```
+
+### daily-auto.yml の入力
+- `date`: 空なら JST 今日
+- `with_choices`: **false** 既定（true で composer/game の選択肢を付与）
+- `apply_to_main`: **false** 既定（PRを作る場合 true）
 
 ## 方針
 - 既存 `scripts/generate_daily.js` は**一切変更しない**（既存の `daily.json` は温存）

--- a/scripts/enrich_media_start.js
+++ b/scripts/enrich_media_start.js
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * Enrich candidates JSONL with better `media.start` guesses.
+ * - Prefer dataset-provided starts (public/build/dataset.json)
+ * - Parse common YouTube params (?t=, ?start=, #t=1m23s)
+ * - Fallback heuristic on title keywords; default 45s
+ *
+ * Usage:
+ *   node scripts/enrich_media_start.js --in public/app/daily_candidates_scored.jsonl --out public/app/daily_candidates_scored_enriched.jsonl
+ */
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const { normalizeAnswer } = require('./pipeline/normalize');
+
+function secFromTimecode(tc){
+  // 1h2m3s / 2m10s / 90s / 75
+  const m = String(tc).match(/(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
+  if (m && (m[1]||m[2]||m[3])){
+    const h = parseInt(m[1]||'0',10);
+    const mn = parseInt(m[2]||'0',10);
+    const s = parseInt(m[3]||'0',10);
+    return h*3600 + mn*60 + s;
+  }
+  const n = Number(tc);
+  return Number.isFinite(n) ? Math.max(0, Math.floor(n)) : null;
+}
+
+function extractYouTubeId(url){
+  // supports: youtu.be/ID, youtube.com/watch?v=ID, youtube-nocookie.com/embed/ID
+  try{
+    const u = new URL(url);
+    if (/youtu\.be$/.test(u.hostname)) return u.pathname.slice(1);
+    if (/youtube(?:-nocookie)?\.com$/.test(u.hostname)){
+      if (u.pathname.startsWith('/watch')) return u.searchParams.get('v');
+      const m = u.pathname.match(/\/embed\/([\w-]{5,})/);
+      if (m) return m[1];
+    }
+  }catch{}
+  // fallback: raw id-ish
+  const m = String(url).match(/([\w-]{11})/);
+  return m ? m[1] : null;
+}
+
+function extractStartFromUrl(url){
+  try{
+    const u = new URL(url);
+    const t = u.searchParams.get('t') || u.searchParams.get('start');
+    const s1 = secFromTimecode(t);
+    if (s1!=null) return s1;
+    if (u.hash && u.hash.includes('t=')){
+      const v = u.hash.split('t=')[1];
+      const s2 = secFromTimecode(v);
+      if (s2!=null) return s2;
+    }
+  }catch{}
+  // also accept fragments like #1m23s
+  const m = String(url).match(/#(\d+h)?(\d+m)?(\d+s)/i);
+  if (m){ return secFromTimecode(m[0].slice(1)); }
+  return null;
+}
+
+function readJSON(p){ return JSON.parse(fs.readFileSync(p,'utf-8')); }
+async function readJSONL(p){
+  const rs = fs.createReadStream(p, 'utf-8');
+  const rl = readline.createInterface({ input: rs, crlfDelay: Infinity });
+  const rows = [];
+  for await (const line of rl){
+    const s = line.trim(); if (!s) continue;
+    try { rows.push(JSON.parse(s)); } catch {}
+  }
+  return rows;
+}
+function ensureDir(dir){ fs.mkdirSync(dir, { recursive:true }); }
+
+function parseArgs(){
+  const args = process.argv.slice(2);
+  const i = args.indexOf('--in');  const input = i>=0 ? args[i+1] : 'public/app/daily_candidates_scored.jsonl';
+  const o = args.indexOf('--out'); const output = o>=0 ? args[o+1] : 'public/app/daily_candidates_scored_enriched.jsonl';
+  const d = args.indexOf('--dataset'); const datasetPath = d>=0 ? args[d+1] : 'public/build/dataset.json';
+  return { input, output, datasetPath };
+}
+
+function buildMediaIndex(dataset){
+  const index = new Map(); // key -> {kind,id,start?}
+  const list = Array.isArray(dataset) ? dataset : (dataset.tracks || []);
+  for(const rec of list){
+    const title = rec.title || rec.track || '';
+    const game  = rec.game  || '';
+    const composer = rec.composer || '';
+    const key = `${normalizeAnswer(title)}|${normalizeAnswer(game)}|${normalizeAnswer(composer)}`;
+    let media = null;
+    // known fields
+    const yt = rec.youtube || rec.youtubeId || rec.youtube_id || rec.yt || rec.video || rec.url;
+    if (yt){
+      const id = extractYouTubeId(yt);
+      const start = extractStartFromUrl(yt) ?? rec.start ?? rec.t ?? rec.startSeconds ?? null;
+      if (id){
+        media = { kind:'youtube', id, start: start!=null ? Number(start) : undefined };
+      }
+    }
+    // apple music preview start (ms) → seconds if no youtube
+    if (!media){
+      const ms = rec.previewStartMs || rec.applePreviewStartMs || rec.apple_preview_start_ms;
+      if (ms!=null){
+        media = { kind:'apple', previewStart: Math.floor(Number(ms)/1000) };
+      }
+    }
+    if (media){
+      index.set(key, media);
+    }
+  }
+  return index;
+}
+
+function heuristicStart(c){
+  const text = [c.title, c.game].filter(Boolean).join(' ').toLowerCase();
+  if (/\bintro\b|prologue/.test(text)) return 5;
+  if (/\bboss\b/.test(text)) return 15;
+  if (/\bbattle\b/.test(text)) return 25;
+  if (/main\s*theme|title\s*theme/.test(text)) return 30;
+  return 45; // default
+}
+
+async function main(){
+  const { input, output, datasetPath } = parseArgs();
+  if (!fs.existsSync(input)) { console.error(`[enrich] not found: ${input}`); process.exit(1); }
+  let mediaIndex = new Map();
+  if (fs.existsSync(datasetPath)){
+    try {
+      const dataset = readJSON(datasetPath);
+      mediaIndex = buildMediaIndex(dataset);
+    } catch (e) {
+      console.warn('[enrich] dataset read failed; continue with heuristic only:', e.message);
+    }
+  } else {
+    console.warn('[enrich] dataset not found; continue with heuristic only');
+  }
+  const rows = await readJSONL(input);
+  const outDir = path.dirname(output); ensureDir(outDir);
+  const ws = fs.createWriteStream(output, 'utf-8');
+  let touched = 0, total=0;
+  for(const c of rows){
+    total++;
+    const key = `${c.norm.title}|${c.norm.game}|${c.norm.composer}`;
+    const idx = mediaIndex.get(key);
+    if (!c.media && idx){
+      c.media = { ...idx };
+      if (typeof c.media.start !== 'number') c.media.start = heuristicStart(c);
+      touched++;
+    } else if (c.media){
+      if (typeof c.media.start !== 'number'){
+        if (idx && typeof idx.start === 'number') {
+          c.media.start = Number(idx.start);
+          touched++;
+        } else {
+          const guess = heuristicStart(c);
+          c.media.start = guess;
+          touched++;
+        }
+      }
+    } else {
+      // no media at all; leave null
+    }
+    ws.write(JSON.stringify(c) + '\n');
+  }
+  ws.end();
+  console.log(`[enrich] in=${total}, updated=${touched}, out=${output}`);
+}
+
+if (require.main === module) main();

--- a/scripts/generate_daily_from_candidates.js
+++ b/scripts/generate_daily_from_candidates.js
@@ -4,16 +4,20 @@
  * Pick one candidate for a given date and write/merge into public/app/daily_auto.json
  * - non-destructive to existing daily.json
  * - 30-day dedup (within daily_auto.json only)
+ * - optional: attach multiple-choice distractors (composer/game)
  */
 const fs = require('fs');
 const path = require('path');
+const { normalizeAnswer } = require('./pipeline/normalize');
 
 function parseArgs(){
   const a = process.argv.slice(2);
   const i = a.indexOf('--in');  const input = i>=0 ? a[i+1] : 'public/app/daily_candidates_scored.jsonl';
   const d = a.indexOf('--date'); const date = d>=0 ? a[d+1] : (new Date(Date.now()+9*3600*1000)).toISOString().slice(0,10);
   const o = a.indexOf('--out'); const output = o>=0 ? a[o+1] : 'public/app/daily_auto.json';
-  return { input, date, output };
+  const wc = a.indexOf('--with-choices'); const withChoices = wc>=0 ? true : false;
+  const ds = a.indexOf('--dataset'); const datasetPath = ds>=0 ? a[ds+1] : 'public/build/dataset.json';
+  return { input, date, output, withChoices, datasetPath };
 }
 function ensureDir(dir){ fs.mkdirSync(dir, { recursive:true }); }
 function readJSON(p){ return JSON.parse(fs.readFileSync(p,'utf-8')); }
@@ -32,9 +36,53 @@ function datesBetween(startISO, days){
   }
   return out;
 }
+// deterministic PRNG (mulberry32) from a seed (u32)
+function mulberry32(a){ return function(){ let t=a+=0x6D2B79F5; t=Math.imul(t^t>>>15, t|1); t^=t+Math.imul(t^t>>>7, t|61); return ((t^t>>>14)>>>0)/4294967296; } }
+function fnv1a(str){ let h=2166136261>>>0; for(let i=0;i<str.length;i++){ h^=str.charCodeAt(i); h=Math.imul(h,16777619);} return h>>>0; }
+function pickN(arr, n, rnd){ const a=[...arr]; const out=[]; while(a.length && out.length<n){ const i=Math.floor(rnd()*a.length); out.push(a.splice(i,1)[0]); } return out; }
+function decade(y){ return y? Math.floor(y/10)*10 : null; }
+
+function buildPools(dataset, chosen){
+  const list = Array.isArray(dataset) ? dataset : (dataset.tracks || []);
+  const compSet = new Map(); const gameSet = new Map();
+  for(const r of list){
+    const comp = r.composer || ''; const game = r.game || ''; const plat = r.platform || r.system || null; const yr = r.year || null;
+    const cn = normalizeAnswer(comp); const gn = normalizeAnswer(game);
+    if (!cn || !gn) continue;
+    if (cn===chosen.norm.composer && gn===chosen.norm.game) continue;
+    const keyC = cn; if (!compSet.has(keyC)) compSet.set(keyC, { name: comp, year: yr, platform: plat });
+    const keyG = gn; if (!gameSet.has(keyG)) gameSet.set(keyG, { name: game, year: yr, platform: plat });
+  }
+  return { composers: Array.from(compSet.values()), games: Array.from(gameSet.values()) };
+}
+
+function makeChoices(dataset, chosen, seedStr){
+  const pools = buildPools(dataset, chosen);
+  const rnd = mulberry32(fnv1a(seedStr));
+  const targetDec = decade(chosen.year||0); const targetPlat = chosen.platform||null;
+  const compCandidates = pools.composers
+    .map(c => ({ c, score: (c.platform===targetPlat?2:0) + (targetDec && decade(c.year)===targetDec ? 1:0) }))
+    .sort((a,b)=> b.score-a.score);
+  const compTop = compCandidates.filter(x=>x.score>=1).map(x=>x.c);
+  const compPool = (compTop.length>=6? compTop : compCandidates.map(x=>x.c));
+  const compNames = pickN(compPool.filter(c=>normalizeAnswer(c.name)!==chosen.norm.composer).map(c=>c.name), 3, rnd);
+
+  const gameCandidates = pools.games
+    .map(g => ({ g, score: (g.platform===targetPlat?2:0) + (targetDec && decade(g.year)===targetDec ? 1:0) }))
+    .sort((a,b)=> b.score-a.score);
+  const gameTop = gameCandidates.filter(x=>x.score>=1).map(x=>x.g);
+  const gamePool = (gameTop.length>=6? gameTop : gameCandidates.map(x=>x.g));
+  const gameNames = pickN(gamePool.filter(g=>normalizeAnswer(g.name)!==chosen.norm.game).map(g=>g.name), 3, rnd);
+
+  return {
+    composer: shuffle([chosen.composer, ...compNames], rnd),
+    game: shuffle([chosen.game, ...gameNames], rnd),
+  };
+}
+function shuffle(arr, rnd){ const a=[...arr]; for(let i=a.length-1;i>0;i--){ const j=Math.floor(rnd()* (i+1)); [a[i],a[j]]=[a[j],a[i]];} return a; }
 
 function main(){
-  const { input, date, output } = parseArgs();
+  const { input, date, output, withChoices, datasetPath } = parseArgs();
   if(!fs.existsSync(input)){ console.error(`[generate-auto] not found: ${input}`); process.exit(1); }
   const cands = readJSONL(input);
   const outDir = path.dirname(output); ensureDir(outDir);
@@ -59,6 +107,14 @@ function main(){
   });
   if (pool.length === 0){ console.error('[generate-auto] no available candidates after dedup'); process.exit(2); }
   const chosen = pick(pool);
+  if (withChoices){
+    try{
+      const dataset = readJSON(datasetPath);
+      chosen.choices = makeChoices(dataset, chosen, date);
+    }catch(e){
+      console.warn('[generate-auto] with-choices requested but dataset not available:', e.message);
+    }
+  }
   auto.by_date[date] = chosen;
   fs.writeFileSync(output, JSON.stringify(auto, null, 2));
   console.log(`[generate-auto] date=${date} saved to ${output}`);


### PR DESCRIPTION
## Summary
- add script to enrich candidate media start times using dataset, URL params, and heuristics
- allow generate script to attach optional multiple-choice distractors and expose via workflow input
- document enrich and choice steps in pipeline

## Testing
- `npm test` *(fails: clojure: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b455b456e08324941fccda7279d0d4