### PR TITLE
chore(daily-auto): update daily_auto.json

### DIFF
--- a/public/app/daily_auto.json
+++ b/public/app/daily_auto.json
@@ -14,6 +14,35 @@
         "composer": "光田康典"
       },
       "difficulty": 4
+    },
+    "2025-09-01": {
+      "title": "メインテーマ",
+      "game": "ゼルダの伝説",
+      "composer": "近藤浩治",
+      "platform": null,
+      "year": 1986,
+      "media": null,
+      "source": "dataset",
+      "norm": {
+        "title": "メインテマ",
+        "game": "ゼルダの伝説",
+        "composer": "近藤浩治"
+      },
+      "difficulty": 4,
+      "choices": {
+        "composer": [
+          "Toby Fox",
+          "近藤浩治",
+          "すぎやまこういち",
+          "光田康典"
+        ],
+        "game": [
+          "ゼルダの伝説",
+          "クロノ・トリガー",
+          "ドラゴンクエスト",
+          "UNDERTALE"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Auto pipeline (harvest→score→generate) for (today JST).

- Writes `public/app/daily_auto.json` (separate from existing daily.json)
- 30-day dedup within the auto file

Default-off; merging does not affect current daily.json pipeline.