### PR TITLE
feat: allow heuristic media creation

### DIFF
--- a/.github/workflows/daily-auto.yml
+++ b/.github/workflows/daily-auto.yml
@@ -11,6 +11,10 @@ on:
         description: 'Attach multiple-choice distractors (composer/game) to output'
         required: false
         type: boolean
+      allow_heuristic_media:
+        description: 'If no media exists, create heuristic media with guessed start (safe default = false)'
+        required: false
+        type: boolean
       apply_to_main:
         description: 'Create PR to update public/app/daily_auto.json'
         required: false
@@ -52,7 +56,13 @@ jobs:
         run: node scripts/score_candidates.js --in public/app/daily_candidates.jsonl --out public/app/daily_candidates_scored.jsonl
 
       - name: Step 2.5 enrich media start
-        run: node scripts/enrich_media_start.js --in public/app/daily_candidates_scored.jsonl --out public/app/daily_candidates_scored_enriched.jsonl
+        env:
+          AHM: ${{ github.event.inputs.allow_heuristic_media }}
+        run: |
+          EXTRA=""
+          if [ "$AHM" = "true" ]; then EXTRA="--allow-heuristic-media"; fi
+          echo "allow_heuristic_media=$AHM (extra: $EXTRA)"
+          node scripts/enrich_media_start.js --in public/app/daily_candidates_scored.jsonl --out public/app/daily_candidates_scored_enriched.jsonl $EXTRA
 
       - name: Step 3/3 generate (for date)
         id: gen
@@ -80,6 +90,7 @@ jobs:
         env:
           INPUT_DATE: ${{ github.event.inputs.date }}
           RESOLVED_DATE: ${{ env.RESOLVED_DATE }}
+          ALLOW_HEURISTIC_MEDIA: ${{ github.event.inputs.allow_heuristic_media }}
         run: |
           node - <<'NODE'
           const fs = require('fs');
@@ -110,6 +121,12 @@ jobs:
             const avail = comp.length>0 || game.length>0;
             lines.push(`- choices_override: ${avail ? '**available**' : 'none'}`);
             if (avail) lines.push(`- choices: composer[${comp.join(', ')}], game[${game.join(', ')}]`);
