### PR TITLE
chore: add lighthouse budgets CI

### DIFF
--- a/.github/workflows/lighthouse-budgets.yml
+++ b/.github/workflows/lighthouse-budgets.yml
@@ -1,0 +1,26 @@
+name: lighthouse (budgets, nightly)
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "30 19 * * *" # UTC 19:30 ≒ JST 04:30 (after daily.json generator)
+
+jobs:
+  lhci-budgets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Lighthouse CI
+        run: npm i -g @lhci/cli@0.14
+
+      - name: Run LHCI (budgets)
+        run: lhci autorun --config=.lighthouserc.budgets.json

--- a/.lighthouserc.budgets.json
+++ b/.lighthouserc.budgets.json
@@ -1,0 +1,21 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 1,
+      "url": [
+        "https://nantes-rfli.github.io/vgm-quiz/app/",
+        "https://nantes-rfli.github.io/vgm-quiz/daily/latest.html?no-redirect=1"
+      ]
+    },
+    "assert": {
+      "preset": "lighthouse:recommended",
+      "assertions": {
+        "categories:performance": ["warn", {"minScore": 0.85}],
+        "budgets": ["warn", {"budgetsFile": "lighthouse/budgets.json"}]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/docs/ci-status.md
+++ b/docs/ci-status.md
@@ -1,0 +1,10 @@
+# CI / Ops Status
+
+- **e2e (daily share & latest smoke)**  
+  ![e2e (daily share & latest smoke)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e-daily-pages-smoke.yml/badge.svg?branch=main)
+
+- **lighthouse (budgets, nightly)**  
+  ![lighthouse (budgets, nightly)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse-budgets.yml/badge.svg?branch=main)
+
+- **daily.json generator (JST)**  
+  *(既存ワークフロー名に合わせて必要なら差し替えてください)*

--- a/docs/lighthouse-budgets.md
+++ b/docs/lighthouse-budgets.md
@@ -1,0 +1,16 @@
+# lighthouse (budgets, nightly)
+
+- 目的: **退行の早期検知**（ただし誤検知を避けるため、しきい値は緩め / `warn`）
+- 対象URL:
+  - `/app/`
+  - `/daily/latest.html?no-redirect=1`
+- 実行: Actions → **lighthouse (budgets, nightly)**（手動 or 深夜定期/JST 04:30 相当）
+
+## しきい値（初期）
+- `categories:performance >= 0.85`（warn）
+- Budgets（warn）
+  - `total` size ≤ **2.5MB**
+  - `script` size ≤ **1.5MB**
+  - `resource count (total)` ≤ **200**
+
+> Required には入れていません。必要に応じてしきい値は段階的に引き締めてください。

--- a/lighthouse/budgets.json
+++ b/lighthouse/budgets.json
@@ -1,0 +1,12 @@
+[
+  {
+    "path": "/*",
+    "resourceCounts": [
+      { "resourceType": "total",   "budget": 200 }
+    ],
+    "resourceSizes": [
+      { "resourceType": "total",   "budget": 2500 },
+      { "resourceType": "script",  "budget": 1500 }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add Lighthouse CI config with performance and budget thresholds
- track resource budgets in dedicated JSON file
- document nightly Lighthouse budgets workflow and badges

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b1f4a2a88324842283f2e34554cd