### PR TITLE
Add meta description to latest daily page

### DIFF
--- a/scripts/generate_daily_index.js
+++ b/scripts/generate_daily_index.js
@@ -69,6 +69,7 @@ function jstISO(d = new Date()) {
   const mkLatest = (d) => `<!doctype html>
 <html lang="ja"><head>
   <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="VGM Quiz のデイリーページ（最新）。ゲーム音楽の1日1問にすぐアクセスできます。">
   <title>VGM Quiz — Daily latest</title>
   <script>(function(){try{var p=new URLSearchParams(location.search||"");if(p.get("no-redirect")==="1")return;var delay=parseInt(p.get("redirectDelayMs")||"0",10);if(isNaN(delay)||delay<0)delay=0;setTimeout(function(){location.replace(${JSON.stringify('./'+d+'.html')});},delay);}catch(e){}})();</script>
 </head><body>


### PR DESCRIPTION
## Summary
- add meta description to latest daily page to improve SEO and sharing

## Testing
- `npm test` *(fails: clojure: not found)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b67283f9e0832481344dbd82254a36