### PR TITLE
docs: expand README and add feature inventory

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,11 @@
 ## Summary
-<!-- 変更の要約 -->
+<!-- 変更の概要を簡潔に -->
 
 ## Checklist
-- [ ] E2E / Lint / Build がすべて緑（必要に応じて）
-- [ ] ドキュメント更新（該当時）: `docs/` or README
-- [ ] `/daily` 生成に影響する変更の場合は `daily.json generator (JST)` での確認メモを添付
-- [ ] `daily (auto …)` 実行時の挙動に影響する変更の場合は `e2e (auto choices smoke)` の確認メモを添付
+- [ ] 実装に関する **Docs を更新**（`README.md` / `docs/FEATURES.*` / `docs/params.md` / `docs/ROADMAP.md` いずれか）
+- [ ] E2E / CI に影響がある場合、関連ワークフローやテストを更新
+- [ ] ドキュメント不要な変更の場合のみ **label: docs:skip** を付与
 
-## Screenshots / Logs
-<!-- UI / Summary / Actions のログなど -->
-
-## Related Issues / PRs
-- 
+## Links
+- 本番確認URL:
+- 関連Issue/PR:

--- a/.github/workflows/docs-enforcer.yml
+++ b/.github/workflows/docs-enforcer.yml
@@ -1,0 +1,48 @@
+name: docs-enforcer
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  check-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect code changes
+        id: diff
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1 || true
+          base="${{ github.base_ref }}"
+          if [ -z "$base" ]; then
+            base="main"
+          fi
+          git diff --name-only "origin/${base}"...HEAD > changed.txt || true
+          echo "Changed files:"
+          cat changed.txt || true
+          # If PR has only docs/.github/markdown, skip
+          if ! grep -E '^(public/|src/|scripts/|tools/|lighthouse/|e2e/|test/)' changed.txt >/dev/null 2>&1; then
+            echo "code_changed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "code_changed=true" >> $GITHUB_OUTPUT
+      - name: Ensure docs updated or label present
+        if: steps.diff.outputs.code_changed == 'true'
+        run: |
+          set -e
+          if grep -E '^(docs/|README.md|CHANGELOG.md|docs/FEATURES.yml|docs/FEATURES.md|docs/ROADMAP.md)' changed.txt >/dev/null 2>&1; then
+            echo "Docs were updated alongside code ✅"
+            exit 0
+          fi
+          echo "Docs not updated; checking labels..."
+          echo "labels:" > labels.txt
+          echo "${{ toJson(github.event.pull_request.labels) }}" >> labels.txt
+          if grep -E 'docs:skip' labels.txt >/dev/null 2>&1; then
+            echo "docs:skip label present → allow ✅"
+            exit 0
+          fi
+          echo "::error title=Docs required::This PR changes code but not docs. Update docs (README / docs/FEATURES.* / ROADMAP / CHANGELOG) or add label 'docs:skip'."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -36,15 +36,18 @@
 
 ### Share page
 - 毎日の共有用静的ページ: `public/daily/YYYY-MM-DD.html`
-- そのURLをSNSに貼ると、上記 OGP 画像のプレビューとともに **`/app/?daily=YYYY-MM-DD`** へ自動リダイレクトします。
+- そのURLをSNSに貼ると、上記 OGP 画像のプレビューとともに **JS リダイレクト**で `/app/?daily=YYYY-MM-DD` へ遷移します。
+- デバッグ用クエリ:
+  - `?no-redirect=1` → リダイレクト抑止
+  - `?redirectDelayMs=1500` → リダイレクトを 1.5s 遅延
 - 一覧: `/daily/index.html`（過去分のリンク集）
-- 常に当日: `/daily/latest.html`（メタリフレッシュで当日の share page へ）
+- 常に当日: `/daily/latest.html`（**JS リダイレクト**で当日の share page へ。上記のデバッグ用クエリも利用可）
 
   A small quiz app for video game music. Runs on GitHub Pages.
 
 - Production: https://nantes-rfli.github.io/vgm-quiz/app/
 - Daily index: https://nantes-rfli.github.io/vgm-quiz/daily/index.html
