### PR TITLE
feat(ci): add roadmap guard

### DIFF
--- a/.github/workflows/roadmap-guard.yml
+++ b/.github/workflows/roadmap-guard.yml
@@ -1,0 +1,59 @@
+name: roadmap guard (non-blocking)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install deps
+        run: npm i --no-save yaml
+
+      - name: Run roadmap guard
+        run: node scripts/roadmap-guard.mjs
+
+      - name: Comment on PR if drift detected
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('roadmap_guard_result.json')) {
+              core.info('no result file; skip');
+              return;
+            }
+            const data = JSON.parse(fs.readFileSync('roadmap_guard_result.json', 'utf8'));
+            if (!data || data.ok || !data.missing || data.missing.length === 0) {
+              core.info('no drift detected');
+              return;
+            }
+            const lines = [];
+            lines.push('### 🔎 ROADMAP vs FEATURES drift detected (non-blocking)');
+            lines.push('The following **planned** features in `docs/FEATURES.yml` were **not found** in `docs/ROADMAP.md`:');
+            for (const m of data.missing) {
+              lines.push(`- \`${m.id}\` — ${m.title} (area: ${m.area})`);
+            }
+            lines.push('');
+            lines.push('> Action: Roadmapに上記ID/タイトルのいずれかを含めるか、FEATURES.ymlのstatusを見直してください。（このチェックは**非ブロッキング**です）');
+            const body = lines.join('\n');
+            // Create or update a single bot comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const prev = comments.find(c => c.user.type === 'Bot' && c.body && c.body.includes('ROADMAP vs FEATURES drift detected'));
+            if (prev) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: prev.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body });
+            }
+

--- a/scripts/roadmap-guard.mjs
+++ b/scripts/roadmap-guard.mjs
@@ -1,0 +1,42 @@
+// scripts/roadmap-guard.mjs
+// Non-blocking checker: ensure planned features in docs/FEATURES.yml appear in docs/ROADMAP.md.
+// Outputs a JSON summary to roadmap_guard_result.json
+
+import { readFile, writeFile } from 'node:fs/promises';
+import yaml from 'yaml';
+
+function norm(s) {
+  return (s || '').toString().toLowerCase();
+}
+
+async function main() {
+  const featuresRaw = await readFile('docs/FEATURES.yml', 'utf8').catch(() => '');
+  const roadmapRaw  = await readFile('docs/ROADMAP.md', 'utf8').catch(() => '');
+  if (!featuresRaw || !roadmapRaw) {
+    await writeFile('roadmap_guard_result.json', JSON.stringify({ ok:false, error:'missing files' }), 'utf8');
+    return;
+  }
+
+  const features = yaml.parse(featuresRaw) || [];
+  const roadmap = norm(roadmapRaw);
+  const planned = (features || []).filter(x => (x?.status || '').toLowerCase() === 'planned');
+
+  const missing = [];
+  for (const f of planned) {
+    const id = norm(f.id);
+    const title = norm(f.title);
+    // id or title must appear somewhere in Roadmap
+    const found = (id && roadmap.includes(id)) || (title && roadmap.includes(title));
+    if (!found) missing.push({ id: f.id, title: f.title, area: f.area });
+  }
+
+  const result = { ok: missing.length === 0, missing, counts: { planned: planned.length } };
+  await writeFile('roadmap_guard_result.json', JSON.stringify(result, null, 2), 'utf8');
+  console.log('[roadmap-guard] result:', result);
+}
+
+main().catch(async (e) => {
+  console.error('[roadmap-guard] error:', e);
+  try { await writeFile('roadmap_guard_result.json', JSON.stringify({ ok:false, error:String(e) }), 'utf8'); } catch {}
+  process.exit(0); // non-blocking
+});


### PR DESCRIPTION
## Summary
- add script to ensure planned features from docs/FEATURES.yml appear in docs/ROADMAP.md
- add non-blocking workflow to run script and comment on PRs when drift detected

## Testing
- `npm test` (fails: sh: 1: clojure: not found)
- `apt-get update` (fails: repository is not signed)
- `npm i --no-save yaml` (fails: 403 Forbidden)
- `node scripts/roadmap-guard.mjs` (fails: cannot find package 'yaml')

------
https://chatgpt.com/codex/tasks/task_e_68b654d606c083248f043d07f6b60f9e