### PR TITLE
Add daily auto choice overrides

### DIFF
--- a/public/app/auto_choices_loader.mjs
+++ b/public/app/auto_choices_loader.mjs
@@ -1,0 +1,62 @@
+// Load daily_auto.json and expose today's pick (and its choices) on window
+// Enabled only when ?auto=1 or ?daily_auto=1 is present.
+// Index.html loads this before mc.js so that generateChoices can consult it.
+
+import { normalize as normalizeV2 } from './normalize.mjs';
+
+function isEnabled() {
+  const sp = new URLSearchParams(location.search);
+  return sp.get('auto') === '1' || sp.get('daily_auto') === '1';
+}
+
+function todayJST() {
+  // get YYYY-MM-DD in JST
+  const now = new Date();
+  const tzNow = new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }));
+  const y = tzNow.getFullYear();
+  const m = String(tzNow.getMonth() + 1).padStart(2, '0');
+  const d = String(tzNow.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function requestedDate() {
+  const sp = new URLSearchParams(location.search);
+  const d = sp.get('daily');
+  if (d && /^\d{4}-\d{2}-\d{2}$/.test(d)) return d;
+  if (d === '1') return todayJST();
+  return todayJST();
+}
+
+async function loadAuto() {
+  try {
+    const res = await fetch('./daily_auto.json', { cache: 'no-store' });
+    if (!res.ok) return null;
+    const j = await res.json();
+    return j;
+  } catch (e) {
+    console.warn('[auto-choices] failed to load daily_auto.json', e);
+    return null;
+  }
+}
+
+function norm(s) {
+  try { return normalizeV2(String(s)); }
+  catch { return String(s || '').normalize('NFKC').trim().toLowerCase(); }
+}
+
+async function bootstrap() {
+  if (!isEnabled()) return;
+  const j = await loadAuto();
+  if (!j || !j.by_date) return;
+  const date = requestedDate();
+  const entry = j.by_date[date];
+  if (!entry) return;
+  // store raw entry for mc.js to match canonically (alias-aware)
+  window.__DAILY_AUTO_CHOSEN = entry;
+  // Also expose a normalized fallback key for debugging/helpers
+  window.__DAILY_AUTO_KEY_NORM = `${norm(entry.title)}|${norm(entry.game)}|${norm(entry.composer)}`;
+  console.log('[auto-choices] loaded for', date, entry.title, '/', entry.game);
+}
+
+bootstrap();
+

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -10,6 +10,9 @@
 <link rel="manifest" href="manifest.webmanifest">
 <!-- ESM の事前解決は modulepreload を使う。credentials 警告回避に crossorigin を明示 -->
 <link rel="modulepreload" href="app.js" crossorigin="anonymous">
+<!-- Load auto choices (no-op unless ?auto=1 or ?daily_auto=1) BEFORE mc.js so it can consult overrides -->
+<script type="module" src="./auto_choices_loader.mjs"></script>
+
   <script>
     // Conditionally load test API when ?mock=1
     (function() {

--- a/public/mc.js
+++ b/public/mc.js
@@ -1,4 +1,47 @@
+function _equalCanon(a, b) {
+  try {
+    if (!a || !b) return false;
+    return canonical(a.title) === canonical(b.title)
+      && canonical(a.game) === canonical(b.game)
+      && canonical(a.composer) === canonical(b.composer);
+  } catch (_) { return false; }
+}
+
+function _pickOverride(track, type, canonical) {
+  try {
+    const chosen = (typeof window !== 'undefined') && window.__DAILY_AUTO_CHOSEN;
+    if (!chosen || !chosen.choices) return null;
+    // ensure we're on the same record (avoid accidental cross-use)
+    const a = { title: track.title, game: track.game, composer: track.composer };
+    const b = { title: chosen.title, game: chosen.game, composer: chosen.composer };
+    if (!_equalCanon(a, b)) return null;
+    // choose field
+    const field = type === 'title-game' ? 'game' : 'composer';
+    const arr = (chosen.choices && chosen.choices[field]) || null;
+    if (!Array.isArray(arr) || arr.length < 2) return null;
+    // ensure correct is included
+    const correct = track[field];
+    const canon = v => canonical(v);
+    const hasCorrect = arr.some(v => canon(v) === canon(correct));
+    const dedup = [];
+    const seen = new Set();
+    const push = (v) => { const c = canon(v); if (!seen.has(c)) { seen.add(c); dedup.push(v); } };
+    if (!hasCorrect) push(correct);
+    arr.forEach(push);
+    // trim/pad to 4
+    while (dedup.length < 4) dedup.push(correct);
+    return dedup.slice(0, 4);
+  } catch (e) {
+    console.warn('[mc] override choices failed', e);
+    return null;
+  }
+}
+
 function generateChoices(track, type, tracks, canonical) {
+  // 1) Try override from daily_auto (when ?auto=1 and choices exist)
+  const overridden = _pickOverride(track, type, canonical);
+  if (overridden) return overridden;
+  // 2) Fallback to built-in heuristics
   const field = type === 'title-game' ? 'game' : 'composer';
   const correct = track[field];
   const used = new Set([canonical(correct)]);


### PR DESCRIPTION
## Summary
- load daily_auto.json and expose today's auto choices for debugging and overrides
- allow mc.js to use provided choices when auto mode is enabled
- load auto choices loader before mc.js in the app

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68b45b12f2688324b71699f5b976e840