### PR TITLE
feat(auto): add AUTO mode badge and workflow summary

### DIFF
--- a/.github/workflows/daily-auto.yml
+++ b/.github/workflows/daily-auto.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Summary details
         run: |
-          node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('public/app/daily_auto.json','utf-8'));const entries=Object.entries(j.by_date||{});const last=entries[entries.length-1];const s=[];s.push('### daily (auto) details');if(last){const [d,v]=last;s.push(`- date: **${d}**`);s.push(`- pick: ${v.title} / ${v.game} / ${v.composer} (diff=${v.difficulty||'n/a'})`);if(v.choices){s.push(`- choices: composer[${v.choices.composer.join(', ')}], game[${v.choices.game.join(', ')}]`);}}fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,s.join('\n')+'\n');"
+          node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('public/app/daily_auto.json','utf-8'));const entries=Object.entries(j.by_date||{});const last=entries[entries.length-1];const s=[];s.push('### daily (auto) details');if(last){const [d,v]=last;s.push(`- date: **${d}**`);s.push(`- pick: ${v.title} / ${v.game} / ${v.composer} (diff=${v.difficulty||'n/a'})`);const hasChoices=!!(v.choices&&Array.isArray(v.choices.composer)&&v.choices.composer.length);s.push(`- choices_override: ${hasChoices?'**available**':'none'}`);if(v.choices){s.push(`- choices: composer[${v.choices.composer.join(', ')}], game[${v.choices.game.join(', ')}]`);} } fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,s.join('\n')+'\n');"
 
       - name: Create PR (optional)
         if: ${{ github.event.inputs.apply_to_main == 'true' }}

--- a/public/app/auto_badge.mjs
+++ b/public/app/auto_badge.mjs
@@ -1,0 +1,57 @@
+// AUTO mode badge: shows a small pill when ?auto=1 (or ?daily_auto=1) and __DAILY_AUTO_CHOSEN is present.
+// A11y: role="status", aria-live polite, contrast-safe colors.
+
+function isEnabled() {
+  const sp = new URLSearchParams(location.search);
+  return sp.get('auto') === '1' || sp.get('daily_auto') === '1';
+}
+
+function injectBadge(text = 'AUTO') {
+  if (document.getElementById('auto-mode-badge')) return;
+  const badge = document.createElement('div');
+  badge.id = 'auto-mode-badge';
+  badge.setAttribute('role', 'status');
+  badge.setAttribute('aria-live', 'polite');
+  badge.style.position = 'fixed';
+  badge.style.top = '12px';
+  badge.style.right = '12px';
+  badge.style.zIndex = '9999';
+  badge.style.padding = '4px 10px';
+  badge.style.borderRadius = '999px';
+  badge.style.fontSize = '12px';
+  badge.style.fontWeight = '700';
+  badge.style.letterSpacing = '0.03em';
+  badge.style.background = '#0ea5e9';   // sky-500
+  badge.style.color = 'white';
+  badge.style.boxShadow = '0 2px 8px rgba(0,0,0,0.15)';
+  badge.style.userSelect = 'none';
+  badge.textContent = text;
+  document.body.appendChild(badge);
+}
+
+function updateTooltip(entry) {
+  const el = document.getElementById('auto-mode-badge');
+  if (!el) return;
+  if (entry) {
+    el.title = `AUTO: ${entry.title} / ${entry.game} (${entry.composer})`;
+  } else {
+    el.title = 'AUTO mode';
+  }
+}
+
+function bootstrap() {
+  if (!isEnabled()) return;
+  const tryShow = () => {
+    const entry = (typeof window !== 'undefined') && window.__DAILY_AUTO_CHOSEN;
+    injectBadge('AUTO');
+    updateTooltip(entry || null);
+  };
+  // DOM ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', tryShow);
+  } else {
+    tryShow();
+  }
+}
+
+bootstrap();

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -12,6 +12,7 @@
 <link rel="modulepreload" href="app.js" crossorigin="anonymous">
 <!-- Load auto choices (no-op unless ?auto=1 or ?daily_auto=1) BEFORE mc.js so it can consult overrides -->
 <script type="module" src="./auto_choices_loader.mjs"></script>
+<script type="module" src="./auto_badge.mjs"></script>
 
   <script>
     // Conditionally load test API when ?mock=1


### PR DESCRIPTION
## Summary
- show an "AUTO" status pill when running in auto modes
- document choice override availability in daily-auto workflow summary
- load the badge script on app index page

## Testing
- `npm test` *(fails: clojure not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b45e4ba12c83249d1161a0571d481e