-- Daily latest redirect: https://nantes-rfli.github.io/vgm-quiz/daily/latest.html
+- Daily latest redirect: https://nantes-rfli.github.io/vgm-quiz/daily/latest.html （JS リダイレクト）
 - Daily RSS feed: https://nantes-rfli.github.io/vgm-quiz/daily/feed.xml
 - Repo: https://github.com/nantes-rfli/vgm-quiz
 
@@ -57,6 +60,18 @@ npx http-server -p 8080 -c-1 .    # or any static server
 # 2) open
 http://127.0.0.1:8080/app/?test=1&mock=1&autostart=0
 ```
+
+## Parameters (quick)
+
+- `?daily=1`（JST 今日）/ `?daily=YYYY-MM-DD`
+- `?auto=1` / `?auto_any=1`（検証用途）
+- `?seed=abc`（シード固定）, `?qp=1`（年次バケット・決定論的並び）
+- `?lives=on` または `?lives=5`（ライフゲージ。上限到達で終了/デフォルトは表示のみ）
+- `?test=1` / `?mock=1` / `?autostart=0`（ローカル検証向け）
+- `?lhci=1` / `?nomedia=1`（Lighthouse向けスタブ）
+- `/daily/*.html`: `?no-redirect=1` / `?redirectDelayMs=...`（JS リダイレクト制御）
+
+> 詳細は `docs/params.md` を参照。
 
 ## Features
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,22 @@
+# Feature Matrix (Source of truth)
+
+> この一覧は `docs/FEATURES.yml` を人間可読にした **正本** です。新機能を追加/変更するPRでは、ここを更新してください。
+
+| ID | Area | Title | Status | Since |
+|----|------|-------|--------|-------|
+| quiz-modes | app | MCQ / Free-form | implemented | v1.0.0 |
+| deterministic-order | app | Seed + Year-bucket | implemented | v1.0.0 |
+| hud-a11y-baseline | a11y | HUD & focus mgmt | implemented | v1.0.0 |
+| results-modal-a11y | a11y | Accessible dialog | implemented | v1.0.0 |
+| media-stubs | media | YT nocookie + stubs | implemented | v1.0.0 |
+| daily-mode | daily | ?daily=1 / YYYY-MM-DD | implemented | v1.0.0 |
+| lives-rule | gameplay | Finish on limit | implemented | v1.0.0 |
+| normalize-v1-2 | normalize | Answer normalization v1.2 | implemented | v1.0.1 |
+| daily-feed | daily | /daily/feed.xml | implemented | v1.0.0 |
+| sw-update-banner | sw | Update banner | implemented | v1.0.0 |
+| daily-share-js-redirect | share | JS redirect + debug params | implemented | 2025-09-01 |
+| auto-mode | auto | daily_auto.json choices | implemented | v1.0.0 |
+| auto-any | auto | bypass match (test) | implemented | v1.0.0 |
+| a11y-hardening | a11y | Focus/roles/labels | planned | — |
+| difficulty-badge | ui | Difficulty badge | planned | — |
+| heuristic-media-guard | media | Heuristic media fallback | planned | — |

--- a/docs/FEATURES.yml
+++ b/docs/FEATURES.yml
@@ -1,0 +1,83 @@
+# Canonical feature inventory for vgm-quiz
+# status: implemented | planned | deprecated
+# since: version tag or date (YYYY-MM-DD)
+- id: quiz-modes
+  area: app
+  title: Quiz modes (MCQ / Free-form)
+  status: implemented
+  since: v1.0.0
+- id: deterministic-order
+  area: app
+  title: Deterministic ordering (seed + year-bucket pipeline)
+  status: implemented
+  since: v1.0.0
+- id: hud-a11y-baseline
+  area: a11y
+  title: HUD & a11y baseline (lives HUD, progressbar, polite timer, focus mgmt)
+  status: implemented
+  since: v1.0.0
+- id: results-modal-a11y
+  area: a11y
+  title: Results modal (accessible dialog, initial focus, Tab trap, Escape)
+  status: implemented
+  since: v1.0.0
+- id: media-stubs
+  area: media
+  title: Media stubs (YouTube nocookie→fallback, test/lhci/nomedia toggles)
+  status: implemented
+  since: v1.0.0
+- id: daily-mode
+  area: daily
+  title: Daily mode (?daily=1 / YYYY-MM-DD)
+  status: implemented
+  since: v1.0.0
+- id: lives-rule
+  area: gameplay
+  title: Lives rule (finish on limit)
+  status: implemented
+  since: v1.0.0
+- id: normalize-v1-2
+  area: normalize
+  title: Answer normalization v1.2 (NFKC, diacritics, punctuation, long sound mark, spaces, 1–20 Roman↔Arabic, articles, &→and, aliases)
+  status: implemented
+  since: v1.0.1
+- id: daily-feed
+  area: daily
+  title: Static RSS feed (/daily/feed.xml)
+  status: implemented
+  since: v1.0.0
+- id: sw-update-banner
+  area: sw
+  title: SW update banner (skipWaiting→controllerchange→reload)
+  status: implemented
+  since: v1.0.0
+- id: daily-share-js-redirect
+  area: share
+  title: Share page JS redirect (+ no-redirect / redirectDelayMs)
+  status: implemented
+  since: 2025-09-01
+- id: auto-mode
+  area: auto
+  title: AUTO mode (daily_auto.json choices apply)
+  status: implemented
+  since: v1.0.0
+- id: auto-any
+  area: auto
+  title: AUTO any (bypass match; test only)
+  status: implemented
+  since: v1.0.0
+- id: a11y-hardening
+  area: a11y
+  title: A11y hardening (focus ring, roles/labels, sr text) 
+  status: planned
+  since: null
+- id: difficulty-badge
+  area: ui
+  title: Difficulty badge (display-only)
+  status: planned
+  since: null
+- id: heuristic-media-guard
+  area: media
+  title: Heuristic media with safe fallback order
+  status: planned
+  since: null

--- a/docs/params.md
+++ b/docs/params.md
@@ -1,0 +1,22 @@
+# URL Parameters
+
+アプリとシェアページで利用できるクエリパラメータの一覧です。
+
+## App (`/app/`)
+- `daily=1` / `daily=YYYY-MM-DD` — デイリー問題の指定（JST）
+- `auto=1` — AUTO モード（`public/app/daily_auto.json` から choices 反映）
+- `auto_any=1` — AUTO モードの曲一致チェックを無効化（検証用途）
+- `seed=...` — シード固定（決定論的な並び）
+- `qp=1` — 年次バケットパイプライン（決定論的選定）
+- `lives=on` / `lives=N` — ライフゲージを有効化（N=上限値）。上限到達で終了
+- `test=1`, `mock=1`, `autostart=0` — ローカル検証向け
+- `lhci=1`, `nomedia=1` — Lighthouse 向けスタブ・メディア無効化
+- `nomusic=1` — （任意）楽曲再生を抑止して UI のみ検証（実装状況に合わせて拡張）
+
+## Share (`/daily/*.html`)
+- `no-redirect=1` — 自動リダイレクトを抑止（導線確認・デバッグ）
+- `redirectDelayMs=1500` — リダイレクトを指定ミリ秒遅延
+
+> 備考
+> - リダイレクトは JS 実装。`no-redirect` / `redirectDelayMs` は `latest.html` でも利用できます。
+> - `auto_any=1` は本番導線では **非推奨**（検証時のみ）。


### PR DESCRIPTION
## Summary
- document new share page behavior and runtime parameters
- add canonical feature inventory and docs enforcement workflow

## Testing
- `npm test` *(fails: clojure not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b63c47b4f48324bf377d3534bd380d