+            // media glance
+            if (v.media) {
+              const kind = typeof v.media==='object' ? v.media.kind : 'n/a';
+              const start = typeof v.media==='object' ? v.media.start : undefined;
+              lines.push(`- media: kind=${kind ?? 'n/a'}, start=${(start ?? 'n/a')}`);
+            }
           } else {
             lines.push(`- pick: (no entry for this date)`);
           }

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -20,12 +20,18 @@
    node scripts/generate_daily_from_candidates.js --in public/app/daily_candidates_scored.jsonl --date 2025-09-01 --out public/app/daily_auto.json
    ```
 
-4. （任意）メディア開始秒の精度を上げる（enrich）  
+4. （任意）メディア開始秒の精度を上げる（enrich）
    ```bash
    node scripts/enrich_media_start.js --in public/app/daily_candidates_scored.jsonl --out public/app/daily_candidates_scored_enriched.jsonl
    ```
 
-5. （任意）ディストラクタを付与して出力（with-choices）  
+   - データに手掛かりが無い場合でも、**推定開始秒で media を作成**したいときは（検証用・既定OFF）:
+     ```bash
+     node scripts/enrich_media_start.js --in public/app/daily_candidates_scored.jsonl --out public/app/daily_candidates_scored_enriched.jsonl --allow-heuristic-media
+     ```
+   - `daily-auto.yml` の `allow_heuristic_media: true` で同等指定が可能です（Summary に kind/start を表示）。
+
+5. （任意）ディストラクタを付与して出力（with-choices）
    ```bash
    node scripts/generate_daily_from_candidates.js --in public/app/daily_candidates_scored_enriched.jsonl --date 2025-09-01 --out public/app/daily_auto.json --with-choices
    ```
@@ -33,6 +39,7 @@
 ### daily-auto.yml の入力
 - `date`: 空なら JST 今日
 - `with_choices`: **false** 既定（true で composer/game の選択肢を付与）
+- `allow_heuristic_media`: **false** 既定（media が空なら推定 start で作成）
 - `apply_to_main`: **false** 既定（PRを作る場合 true）
 
 ## 方針

--- a/scripts/enrich_media_start.js
+++ b/scripts/enrich_media_start.js
@@ -5,9 +5,10 @@
  * - Prefer dataset-provided starts (public/build/dataset.json)
  * - Parse common YouTube params (?t=, ?start=, #t=1m23s)
  * - Fallback heuristic on title keywords; default 45s
+ * - (opt-in) If --allow-heuristic-media is set, create `media` when absent using heuristic start
  *
  * Usage:
- *   node scripts/enrich_media_start.js --in public/app/daily_candidates_scored.jsonl --out public/app/daily_candidates_scored_enriched.jsonl
+ *   node scripts/enrich_media_start.js --in public/app/daily_candidates_scored.jsonl --out public/app/daily_candidates_scored_enriched.jsonl [--allow-heuristic-media]
  */
 const fs = require('fs');
 const path = require('path');
@@ -79,7 +80,8 @@ function parseArgs(){
   const i = args.indexOf('--in');  const input = i>=0 ? args[i+1] : 'public/app/daily_candidates_scored.jsonl';
   const o = args.indexOf('--out'); const output = o>=0 ? args[o+1] : 'public/app/daily_candidates_scored_enriched.jsonl';
   const d = args.indexOf('--dataset'); const datasetPath = d>=0 ? args[d+1] : 'public/build/dataset.json';
-  return { input, output, datasetPath };
+  const ahm = args.indexOf('--allow-heuristic-media'); const allowHeuristicMedia = ahm>=0;
+  return { input, output, datasetPath, allowHeuristicMedia };
 }
 
 function buildMediaIndex(dataset){
@@ -124,7 +126,7 @@ function heuristicStart(c){
 }
 
 async function main(){
-  const { input, output, datasetPath } = parseArgs();
+  const { input, output, datasetPath, allowHeuristicMedia } = parseArgs();
   if (!fs.existsSync(input)) { console.error(`[enrich] not found: ${input}`); process.exit(1); }
   let mediaIndex = new Map();
   if (fs.existsSync(datasetPath)){
@@ -140,7 +142,7 @@ async function main(){
   const rows = await readJSONL(input);
   const outDir = path.dirname(output); ensureDir(outDir);
   const ws = fs.createWriteStream(output, 'utf-8');
-  let touched = 0, total=0;
+  let touched = 0, total=0, createdHeuristic=0;
   for(const c of rows){
     total++;
     const key = `${c.norm.title}|${c.norm.game}|${c.norm.composer}`;
@@ -161,12 +163,16 @@ async function main(){
         }
       }
     } else {
-      // no media at all; leave null
+      // no media at all
+      if (allowHeuristicMedia){
+        c.media = { kind: 'heuristic', start: heuristicStart(c) };
+        touched++; createdHeuristic++;
+      }
     }
     ws.write(JSON.stringify(c) + '\n');
   }
   ws.end();
-  console.log(`[enrich] in=${total}, updated=${touched}, out=${output}`);
+  console.log(`[enrich] in=${total}, updated=${touched}, createdHeuristic=${createdHeuristic}, out=${output}`);
 }
 
 if (require.main === module) main();


### PR DESCRIPTION
## Summary
- add --allow-heuristic-media flag to enrich script to create media entries when missing
- expose allow_heuristic_media input in daily-auto workflow and surface media summary
- document heuristic media option in pipeline guide

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: repository access denied)*

------
https://chatgpt.com/codex/tasks/task_e_68b571cee5ec8324a12884ed4d48193f