### PR TITLE
Add daily page smoke tests

### DIFF
--- a/.github/workflows/e2e-daily-pages-smoke.yml
+++ b/.github/workflows/e2e-daily-pages-smoke.yml
@@ -1,0 +1,33 @@
+name: e2e (daily share & latest smoke)
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_url:
+        description: "Base app URL (must end with /app/)"
+        required: false
+        type: string
+  schedule:
+    - cron: "20 19 * * *" # UTC 19:20 ≒ JST 04:20 (after daily.json generator)
+
+jobs:
+  daily-pages-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run share page smoke
+        env:
+          APP_URL: ${{ inputs.app_url || 'https://nantes-rfli.github.io/vgm-quiz/app/' }}
+        run: node e2e/test_daily_share_page.js
+
+      - name: Run latest page smoke
+        env:
+          APP_URL: ${{ inputs.app_url || 'https://nantes-rfli.github.io/vgm-quiz/app/' }}
+        run: node e2e/test_daily_latest_page.js

--- a/docs/e2e-daily-pages-smoke.md
+++ b/docs/e2e-daily-pages-smoke.md
@@ -1,0 +1,22 @@
+# e2e (daily share & latest smoke)
+
+`/daily/YYYY-MM-DD.html` と `/daily/latest.html` の **JS リダイレクト**・**デバッグ用クエリ**の基本動作を確認するスモークです。
+
+## 使い方
+
+- Actions → **e2e (daily share & latest smoke)** → Run workflow
+  - `app_url` は省略可（既定: `https://nantes-rfli.github.io/vgm-quiz/app/`）
+- またはスケジュール（JST 04:20 相当）で自動実行
+
+## 検査内容
+
+- `/daily/YYYY-MM-DD.html?no-redirect=1` と `/daily/latest.html?no-redirect=1` を取得（`status=200`）
+- HTML に以下のいずれかが含まれることを確認
+  - `location.replace(` （JS リダイレクトの痕跡）
+  - `AUTOで遊ぶ` （導線の可視化）
+  - `<link rel="canonical" href="../app/?daily=YYYY-MM-DD">`
+
+## 備考
+
+- CI **Required** ではありません（安全のため分離）。
+- 直近で `daily.json generator (JST)` 実行が無いと、当日分 HTML が存在しない場合があります。

--- a/e2e/test_daily_latest_page.js
+++ b/e2e/test_daily_latest_page.js
@@ -1,0 +1,24 @@
+// e2e/test_daily_latest_page.js
+// Smoke test: /daily/latest.html?no-redirect=1 renders and contains expected markers.
+async function main() {
+  const appUrl = process.env.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/';
+  if (!appUrl.endsWith('/app/')) throw new Error(`APP_URL must end with '/app/' (got: ${appUrl})`);
+  const dailyBase = appUrl.replace('/app/', '/daily/');
+  const url = `${dailyBase}latest.html?no-redirect=1`;
+
+  console.log('[E2E daily latest] URL =', url);
+  const res = await fetch(url, { redirect: 'manual' });
+  if (res.status !== 200) throw new Error(`unexpected status: ${res.status}`);
+  const html = await res.text();
+  const hints = [
+    'location.replace(',
+    'AUTOで遊ぶ',
+    '<link rel="canonical" href="../app/?daily=',
+  ];
+  if (!hints.some(h => html.includes(h))) {
+    console.error(html.slice(0, 1200));
+    throw new Error('expected markers not found in latest page');
+  }
+  console.log('[E2E daily latest] OK');
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/e2e/test_daily_share_page.js
+++ b/e2e/test_daily_share_page.js
@@ -1,0 +1,26 @@
+// e2e/test_daily_share_page.js
+// Smoke test: /daily/YYYY-MM-DD.html?no-redirect=1 renders and contains expected markers.
+async function main() {
+  const appUrl = process.env.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/';
+  if (!appUrl.endsWith('/app/')) throw new Error(`APP_URL must end with '/app/' (got: ${appUrl})`);
+  const jstFmt = new Intl.DateTimeFormat('ja-JP', { timeZone: 'Asia/Tokyo', year: 'numeric', month: '2-digit', day: '2-digit' });
+  const jstDate = jstFmt.format(new Date()).replaceAll('/', '-').replace(/^([0-9]{4})-([0-9]{2})-([0-9]{2})$/, (_, y, m, d) => `${y}-${m}-${d}`);
+  const dailyBase = appUrl.replace('/app/', '/daily/');
+  const shareUrl = `${dailyBase}${jstDate}.html?no-redirect=1`;
+
+  console.log('[E2E daily share] URL =', shareUrl);
+  const res = await fetch(shareUrl, { redirect: 'manual' });
+  if (res.status !== 200) throw new Error(`unexpected status: ${res.status}`);
+  const html = await res.text();
+  const hints = [
+    'location.replace(',
+    'AUTOで遊ぶ',
+    `<link rel="canonical" href="../app/?daily=${jstDate}">`,
+  ];
+  if (!hints.some(h => html.includes(h))) {
+    console.error(html.slice(0, 1200));
+    throw new Error('expected markers not found in share page');
+  }
+  console.log('[E2E daily share] OK');
+}
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add Node E2E smoke tests for daily share and latest pages
- schedule GitHub workflow to run them manually or daily
- document smoke test usage and checks

## Testing
- `npm test` *(fails: clojure: not found)*
- `node e2e/test_daily_share_page.js` *(fails: fetch failed)*
- `node e2e/test_daily_latest_page.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5afbc1d488324843af78de4bc7171