### PR TITLE
Add light regression E2E tests for keyboard flow and share CTA

### DIFF
--- a/.github/workflows/e2e-light-regressions.yml
+++ b/.github/workflows/e2e-light-regressions.yml
@@ -1,0 +1,55 @@
+name: e2e (light regressions)
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_url:
+        description: 'Base app URL ending with /app/'
+        required: false
+      share_base:
+        description: 'Base share URL ending with /daily/'
+        required: false
+      date:
+        description: 'YYYY-MM-DD (JST); empty means today (JST)'
+        required: false
+  schedule:
+    - cron: '25 19 * * *'  # JST 04:25
+
+jobs:
+  light-regressions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Playwright Chromium (for keyboard flow)
+        run: |
+          npm i --no-save playwright
+          npx playwright install --with-deps chromium
+
+      - name: Keyboard flow smoke
+        env:
+          APP_URL: ${{ inputs.app_url || 'https://nantes-rfli.github.io/vgm-quiz/app/' }}
+          DATE: ${{ inputs.date }}
+        run: node e2e/test_keyboard_flow_smoke.mjs
+
+      - name: Share CTA visibility
+        env:
+          SHARE_BASE: ${{ inputs.share_base || 'https://nantes-rfli.github.io/vgm-quiz/daily/' }}
+          DATE: ${{ inputs.date }}
+        run: node e2e/test_share_cta_visibility.mjs
+
+      - name: Upload artifacts on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-light-regressions-artifacts
+          path: |
+            kb_flow_failure.html
+            kb_flow_failure.png
+            share_cta_failure.html
+            share_cta_latest_failure.html
+          if-no-files-found: ignore

--- a/e2e/test_keyboard_flow_smoke.mjs
+++ b/e2e/test_keyboard_flow_smoke.mjs
@@ -1,0 +1,120 @@
+/* e2e/test_keyboard_flow_smoke.mjs
+ * Purpose: Minimal regression check that the quiz can be operated with keyboard only.
+ * Strategy: Open app, Tab to first "button-like" choice, press Enter,
+ *           and verify a plausible "answered" signal (selected/pressed/dialog/etc.).
+ *
+ * Env:
+ *   APP_URL (must end with /app/, default: https://nantes-rfli.github.io/vgm-quiz/app/)
+ *   DATE    (YYYY-MM-DD, optional; default JST today)
+ */
+import { chromium } from 'playwright';
+import { writeFile } from 'node:fs/promises';
+
+function jstToday() {
+  const f = new Intl.DateTimeFormat('ja-JP', { timeZone: 'Asia/Tokyo', year: 'numeric', month: '2-digit', day: '2-digit' });
+  const s = f.format(new Date());
+  const [y,m,d] = s.split('/');
+  return `${y}-${m}-${d}`;
+}
+
+function buildUrl(app, date) {
+  const u = new URL(app);
+  u.searchParams.set('daily', date);
+  u.searchParams.set('autostart', '0');
+  u.searchParams.set('lhci', '1');
+  u.searchParams.set('nomedia', '1');
+  u.searchParams.set('seed', 'kb');
+  return u.toString();
+}
+
+async function findChoiceViaTab(page, maxHops = 20) {
+  for (let i = 0; i < maxHops; i++) {
+    await page.keyboard.press('Tab');
+    const info = await page.evaluate(() => {
+      const el = document.activeElement;
+      if (!el) return { ok:false };
+      const tag = (el.tagName || '').toLowerCase();
+      const role = el.getAttribute?.('role') || '';
+      const cls = (el.className || '').toString();
+      const txt = (el.textContent || '').trim();
+      // button-like heuristics
+      const isBtn = tag === 'button' || role === 'button' || el.hasAttribute('tabindex');
+      return {
+        ok: isBtn && txt.length > 0,
+        tag, role, cls, txt,
+        selector: (() => {
+          try { el.setAttribute('data-kb-probe','1'); return '[data-kb-probe="1"]'; } catch(e) { return null; }
+        })()
+      };
+    });
+    if (info.ok) return info;
+  }
+  return { ok:false };
+}
+
+async function answeredSignal(page) {
+  return await page.evaluate(() => {
+    // A union of common patterns after answering.
+    const el = document.activeElement;
+    const sel = [
+      '[role="dialog"]',
+      '.selected, .correct, .wrong',
+      '[aria-pressed="true"]',
+      '[data-selected], [data-state="selected"]',
+      // hints of result area
+      '.result, .results, [data-testid*="result"], [data-role="result"]'
+    ].join(',');
+    const any = document.querySelector(sel);
+    // also allow currently-focused to look selected/disabled
+    const looksPressed = el && (el.getAttribute('aria-pressed') === 'true' || el.hasAttribute('disabled') || /selected|active/.test(el.className || ''));
+    return !!(any || looksPressed);
+  });
+}
+
+async function run() {
+  const base = process.env.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/';
+  if (!base.endsWith('/app/')) throw new Error(`APP_URL must end with "/app/": ${base}`);
+  const date = process.env.DATE || jstToday();
+  const url  = buildUrl(base, date);
+
+  console.log('[kb] url =', url);
+  const browser = await chromium.launch({ headless: true });
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const page = await ctx.newPage();
+  const gotoOpts = { waitUntil: 'networkidle', timeout: 30000 };
+
+  await page.goto(url, gotoOpts);
+  await page.waitForSelector('body', { timeout: 15000 });
+
+  // Move focus into document
+  await page.focus('body');
+
+  const info = await findChoiceViaTab(page);
+  if (!info.ok) {
+    await writeFile('kb_flow_failure.html', await page.content(), 'utf8');
+    await page.screenshot({ path: 'kb_flow_failure.png', fullPage: true });
+    await browser.close();
+    throw new Error('Could not reach a button-like choice with Tab (see kb_flow_failure.*)');
+  }
+  console.log('[kb] focused candidate:', info);
+
+  // Activate with Enter
+  await page.keyboard.press('Enter');
+
+  // Check for an "answered" signal
+  const ok = await answeredSignal(page);
+  if (!ok) {
+    await writeFile('kb_flow_failure.html', await page.content(), 'utf8');
+    await page.screenshot({ path: 'kb_flow_failure.png', fullPage: true });
+    await browser.close();
+    throw new Error('After Enter key, no plausible answered signal found (see kb_flow_failure.*)');
+  }
+
+  console.log('[kb] OK');
+  await browser.close();
+}
+
+run().catch(async (e) => {
+  console.error('[kb] FAILED:', e);
+  process.exit(1);
+});

