### PR TITLE
chore(daily): ensure meta description in latest page

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -87,6 +87,9 @@ jobs:
           node scripts/generate_daily_index.js
           ls -lah public/daily || true
 
+      - name: Ensure meta description in latest.html
+        run: node scripts/ensure_latest_meta.js
+
       - name: Generate Daily RSS feed
         run: node scripts/generate_daily_feed.js
 
@@ -105,3 +108,4 @@ jobs:
           delete-branch: true
           signoff: true
           labels: "automation,daily"
+

--- a/scripts/ensure_latest_meta.js
+++ b/scripts/ensure_latest_meta.js
@@ -1,0 +1,28 @@
+// Ensure <meta name="description"> exists in public/daily/latest.html (idempotent)
+// Usage: node scripts/ensure_latest_meta.js
+const fs = require('fs');
+const path = require('path');
+
+const latestPath = path.join(process.cwd(), 'public', 'daily', 'latest.html');
+if (!fs.existsSync(latestPath)) {
+  console.log('[ensure_latest_meta] skip: file not found:', latestPath);
+  process.exit(0);
+}
+let html = fs.readFileSync(latestPath, 'utf8');
+if (/\<meta\s+name=["']description["']/i.test(html)) {
+  console.log('[ensure_latest_meta] already has meta description');
+  process.exit(0);
+}
+const meta = '  <meta name="description" content="VGM Quiz のデイリーページ（最新）。ゲーム音楽の1日1問にすぐアクセスできます。">';
+// Try to insert after viewport
+if (/\<meta\s+name=["']viewport["'][^>]*\>/.test(html)) {
+  html = html.replace(/(\<meta\s+name=["']viewport["'][^>]*\>)/i, '$1\n' + meta);
+} else if (/\<head\>/.test(html)) {
+  html = html.replace(/\<head\>/i, '<head>\n' + meta + '\n');
+} else {
+  // last resort: prepend
+  html = meta + '\n' + html;
+}
+fs.writeFileSync(latestPath, html, 'utf8');
+console.log('[ensure_latest_meta] meta description inserted');
+


### PR DESCRIPTION
## Summary
- ensure latest daily page always has a meta description
- run script in daily workflow before RSS generation

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository not signed; 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b6752472888324b9c5eca1ae5a9d53