### PR TITLE
docs: add handbook and ops references

### DIFF
--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -1,0 +1,68 @@
+# VGM Quiz Handbook
+
+本ドキュメントは、**開発 / データパイプライン / 配信 / 運用 / 監視 / QA** を一箇所に集約したハンドブックです。
+
+## 0. 用語（Glossary）
+- **daily.json generator (JST)**: Clojure ビルドから `public/build/dataset.json` を発行し、`scripts/*` により `/public/app/daily.json` と `/public/daily/*.html` を生成する定期処理（手動実行可）。
+- **daily (auto …)**: `public/app/daily_auto.json` を生成するパイプライン。**HTML は生成しない**。
+- **AUTO モード**: `?auto=1`（必要なら `&auto_any=1`）を付与して、`daily_auto.json` の choices をアプリ側に反映。
+- **JS リダイレクト**: `/public/daily/*.html` は `meta refresh` ではなく **JS リダイレクト**でアプリへ遷移。`?no-redirect=1` で抑止、`?redirectDelayMs=1500` で遅延。
+- **SW ハンドシェイク**: `public/app/version.json` を用いた Service Worker の更新検知（~60 秒ポーリング）。
+
+より詳細は [docs/glossary.md](glossary.md) 参照。
+
+## 1. アーキテクチャ概要
+- **データ**: Clojure で `public/build/dataset.json` を生成 → Node スクリプトで `daily.json` / `daily_auto.json` / `/public/daily/*.html` を生成。
+- **アプリ**: GitHub Pages で `/public/app/` を配信。クエリ `?daily=YYYY-MM-DD` で対象データ表示。`?auto=1` で AUTO 反映。
+- **配信**: GitHub Actions（Required → Auto-merge）。フッター右で `Dataset: vN • commit: abcdefg • updated: YYYY-MM-DD HH:mm` を目視確認。
+
+図は略。詳細は [docs/architecture.md](architecture.md)。
+
+## 2. パイプライン（責務の分離）
+- **daily.json generator (JST)** = `/public/app/daily.json` **と** `/public/daily/*.html` を生成 / 更新
+- **daily (auto …)** = `/public/app/daily_auto.json` の生成 / 更新（**HTML には触れない**）
+
+運用の具体的な流れは [docs/pipeline.md](pipeline.md) と [docs/ops-runbook.md](ops-runbook.md)。
+
+## 3. 運用 Tips（落とし穴）
+- GitHub Actions の `outputs` で **ハイフンキー**はブラケット記法：`steps.<id>.outputs['pull-request-url']`
+- `if:` は **真偽値**で評価（URL 文字列そのままは不可）
+- `Summary` は `run: |` で整形し、`RESOLVED_DATE → inputs.date → JST今日` の順にフォールバック
+- PR は **差分が無いと作られない**（正常）
+- `/daily/*.html` の JS リダイレクトで `?no-redirect=1` / `?redirectDelayMs=...` が使える
+
+詳細は [docs/ops-tips.md](ops-tips.md)。
+
+## 4. QA / 監視
+- **E2E（/daily シェア & latest）**: [docs/e2e-daily-pages-smoke.md](e2e-daily-pages-smoke.md)
+- **E2E（AUTO バッジ）**: [docs/e2e-auto-badge-smoke.md](e2e-auto-badge-smoke.md)
+- **Lighthouse Budgets**（warn, nightly）: [docs/lighthouse-budgets.md](lighthouse-budgets.md)
+- **CI バッジ一覧**: [docs/ci-status.md](ci-status.md)
+
+## 5. リリース・チェックリスト
+- PR の説明に **実行したワークフロー**と**確認 URL** を明記
+- 必要に応じて `daily.json generator (JST)` を手動実行（/daily の HTML 反映）
+- 反映確認：フッター右（Dataset/commit/updated）、`/daily/YYYY-MM-DD.html?no-redirect=1`
+- 主要 E2E / Lighthouse の状況を確認（緑）
+
+詳細は [docs/release-checklist.md](release-checklist.md)。
+
+## 6. トラブルシューティング
+- YAML の `bad indentation` / `if:` で URL を直接置いてしまう → 修正例あり
+- `/daily/*.html` がすぐリダイレクトして検証できない → `?no-redirect=1`
+- 当日分のシェアページが 404 → `daily.json generator (JST)` の実行を確認
+- AUTO が反映されない → `?auto=1` 付与、曲の正規化一致（検証時は `&auto_any=1`）
+
+詳細は [docs/troubleshooting.md](troubleshooting.md)。
+
+## 7. 参照
+- [docs/pipeline.md](pipeline.md)
+- [docs/auto-mode.md](auto-mode.md)
+- [docs/ops-runbook.md](ops-runbook.md)
+- [docs/ops-tips.md](ops-tips.md)
+- [docs/glossary.md](glossary.md)
+- [docs/urls-and-params.md](urls-and-params.md)
+- [docs/e2e-daily-pages-smoke.md](e2e-daily-pages-smoke.md)
+- [docs/e2e-auto-badge-smoke.md](e2e-auto-badge-smoke.md)
+- [docs/lighthouse-budgets.md](lighthouse-budgets.md)
+- [docs/ci-status.md](ci-status.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,23 @@
 # Docs Index
 
-> vgm-quiz の開発・運用ドキュメントのハブです。
+> vgm-quiz の開発・運用ドキュメントのハブです。迷ったらまず **HANDBOOK** へ。
 
-## Pipelines / Ops
-- [パイプライン全体像](pipeline.md)
-- [AUTO モード運用](auto-mode.md)
-- [運用 Tips（outputs記法・Summary・no-redirect 等）](ops-tips.md)
+## Handbook
+- [VGM Quiz Handbook](HANDBOOK.md)
 
-## QA / E2E
+## Architecture / Pipelines / Ops
+- [Architecture (high-level)](architecture.md)
+- [Pipeline overview](pipeline.md)
+- [Ops runbook](ops-runbook.md)
+- [Ops Tips](ops-tips.md)
+- [Troubleshooting](troubleshooting.md)
+- [Release checklist](release-checklist.md)
+- [Glossary](glossary.md)
+- [URLs & Query Params](urls-and-params.md)
+
+## QA / Monitoring
 - [e2e (daily share & latest smoke)](e2e-daily-pages-smoke.md)
-
-## Monitoring
+- [e2e (auto badge smoke)](e2e-auto-badge-smoke.md)
 - [lighthouse (budgets, nightly)](lighthouse-budgets.md)
 
 ## CI Status

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,15 @@
+# Architecture (High-Level)
+
+## Data -> App -> Pages
+1. **Data Build (Clojure)** → `public/build/dataset.json`
+2. **Node Scripts** → `public/app/daily.json`, `public/app/daily_auto.json`, `/public/daily/*.html`
+3. **App (GitHub Pages)** → `/public/app/` を配信、`?daily=...` で表示
+4. **SW 更新検知** → `public/app/version.json` でハンドシェイク（~60s）
+
+## Pipelines
+- **daily.json generator (JST)**: daily.json と /daily HTML を更新
+- **daily (auto …)**: daily_auto.json を更新（HTML には触れない）
+
+## E2E / Monitoring
+- smoke テスト（/daily + latest / AUTO バッジ）
+- Lighthouse Budgets（warn）

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,10 @@
+# Glossary
+
+- **dataset.json**: Clojure ビルドが生成する基礎データ（`public/build/dataset.json`）。
+- **daily.json**: アプリが参照する当日/指定日データ（`public/app/daily.json`）。
+- **daily_auto.json**: AUTOモードの候補/選択肢出力（`public/app/daily_auto.json`）。
+- **choices_override**: AUTO で 4 択を上書きするための情報。
+- **allow_heuristic_media**: 検証用途のメディア推定を許可するフラグ。
+- **SW（Service Worker）**: `version.json` で更新検知。
+- **AUTOバッジ**: `?auto=1` 読み込み成功の UI サイン（右上 "AUTO"）。
+- **auto_any**: 検証用フラグ。正規化一致を無視して AUTO を強制適用。

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,8 @@
+# Release Checklist
+
+- [ ] PR の説明に実行ワークフロー（例: daily.json generator / e2e / lighthouse）と確認 URL を記載
+- [ ] 必要に応じて `daily.json generator (JST)` を手動実行（/daily HTML 更新）
+- [ ] フッター右の **Dataset / commit / updated** を確認
+- [ ] `/daily/YYYY-MM-DD.html?no-redirect=1` が動作するか確認
+- [ ] **e2e (daily share & latest smoke)** / **e2e (auto badge smoke)** が緑
+- [ ] **lighthouse (budgets, nightly)** の warn をチェック（大きな退行が無いか）

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,34 +1,18 @@
 # Troubleshooting
 
-## Pages deploy doesn’t reflect changes
+## YAML / GitHub Actions
+- **bad indentation of a mapping entry**: `- name:` 直下の `if:` / `run:` のインデントを揃える。`run: |` を使い複数行 echo を推奨。
+- **if に URL を置いてしまう**: `if: ${{ steps.cpr.outputs['pull-request-url'] != '' }}` のように真偽式にする。
+- **ハイフンキーの outputs**: かならず `['...']` で参照（例: `steps.cpr.outputs['pull-request-url']`）。
 
-- Ensure `pages.yml` uploads **`public/`** (with `.nojekyll`)
-- Check **Deployments → github-pages** and verify the deployed commit matches `main` HEAD
-- Run **Actions → Pages → Run workflow** (branch: `main`) to force redeploy
+## /daily の挙動
+- すぐリダイレクトして検証できない → `?no-redirect=1` を付与。
+- 遅延させたい → `?redirectDelayMs=1500` を付与。
+- 当日分が 404 → `daily.json generator (JST)` の実行状況を確認。
 
-## /daily/index.html or /daily/latest.html returns 404
+## AUTO が反映されない
+- `?auto=1` が付いているか、曲の正規化一致があるかを確認。
+- 検証では `&auto_any=1` を併用。
 
-- Ensure `scripts/generate_daily_index.js` runs in `daily.yml` and **`pages.yml`** (pre-deploy safety)
-- In `daily.yml`, include `public/daily/*.html` in `create-pull-request` `add-paths`
-- After merging the PR, re-run **Pages** deploy (or push an empty commit)
-
-## /daily/feed.xml returns 404
-
-- Confirm `scripts/generate_daily_feed.js` is invoked by `daily.yml` **and** by `pages.yml` (pre-deploy safety)
-- In the daily PR, verify `public/daily/feed.xml` is included
-- After merging, run **Pages** to publish the file
-
-## SW update banner doesn’t show up
-
-- The app now attaches three ways: `navigator.serviceWorker.ready`, polling `getRegistration()` for up to 30s, **and** a `window` event dispatched at registration. If any of these are missing, update `app.js` and `sw_update.js` per latest main.
-- Open DevTools → Application → Service Workers; confirm **Waiting** state appears on update
-- As a quick test, do an empty commit to trigger deploy (see Ops Runbook), keep the old tab open, and watch for the banner
-
-## Required checks keep “waiting…” on PR
-
-- Rulesets require **job names** `pages-pr-build` / `ci-fast-pr-build`
-- If you renamed jobs or workflows, update Rulesets accordingly
-
-## Daily PR authored by github-actions[bot]
-
-- `DAILY_PR_PAT` is missing/expired. Create a new PAT and update repo secrets.
+## PR が作られない
+- 差分が無い場合は正常。Summary に `(no changes / not created)` が出る。

--- a/docs/urls-and-params.md
+++ b/docs/urls-and-params.md
@@ -1,0 +1,11 @@
+# URLs & Query Params
+
+- アプリ: `/app/?daily=YYYY-MM-DD`
+  - `auto=1` : AUTO モード（`daily_auto.json` を 4 択に反映）
+  - `auto_any=1` : 曲一致を無視して強制適用（検証用）
+
+- シェアページ: `/daily/YYYY-MM-DD.html`
+  - `no-redirect=1` : リダイレクト抑止（デバッグ/視認性）
+  - `redirectDelayMs=1500` : 遅延してから遷移
+
+- 最新: `/daily/latest.html` でも上記クエリが利用可能。


### PR DESCRIPTION
## Summary
- centralize operations guidance in new Handbook
- document architecture, glossary, URLs, release checklist and troubleshooting
- reorganize docs index around new resources

## Testing
- `npm test` *(fails: clojure: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b5bb9a32b8832484edfb88465fc3ca