--- a/e2e/test_share_cta_visibility.mjs
+++ b/e2e/test_share_cta_visibility.mjs
@@ -1,0 +1,63 @@
+/* e2e/test_share_cta_visibility.mjs
+ * Purpose: Ensure daily share page exposes a visible CTA before redirect.
+ * Strategy: Fetch share HTML with ?no-redirect=1 and ensure either:
+ *  - "AUTOで遊ぶ" text exists, OR
+ *  - a link to /app/?daily=YYYY-MM-DD (with or without auto=1) exists.
+ *
+ * Env:
+ *   SHARE_BASE (must end with /daily/, default: https://nantes-rfli.github.io/vgm-quiz/daily/)
+ *   DATE       (YYYY-MM-DD, optional; default JST today)
+ */
+import { writeFile } from 'node:fs/promises';
+
+function jstToday() {
+  const f = new Intl.DateTimeFormat('ja-JP', { timeZone: 'Asia/Tokyo', year: 'numeric', month: '2-digit', day: '2-digit' });
+  const s = f.format(new Date());
+  const [y,m,d] = s.split('/');
+  return `${y}-${m}-${d}`;
+}
+
+async function fetchText(url) {
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  return await res.text();
+}
+
+function hasCta(html, date) {
+  const lower = html.toLowerCase();
+  if (html.includes('AUTOで遊ぶ')) return true;
+  if (lower.includes('/app/?daily=' + date.toLowerCase())) return true;
+  if (lower.includes('/app/?daily=' + date.toLowerCase() + '&auto=1')) return true;
+  return false;
+}
+
+async function run() {
+  const base = process.env.SHARE_BASE || 'https://nantes-rfli.github.io/vgm-quiz/daily/';
+  if (!base.endsWith('/daily/')) throw new Error(`SHARE_BASE must end with "/daily/": ${base}`);
+  const date = process.env.DATE || jstToday();
+
+  const share = `${base}${date}.html?no-redirect=1`
+  const latest = `${base}latest.html?no-redirect=1`
+
+  console.log('[share] check:', share);
+  const html = await fetchText(share);
+
+  if (!hasCta(html, date)) {
+    await writeFile('share_cta_failure.html', html, 'utf8');
+    throw new Error('CTA not found in daily share page (see share_cta_failure.html)');
+  }
+  console.log('[share] daily OK');
+
+  console.log('[share] check:', latest);
+  const html2 = await fetchText(latest);
+  if (!hasCta(html2, date)) {
+    await writeFile('share_cta_latest_failure.html', html2, 'utf8');
+    throw new Error('CTA not found in latest share page (see share_cta_latest_failure.html)');
+  }
+  console.log('[share] latest OK');
+}
+
+run().catch((e) => {
+  console.error('[share] FAILED:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add keyboard-only smoke test for quiz interaction
- add share CTA visibility test for daily pages
- wire both tests into scheduled light regression workflow

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `node e2e/test_keyboard_flow_smoke.mjs` *(fails: Cannot find package 'playwright')*
- `node e2e/test_share_cta_visibility.mjs` *(fails: fetch failed, ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b645e57c40832491fc44c2572c2133