### PR TITLE
docs: document light regressions workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@
 ## QA / Monitoring
 - [e2e (daily share & latest smoke)](e2e-daily-pages-smoke.md)
 - [e2e (auto badge smoke)](e2e-auto-badge-smoke.md)
+- [e2e (light regressions)](e2e-light-regressions.md)
 - [lighthouse (budgets, nightly)](lighthouse-budgets.md)
 
 ## CI Status

--- a/docs/ci-status.md
+++ b/docs/ci-status.md
@@ -3,8 +3,17 @@
 - **e2e (daily share & latest smoke)**  
   ![e2e (daily share & latest smoke)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e-daily-pages-smoke.yml/badge.svg?branch=main)
 
+- **e2e (light regressions)**  
+  ![e2e (light regressions)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e-light-regressions.yml/badge.svg?branch=main)
+
 - **lighthouse (budgets, nightly)**  
   ![lighthouse (budgets, nightly)](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/lighthouse-budgets.yml/badge.svg?branch=main)
+
+- **docs enforcer**  
+  ![docs-enforcer](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/docs-enforcer.yml/badge.svg?branch=main)
+
+- **roadmap guard (non-blocking)**  
+  ![roadmap-guard](https://github.com/nantes-rfli/vgm-quiz/actions/workflows/roadmap-guard.yml/badge.svg?branch=main)
 
 - **daily.json generator (JST)**  
   *(既存ワークフロー名に合わせて必要なら差し替えてください)*

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,8 +8,12 @@
 - **`pages-pr-build.yml`** – PR用 Pages シム（Required: `pages-pr-build`）
 - **`daily.yml`** – 00:00 JST に `public/app/daily.json` と `/daily/*.html` と `/daily/feed.xml` を含む **bot PR** を作成
 - **`e2e-matrix.yml`** – Playwright E2E（smoke / a11y / footer / share / **normalize** / **lives**）手動＋Nightly(JST 04:40)
+- **`e2e-light-regressions.yml`** – 軽量回帰（**Keyboard flow** / **Share CTA visibility**）。手動＋Nightly(JST 04:25)
 - **`lighthouse.yml`** – Nightly Lighthouse CI（`?test=1&lhci=1`、**budgets** + **asserts**）
+- **`lighthouse-budgets.yml`** – 予算重視の軽量版（budgets の早期検知）
 - **`json-validate.yml`** – `daily.json` / `aliases.json` / `dataset.json` の軽量バリデーション
+- **`docs-enforcer.yml`** – コード変更があるPRに **ドキュメント更新**（`README` / `docs/**` / `FEATURES.*` / `ROADMAP` / `CHANGELOG`）が無いと **fail**
+- **`roadmap-guard.yml`** – 非ブロッキング。`FEATURES.yml` の **planned** が `ROADMAP.md` に無い場合、PRに**警告コメント**を付与
 
 ## E2E Suite
 
@@ -20,10 +24,15 @@ node e2e/test_footer_version.js
 node e2e/test_share.js
 node e2e/test_normalize.js  # ?mock=1 の normalize API を直接検証
 node e2e/test_lives.js      # lives=on の汎用検証（入力/MCQ/Enter のフォールバック）
+
+# 軽量回帰（ヘッドレス/高速）
+node e2e/test_keyboard_flow_smoke.mjs           # Tab→Enter で回答確定できること
+node e2e/test_share_cta_visibility.mjs          # /daily/*.html?no-redirect=1 にCTA/導線があること
 ```
 
 ### Nightly スケジュール（導入済み）
-- 実行時刻: **JST 04:40**（UTC 19:40）
+- 実行時刻: **JST 04:40**（UTC 19:40） – `e2e-matrix.yml`
+- 実行時刻: **JST 04:25**（UTC 19:25） – `e2e-light-regressions.yml`
 - 失敗時は該当スイートのアーティファクトを確認
 
 ### Artifact 保持
@@ -37,3 +46,7 @@ node e2e/test_lives.js      # lives=on の汎用検証（入力/MCQ/Enter のフ
 ## Required checks（Rulesets）
 - **`pages-pr-build` / `ci-fast-pr-build`** の2本が PR の Required。
   - ジョブ名がズレると PR が永遠に「waiting」になるため、変更時は Rulesets 側も必ず更新。
+
+## Docs / Roadmap の整合性チェック
+- **docs-enforcer**: コード変更のPRで **ドキュメント差分**が無いと **fail**
+- **roadmap-guard**: **非ブロッキング**。`FEATURES.yml` の planned が ROADMAP に無い場合のみ **警告コメント**

--- a/docs/e2e-light-regressions.md
+++ b/docs/e2e-light-regressions.md
@@ -1,0 +1,45 @@
+# e2e (light regressions)
+
+**目的**: 壊れやすい導線を**高速・最小コスト**で見張る。Playwrightを使うのはKeyboardのみ、ShareはfetchでHTML検査。
+
+## ケース
+
+### 1) Keyboard flow smoke
+- **ファイル**: `e2e/test_keyboard_flow_smoke.mjs`
+- **内容**: `Tab`で選択肢にフォーカス→`Enter`で解答確定できるかを確認。
+- **起動例**:
+  ```bash
+  APP_URL="https://nantes-rfli.github.io/vgm-quiz/app/" DATE="2025-09-01" node e2e/test_keyboard_flow_smoke.mjs
+  ```
+- **アーティファクト**: 失敗時 `kb_flow_failure.html` / `kb_flow_failure.png`
+
+### 2) Share CTA visibility
+- **ファイル**: `e2e/test_share_cta_visibility.mjs`
+- **内容**: `/daily/YYYY-MM-DD.html?no-redirect=1` と `latest.html?no-redirect=1` に、CTAまたは当日ページへの明示的リンクがあるかを検査。
+- **起動例**:
+  ```bash
+  SHARE_BASE="https://nantes-rfli.github.io/vgm-quiz/daily/" DATE="2025-09-01" node e2e/test_share_cta_visibility.mjs
+  ```
+- **許容パターン（latest.html）**:
+  - `/daily/YYYY-MM-DD.html` への絶対リンク
+  - `href="./YYYY-MM-DD.html"` の相対リンク
+  - アンカーテキスト `>YYYY-MM-DD<`
+  - `location.href` による遷移文字列
+- **アーティファクト**: 失敗時 `share_cta_failure.html` / `share_cta_latest_failure.html`
+
+## ワークフロー
+
+- **ファイル**: `.github/workflows/e2e-light-regressions.yml`
+- **手動実行**: `Actions → e2e (light regressions) → Run workflow`
+  - `date`: 生成済みの安全な日付（例: `2025-09-01`）を入れると安定
+  - `app_url` / `share_base`: 既定で本番URL
+- **スケジュール**: JST 04:25（UTC 19:25）
+
+## トラブル時の指針
+- **Keyboardが落ちる**: フォーカス移動のヒューリスティックに依存。`findChoiceViaTab()`の条件を微調整（`role="button"` / `.class` / `data-*` を1行追加など）。
+- **Shareが落ちる**: その日の `/daily/*.html` 未生成 or latest実装が変更された可能性。`?no-redirect=1` でHTMLを目視、テスト側の許容パターンを増やす。
+
+## 関連
+- `docs/ci.md` – CI全体像
+- `docs/ops-runbook.md` – 運用フロー
+- `docs/urls-and-params.md` / `docs/params.md` – URL/クエリ仕様

--- a/docs/urls-and-params.md
+++ b/docs/urls-and-params.md
@@ -1,11 +1,18 @@
 # URLs & Query Params
 
-- アプリ: `/app/?daily=YYYY-MM-DD`
-  - `auto=1` : AUTO モード（`daily_auto.json` を 4 択に反映）
-  - `auto_any=1` : 曲一致を無視して強制適用（検証用）
+- アプリ: `/app/?daily=YYYY-MM-DD`（JST） / `/app/?daily=1`（当日）
+  - `auto=1` : AUTO モード（`public/app/daily_auto.json` を 4 択に反映）
+  - `auto_any=1` : 曲一致を無視して強制適用（**検証用**）
+  - `seed=abc` : シード固定（決定論的順序）
+  - `qp=1` : 年次バケットパイプライン
+  - `lives=on` / `lives=5` : ライフゲージ（上限到達で終了／デフォルトは表示のみ）
+  - `test=1` / `mock=1` / `autostart=0` : ローカル検証向け
+  - `lhci=1` / `nomedia=1` : Lighthouse / メディア抑止向けスタブ
 
 - シェアページ: `/daily/YYYY-MM-DD.html`
   - `no-redirect=1` : リダイレクト抑止（デバッグ/視認性）
   - `redirectDelayMs=1500` : 遅延してから遷移
 
 - 最新: `/daily/latest.html` でも上記クエリが利用可能。
+
+> 一覧性のために要点のみを抜粋しています。網羅版は **[docs/params.md](./params.md)** を参照してください。


### PR DESCRIPTION
## Summary
- document e2e light regression workflow and related CI jobs
- expand URL/param and CI docs
- add links and badges for new workflows

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: 403 repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b65765e214832483de8b80f5a8ffbd