### PR TITLE
feat: capture enrich stats

### DIFF
--- a/.github/workflows/candidates-harvest.yml
+++ b/.github/workflows/candidates-harvest.yml
@@ -33,10 +33,16 @@ jobs:
       - name: Harvest from dataset
         run: node scripts/harvest_candidates.js --out public/app/daily_candidates.jsonl
 
-      - name: Summary details
+      - name: Summary details (polish)
         run: |
-          node -e "const fs=require('fs');const f='public/app/daily_candidates.jsonl';const lines=fs.readFileSync(f,'utf-8').trim().split(/\n+/);const N=lines.length;const pick=(i)=>{try{return JSON.parse(lines[i])}catch(e){return null}};const s=[];s.push('### candidates (harvest) details');s.push(`- count: **${N}**`);for(let i=0;i<Math.min(3,N);i++){const o=pick(i);if(o){s.push(`- sample${i+1}: ${o.title} / ${o.game} / ${o.composer}`)}};fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,s.join('\n')+'\n');"
-
+          node - <<'NODE'
+          const fs=require('fs');
+          const f='public/app/daily_candidates.jsonl';
+          const lines = fs.existsSync(f) ? fs.readFileSync(f,'utf-8').trim().split(/\n+/) : [];
+          const N = lines.length;
+          const s = ['### candidates (harvest) details','- count: **'+N+'**'];
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, s.join('\n')+'\n');
+          NODE
       - name: Upload candidates artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/daily-auto.yml
+++ b/.github/workflows/daily-auto.yml
@@ -80,6 +80,13 @@ jobs:
           echo "resolved-date=$DATE" >> "$GITHUB_OUTPUT"
           node scripts/generate_daily_from_candidates.js --in public/app/daily_candidates_scored_enriched.jsonl --date "$DATE" --out public/app/daily_auto.json $EXTRA
 
+      - name: Read enrich stats
+        id: enrichstats
+        run: |
+          if [ -f public/app/enrich_stats.json ]; then
+            echo "stats=$(cat public/app/enrich_stats.json | tr -d '\n')" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload artifact (daily_auto.json)
         uses: actions/upload-artifact@v4
         with:
@@ -91,6 +98,7 @@ jobs:
           INPUT_DATE: ${{ github.event.inputs.date }}
           RESOLVED_DATE: ${{ env.RESOLVED_DATE }}
           ALLOW_HEURISTIC_MEDIA: ${{ github.event.inputs.allow_heuristic_media }}
+          ENRICH_JSON: ${{ steps.enrichstats.outputs.stats }}
         run: |
           node - <<'NODE'
           const fs = require('fs');
@@ -98,6 +106,8 @@ jobs:
           const raw = fs.readFileSync('public/app/daily_auto.json','utf-8');
           const j = JSON.parse(raw);
           const by = j.by_date || {};
