### PR TITLE
Add AUTO badge smoke test workflow

### DIFF
--- a/.github/workflows/e2e-auto-badge-smoke.yml
+++ b/.github/workflows/e2e-auto-badge-smoke.yml
@@ -1,0 +1,44 @@
+name: e2e (auto badge smoke)
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_url:
+        description: "Base app URL (must end with /app/)"
+        required: false
+        type: string
+      date:
+        description: "YYYY-MM-DD (optional, default JST today)"
+        required: false
+        type: string
+  schedule:
+    - cron: "25 19 * * *" # UTC 19:25 ≒ JST 04:25 (after daily.json generator)
+
+jobs:
+  auto-badge-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run AUTO badge smoke
+        env:
+          APP_URL: ${{ inputs.app_url || 'https://nantes-rfli.github.io/vgm-quiz/app/' }}
+          DATE: ${{ inputs.date }}
+        run: node e2e/test_auto_badge_smoke.mjs
+
+      - name: Upload failure screenshot (if any)
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: auto_badge_failure
+          path: auto_badge_failure.png
+          if-no-files-found: ignore

--- a/docs/e2e-auto-badge-smoke.md
+++ b/docs/e2e-auto-badge-smoke.md
@@ -1,0 +1,13 @@
+# e2e (auto badge smoke)
+
+`/app/?daily=YYYY-MM-DD&auto=1` で **AUTOバッジ**が描画されるかを Playwright Chromium で確認するスモークです。
+
+## 使い方
+- Actions → **e2e (auto badge smoke)** → Run workflow
+  - `app_url` は省略可（既定: `https://nantes-rfli.github.io/vgm-quiz/app/`）
+  - `date` は未指定なら **JST 今日**
+- 失敗時は `auto_badge_failure.png` をアーティファクトとして取得可能
+
+## 仕様
+- まず `&auto=1` で確認し、見つからない場合は `&auto_any=1` にフォールバック（検証用途）
+- 必要に応じて Required に格上げせず、ナイトリー（JST 04:25相当）で自動実行

--- a/e2e/test_auto_badge_smoke.mjs
+++ b/e2e/test_auto_badge_smoke.mjs
@@ -1,0 +1,83 @@
+/* e2e/test_auto_badge_smoke.mjs
+ * Smoke test: /app/?daily=YYYY-MM-DD&auto=1 renders and shows "AUTO" badge.
+ * Falls back to &auto_any=1 if strict matching prevents "AUTO" showing.
+ * Usage: node e2e/test_auto_badge_smoke.mjs
+ *
+ * Env:
+ *   APP_URL (must end with /app/, default: https://nantes-rfli.github.io/vgm-quiz/app/)
+ *   DATE (YYYY-MM-DD, optional; default JST today)
+ */
+import { chromium } from 'playwright';
+
+function jstToday() {
+  const f = new Intl.DateTimeFormat('ja-JP', { timeZone: 'Asia/Tokyo', year: 'numeric', month: '2-digit', day: '2-digit' });
+  const s = f.format(new Date());
+  const [y,m,d] = s.split('/');
+  return `${y}-${m}-${d}`;
+}
+
+function buildUrl(base, date, opts={}) {
+  const u = new URL(base);
+  u.searchParams.set('daily', date);
+  u.searchParams.set('auto', '1');
+  if (opts.auto_any) u.searchParams.set('auto_any', '1');
+  return u.toString();
+}
+
+async function hasAutoBadge(page) {
+  return await page.evaluate(() => {
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    let node;
+    while ((node = walker.nextNode())) {
+      if ((node.textContent || '').trim() === 'AUTO' || (node.textContent || '').includes('AUTO')) {
+        return true;
+      }
+    }
+    return !!document.querySelector('[data-auto-badge], .auto-badge, [aria-label="AUTO"], [title="AUTO"]');
+  });
+}
+
+async function run() {
+  const base = process.env.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/';
+  if (!base.endsWith('/app/')) throw new Error(`APP_URL must end with "/app/": ${base}`);
+  const date = process.env.DATE || jstToday();
+
+  const primary = buildUrl(base, date, { auto_any: false });
+  const fallback = buildUrl(base, date, { auto_any: true });
+
+  console.log('[auto-badge] base =', base);
+  console.log('[auto-badge] date =', date);
+  console.log('[auto-badge] url  =', primary);
+
+  const browser = await chromium.launch({ headless: true });
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  const page = await ctx.newPage();
+
+  const gotoOpts = { waitUntil: 'networkidle', timeout: 30000 };
+  await page.goto(primary, gotoOpts);
+
+  // wait for app boot (root element present)
+  await page.waitForSelector('body', { timeout: 10000 });
+
+  // check badge with retries
+  let ok = await hasAutoBadge(page);
+  if (!ok) {
+    console.log('[auto-badge] Not found on strict URL, trying auto_any fallback:', fallback);
+    await page.goto(fallback, gotoOpts);
+    await page.waitForSelector('body', { timeout: 10000 });
+    ok = await hasAutoBadge(page);
+  }
+
+  if (!ok) {
+    await page.screenshot({ path: 'auto_badge_failure.png', fullPage: true });
+    throw new Error('AUTO badge not found (see auto_badge_failure.png)');
+  }
+
+  console.log('[auto-badge] OK');
+  await browser.close();
+}
+
+run().catch(async (e) => {
+  console.error('[auto-badge] FAILED:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add Playwright smoke test that checks AUTO badge and falls back to `auto_any`
- schedule nightly GitHub Action to run the smoke test and upload screenshot on failure
- document the workflow and its usage

## Testing
- `npm test` *(fails: clojure: not found)*
- `curl -L -o /tmp/install-clojure.sh https://download.clojure.org/install/linux-install-1.11.1.1271.sh` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b519195083249953bf97a8ed5f07