### PR TITLE
Capture HTML on AUTO badge smoke failure

### DIFF
--- a/.github/workflows/e2e-auto-badge-smoke.yml
+++ b/.github/workflows/e2e-auto-badge-smoke.yml
@@ -43,5 +43,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: auto_badge_failure
-          path: auto_badge_failure.png
+          path: |
+            auto_badge_failure.png
+            auto_badge_failure.html
           if-no-files-found: ignore

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,3 +22,6 @@
 
 ## CI Status
 - [CI / Ops バッジ一覧](ci-status.md)
+
+## Writing
+- [Docs Style Guide](STYLEGUIDE.md)

--- a/docs/e2e-auto-badge-smoke.md
+++ b/docs/e2e-auto-badge-smoke.md
@@ -6,7 +6,9 @@
 - Actions → **e2e (auto badge smoke)** → Run workflow
   - `app_url` は省略可（既定: `https://nantes-rfli.github.io/vgm-quiz/app/`）
   - `date` は未指定なら **JST 今日**
-- 失敗時は `auto_badge_failure.png` をアーティファクトとして取得可能
+- 失敗時は以下のアーティファクトを取得可能
+  - `auto_badge_failure.png`（スクリーンショット）
+  - `auto_badge_failure.html`（ページのHTML）
 
 ## 仕様
 - まず `&auto=1` で確認し、見つからない場合は `&auto_any=1` にフォールバック（検証用途）

--- a/e2e/test_auto_badge_smoke.mjs
+++ b/e2e/test_auto_badge_smoke.mjs
@@ -1,13 +1,14 @@
 /* e2e/test_auto_badge_smoke.mjs
  * Smoke test: /app/?daily=YYYY-MM-DD&auto=1 renders and shows "AUTO" badge.
  * Falls back to &auto_any=1 if strict matching prevents "AUTO" showing.
- * Usage: node e2e/test_auto_badge_smoke.mjs
+ * On failure, saves screenshot and HTML for diagnosis.
  *
  * Env:
  *   APP_URL (must end with /app/, default: https://nantes-rfli.github.io/vgm-quiz/app/)
  *   DATE (YYYY-MM-DD, optional; default JST today)
  */
 import { chromium } from 'playwright';
+import { writeFile } from 'node:fs/promises';
 
 function jstToday() {
   const f = new Intl.DateTimeFormat('ja-JP', { timeZone: 'Asia/Tokyo', year: 'numeric', month: '2-digit', day: '2-digit' });
@@ -29,9 +30,7 @@ async function hasAutoBadge(page) {
     const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
     let node;
     while ((node = walker.nextNode())) {
-      if ((node.textContent || '').trim() === 'AUTO' || (node.textContent || '').includes('AUTO')) {
-        return true;
-      }
+      if ((node.textContent || '').includes('AUTO')) return true;
     }
     return !!document.querySelector('[data-auto-badge], .auto-badge, [aria-label="AUTO"], [title="AUTO"]');
   });
@@ -56,28 +55,27 @@ async function run() {
   const gotoOpts = { waitUntil: 'networkidle', timeout: 30000 };
   await page.goto(primary, gotoOpts);
 
-  // wait for app boot (root element present)
-  await page.waitForSelector('body', { timeout: 10000 });
-
   // check badge with retries
   let ok = await hasAutoBadge(page);
   if (!ok) {
     console.log('[auto-badge] Not found on strict URL, trying auto_any fallback:', fallback);
     await page.goto(fallback, gotoOpts);
-    await page.waitForSelector('body', { timeout: 10000 });
     ok = await hasAutoBadge(page);
   }
 
   if (!ok) {
+    const html = await page.content();
+    await writeFile('auto_badge_failure.html', html, 'utf8');
     await page.screenshot({ path: 'auto_badge_failure.png', fullPage: true });
-    throw new Error('AUTO badge not found (see auto_badge_failure.png)');
+    await browser.close();
+    throw new Error('AUTO badge not found (see auto_badge_failure.png / auto_badge_failure.html)');
   }
 
   console.log('[auto-badge] OK');
   await browser.close();
 }
 
-run().catch(async (e) => {
+run().catch((e) => {
   console.error('[auto-badge] FAILED:', e);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- Save page HTML alongside screenshot when AUTO badge smoke test fails
- Upload both screenshot and HTML from AUTO badge smoke workflow
- Document failure artifacts and add docs style guide link

## Testing
- `npm test` *(fails: clojure not found)*
- `node e2e/test_auto_badge_smoke.mjs` *(fails: Cannot find package 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68b5bfac5a088324b410fce85355b87d