+          let enrich = null;
+          try { enrich = JSON.parse(process.env.ENRICH_JSON||'null'); } catch {}
           function todayJST(){
             try {
               return new Date(new Date().toLocaleString('en-US', { timeZone: TZ })).toISOString().slice(0,10);
@@ -121,6 +131,10 @@ jobs:
             const avail = comp.length>0 || game.length>0;
             lines.push(`- choices_override: ${avail ? '**available**' : 'none'}`);
             if (avail) lines.push(`- choices: composer[${comp.join(', ')}], game[${game.join(', ')}]`);
+            if (enrich) {
+              const e = enrich;
+              lines.push(`- enrich: updated=${e.updated ?? 'n/a'}, createdHeuristic=${e.createdHeuristic ?? 'n/a'}`);
+            }
             // media glance
             if (v.media) {
               const kind = typeof v.media==='object' ? v.media.kind : 'n/a';

--- a/public/app/auto_choices_loader.mjs
+++ b/public/app/auto_choices_loader.mjs
@@ -8,6 +8,10 @@ function isEnabled() {
   const sp = new URLSearchParams(location.search);
   return sp.get('auto') === '1' || sp.get('daily_auto') === '1';
 }
+function isForceAny() {
+  const sp = new URLSearchParams(location.search);
+  return sp.get('auto_any') === '1';
+}
 
 function todayJST() {
   // get YYYY-MM-DD in JST
@@ -53,9 +57,12 @@ async function bootstrap() {
   if (!entry) return;
   // store raw entry for mc.js to match canonically (alias-aware)
   window.__DAILY_AUTO_CHOSEN = entry;
+  if (isForceAny()) {
+    window.__DAILY_AUTO_FORCE = true;
+  }
   // Also expose a normalized fallback key for debugging/helpers
   window.__DAILY_AUTO_KEY_NORM = `${norm(entry.title)}|${norm(entry.game)}|${norm(entry.composer)}`;
-  console.log('[auto-choices] loaded for', date, entry.title, '/', entry.game);
+  console.log('[auto-choices] loaded for', date, entry.title, '/', entry.game, isForceAny() ? '(FORCE any)' : '');
 }
 
 bootstrap();

--- a/public/mc.js
+++ b/public/mc.js
@@ -1,6 +1,7 @@
 function _equalCanon(a, b) {
   try {
     if (!a || !b) return false;
+    if (typeof canonical !== 'function') return false;
     return canonical(a.title) === canonical(b.title)
       && canonical(a.game) === canonical(b.game)
       && canonical(a.composer) === canonical(b.composer);
@@ -10,11 +11,12 @@ function _equalCanon(a, b) {
 function _pickOverride(track, type, canonical) {
   try {
     const chosen = (typeof window !== 'undefined') && window.__DAILY_AUTO_CHOSEN;
+    const forceAny = (typeof window !== 'undefined') && window.__DAILY_AUTO_FORCE;
     if (!chosen || !chosen.choices) return null;
     // ensure we're on the same record (avoid accidental cross-use)
     const a = { title: track.title, game: track.game, composer: track.composer };
     const b = { title: chosen.title, game: chosen.game, composer: chosen.composer };
-    if (!_equalCanon(a, b)) return null;
+    if (!forceAny && !_equalCanon(a, b)) return null;
     // choose field
     const field = type === 'title-game' ? 'game' : 'composer';
     const arr = (chosen.choices && chosen.choices[field]) || null;
@@ -26,7 +28,8 @@ function _pickOverride(track, type, canonical) {
     const dedup = [];
     const seen = new Set();
     const push = (v) => { const c = canon(v); if (!seen.has(c)) { seen.add(c); dedup.push(v); } };
-    if (!hasCorrect) push(correct);
+    // In forceAny mode, always ensure correct is present first
+    if (forceAny || !hasCorrect) push(correct);
     arr.forEach(push);
     // trim/pad to 4
     while (dedup.length < 4) dedup.push(correct);

--- a/scripts/enrich_media_start.js
+++ b/scripts/enrich_media_start.js
@@ -172,7 +172,14 @@ async function main(){
     ws.write(JSON.stringify(c) + '\n');
   }
   ws.end();
+  const stats = { in: total, updated: touched, createdHeuristic, out: output };
   console.log(`[enrich] in=${total}, updated=${touched}, createdHeuristic=${createdHeuristic}, out=${output}`);
+  try {
+    const statsPath = path.join(path.dirname(output), 'enrich_stats.json');
+    fs.writeFileSync(statsPath, JSON.stringify(stats, null, 2));
+  } catch (e) {
+    // non-fatal
+  }
 }
 
 if (require.main === module) main();


### PR DESCRIPTION
## Summary
- capture enrich stats JSON in enrich_media_start script and surface in daily-auto workflow
- support auto_any query to force override choices and guard canonical usage
- polish candidate harvest summary step

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5753c2b348324ac32c1025a517af4