### PR TITLE
ci: install Playwright before badge smoke tests

### DIFF
--- a/.github/workflows/e2e-auto-badge-smoke.yml
+++ b/.github/workflows/e2e-auto-badge-smoke.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           node-version: 20
 
+      - name: Install Playwright package
+        run: npm i --no-save playwright
+
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 


### PR DESCRIPTION
## Summary
- install Playwright package in auto badge smoke workflow so Chromium install works

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b6f790c88324bda97cfdf6a0ba23