### PR TITLE
feat: add configurable js redirect

### DIFF
--- a/scripts/generate_daily_index.js
+++ b/scripts/generate_daily_index.js
@@ -70,7 +70,7 @@ function jstISO(d = new Date()) {
 <html lang="ja"><head>
   <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
   <title>VGM Quiz — Daily latest</title>
-  <meta http-equiv="refresh" content="0; url=./${d}.html">
+  <script>(function(){try{var p=new URLSearchParams(location.search||"");if(p.get("no-redirect")==="1")return;var delay=parseInt(p.get("redirectDelayMs")||"0",10);if(isNaN(delay)||delay<0)delay=0;setTimeout(function(){location.replace(${JSON.stringify('./'+d+'.html')});},delay);}catch(e){}})();</script>
 </head><body>
   <p>Redirecting to <a href="./${d}.html">${d}</a> …</p>
 </body></html>`;

--- a/scripts/generate_share_page.js
+++ b/scripts/generate_share_page.js
@@ -84,7 +84,7 @@ function jstDateString(d = new Date()) {
   <meta name="twitter:description" content="${ogDesc}">
   <meta name="twitter:image" content="${ogpUrlWithV}">
   <meta name="twitter:url" content="${pageUrl}">
-  <meta http-equiv="refresh" content="0; url=${appUrl}">
+  <script>(function(){try{var p=new URLSearchParams(location.search||"");if(p.get("no-redirect")==="1")return;var d=parseInt(p.get("redirectDelayMs")||"0",10);if(isNaN(d)||d<0)d=0;setTimeout(function(){location.replace(${JSON.stringify(appUrl)});},d);}catch(e){}})();</script>
   <!-- daily-hash:${dailyHash} -->
 </head>
 <body>


### PR DESCRIPTION
## Summary
- replace meta refresh redirect with JS redirect in share page generator
- swap daily latest redirect to JS with optional delay and query control

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a5ff425883248a2ce5e79636f580