### PR TITLE
Add JS redirect post-processing for daily pages

### DIFF
--- a/.github/workflows/daily-auto.yml
+++ b/.github/workflows/daily-auto.yml
@@ -185,6 +185,9 @@ jobs:
           pull-request-number: ${{ steps.cpr.outputs['pull-request-number'] }}
           merge-method: squash
 
+      - name: Post-process daily HTML (JS redirect with no-redirect support)
+        run: node scripts/convert_daily_redirect_to_js.js
+
       - name: Summary (result)
         if: ${{ always() }}
         env:

--- a/docs/ops-tips.md
+++ b/docs/ops-tips.md
@@ -1,0 +1,28 @@
+# 運用 Tips（daily / workflows）
+
+本メモは、`daily (auto)` パイプラインや `/daily/*.html` の運用でハマりやすい点をまとめたものです。
+
+## 1. GitHub Actions の `outputs` 参照（ハイフンキー）
+- `steps.<id>.outputs['pull-request-url']` のように **ブラケット記法**を使う。
+- ドット記法（`steps.<id>.outputs.pull-request-url`）は **NG**。
+- `if:` には **真偽値**を渡す。URL 等の「非空文字列」は避け、`!= ''` 比較などで明示する。
+
+## 2. Summary 出力のベストプラクティス
+- `run: |` を使い、複数行の `echo` を **`>> $GITHUB_STEP_SUMMARY`** に追記する。
+- 日付は `RESOLVED_DATE → inputs.date → JST 今日` の順にフォールバックする。
+- ワークフロー失敗でも Summary を必ず出すため、`if: ${{ always() }}` を活用する。
+
+## 3. `/daily/*.html` のリダイレクト制御
+- 従来の **meta refresh** は即時遷移でデバッグ性が低い。
+- JS ベースのリダイレクトに置換し、以下の URL パラメータをサポートする。
+  - `?no-redirect=1` : リダイレクト抑止（デバッグ・検証用）
+  - `?redirectDelayMs=1500` : 遅延（ミリ秒指定）
+- 変換用ユーティリティ: `node scripts/convert_daily_redirect_to_js.js`
+
+## 4. 差分が無いと PR を作らないのは正常
+- `daily_auto.json` に変更がない場合、PR が作成されない。
+- Summary では `(no changes / not created)` のように明記すること。
+
+## 5. media（ヒューリスティック）の検証
+- `allow_heuristic_media: true` で `media: {kind:"heuristic", start:...}` を生成・検証。
+- 本番運用では off を基本とし、検証時のみ on を推奨。

--- a/scripts/convert_daily_redirect_to_js.js
+++ b/scripts/convert_daily_redirect_to_js.js
@@ -1,0 +1,92 @@
+// scripts/convert_daily_redirect_to_js.js
+// Post-processes public/daily/*.html:
+//  - Replace <meta http-equiv="refresh" ...> with a JS-based redirect
+//  - Adds support for ?no-redirect=1 to suppress redirect (for debugging)
+//  - Adds support for ?redirectDelayMs=1500 to delay redirect
+//
+// Usage:
+//   node scripts/convert_daily_redirect_to_js.js
+//
+// Notes:
+//  - Safe to run multiple times; idempotent.
+//  - Keeps existing content and tries to preserve the "AUTOで遊ぶ" button section.
+
+const fs = require('fs');
+const path = require('path');
+
+const DAILY_DIR = path.join(process.cwd(), 'public', 'daily');
+
+function toJSRedirect(targetUrl) {
+  // JS redirect snippet with no-redirect/redirectDelayMs support
+  return [
+    '<script>',
+    '(function(){',
+    '  try {',
+    '    var params = new URLSearchParams(location.search || "");',
+    '    if (params.get("no-redirect") === "1") {',
+    '      console.log("[daily] no-redirect=1; skipping redirect");',
+    '      return;',
+    '    }',
+    '    var delay = parseInt(params.get("redirectDelayMs") || "0", 10);',
+    '    if (isNaN(delay) || delay < 0) delay = 0;',
+    '    var url = ' + JSON.stringify(targetUrl) + ';',
+    '    setTimeout(function(){ location.replace(url); }, delay);',
+    '  } catch (e) {',
+    '    console.warn("[daily] redirect exception:", e);',
+    '    // Fallback: do nothing (stay on the page for inspection)',
+    '  }',
+    '})();',
+    '</script>'
+  ].join('\n');
+}
+
+function rewriteHtml(html) {
+  // 1) Detect meta refresh
+  // Matches: <meta http-equiv="refresh" content="0; url=..."> (variations tolerated)
+  const metaRegex = /<meta\s+http-equiv=["']?refresh["']?\s+content=["']?\s*\d+\s*;\s*url=([^"'>\s]+)["']?\s*\/?>/i;
+  const m = html.match(metaRegex);
+
+  if (!m) {
+    // Already converted or no redirect present; return as-is
+    return html;
+  }
+  const targetUrl = m[1];
+
+  // 2) Remove meta tag and inject JS redirect (preferably near the end of <head>)
+  let out = html.replace(metaRegex, '');
+  const headCloseIdx = out.search(/<\/head>/i);
+  const snippet = toJSRedirect(targetUrl) + '\n';
+
+  if (headCloseIdx !== -1) {
+    out = out.slice(0, headCloseIdx) + snippet + out.slice(headCloseIdx);
+  } else {
+    // No </head> found; append at end
+    out += '\n' + snippet;
+  }
+
+  return out;
+}
+
+function processDailyHtml(dir) {
+  if (!fs.existsSync(dir)) {
+    console.error("Not found:", dir);
+    process.exit(1);
+  }
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.html'));
+  let changed = 0;
+  for (const f of files) {
+    const p = path.join(dir, f);
+    const html = fs.readFileSync(p, 'utf8');
+    const newHtml = rewriteHtml(html);
+    if (newHtml !== html) {
+      fs.writeFileSync(p, newHtml, 'utf8');
+      changed++;
+      console.log("[daily] converted:", f);
+    } else {
+      console.log("[daily] unchanged:", f);
+    }
+  }
+  console.log("[daily] done. changed =", changed, "/", files.length);
+}
+
+processDailyHtml(DAILY_DIR);


### PR DESCRIPTION
## Summary
- add `scripts/convert_daily_redirect_to_js.js` utility to replace meta refresh with JS-based redirect supporting debug params
- document operational tips for daily workflows
- integrate post-processing step into daily-auto workflow

## Testing
- `npm test` *(fails: clojure: not found)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b59b6eb0dc8324b91937acd19aa4d5