### PR TITLE
docs: sync roadmap with features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- docs: ROADMAP synced with FEATURES (`a11y-hardening`, `difficulty-badge`, `heuristic-media-guard`)
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -119,6 +119,10 @@
 
 ---
 
+- A11y hardening *(ID: `a11y-hardening`, area: a11y)*
+- Difficulty badge (display-only) *(ID: `difficulty-badge`, area: ui)*
+- Heuristic media with safe fallback order *(ID: `heuristic-media-guard`, area: media)*
+
 ## バージョニング方針 / リリース運用
 - **SemVer 準拠**: 互換を壊さない機能追加は **minor**（v1.1, v1.2…）、修正は **patch**（v1.0.2…）
 - リリース条件（共通 DoD）:


### PR DESCRIPTION
## Summary
- list planned items for a11y hardening, difficulty badge, and heuristic media guard in ROADMAP
- note ROADMAP<->FEATURES sync in changelog

## Testing
- ⚠️ `npm test` *(clojure: not found)*
- ⚠️ `apt-get update` *(repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b66c86731483249cd5d0c4398e8bb9