### PR TITLE
chore(daily-auto): update daily_auto.json

### DIFF
--- a/public/app/daily_auto.json
+++ b/public/app/daily_auto.json
@@ -43,6 +43,35 @@
           "UNDERTALE"
         ]
       }
+    },
+    "2025-08-29": {
+      "title": "クロノ・トリガー",
+      "game": "クロノ・トリガー",
+      "composer": "光田康典",
+      "platform": null,
+      "year": 1995,
+      "media": null,
+      "source": "dataset",
+      "norm": {
+        "title": "クロノトリガ",
+        "game": "クロノトリガ",
+        "composer": "光田康典"
+      },
+      "difficulty": 4,
+      "choices": {
+        "composer": [
+          "Toby Fox",
+          "すぎやまこういち",
+          "近藤浩治",
+          "光田康典"
+        ],
+        "game": [
+          "UNDERTALE",
+          "ドラゴンクエスト",
+          "クロノ・トリガー",
+          "ゼルダの伝説"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Auto pipeline (harvest→score→generate) for 2025-08-29.

- Writes `public/app/daily_auto.json` (separate from existing daily.json)
- 30-day dedup within the auto file

Default-off; merging does not affect current daily.json pipeline.