### PR TITLE
feat(ui): persist AUTO mode setting

### DIFF
--- a/.github/workflows/e2e-light-regressions.yml
+++ b/.github/workflows/e2e-light-regressions.yml
@@ -47,6 +47,11 @@ jobs:
           APP_URL: ${{ inputs.app_url || vars.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/' }}
         run: node e2e/test_daily_latest_meta.mjs
 
+      - name: Check Start view has AUTO settings
+        env:
+          APP_URL: ${{ inputs.app_url || vars.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/' }}
+        run: node e2e/test_auto_settings_exists.mjs
+
       - name: Upload artifacts on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - docs: ROADMAP synced with FEATURES (`a11y-hardening`, `difficulty-badge`, `heuristic-media-guard`)
+- feat(ui): Start画面に「AUTOを有効にする」を追加（永続化）; バッジに aria-label を付与
 
 # Changelog
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,6 +26,7 @@
 ---
 
 ## v1.1 — AUTO モード品質 & UX の底上げ（最優先）
+- Deliverables: AUTO起動トースト、Start設定UI（AUTOを有効にする・永続化）、AUTOバッジのA11y（aria-label）。
 **狙い**: “AUTOで遊ぶ”の価値を安定供給する。
 
 **機能/変更**

--- a/docs/urls-and-params.md
+++ b/docs/urls-and-params.md
@@ -2,6 +2,7 @@
 
 - アプリ: `/app/?daily=YYYY-MM-DD`（JST） / `/app/?daily=1`（当日）
   - `auto=1` : AUTO モード（`public/app/daily_auto.json` を 4 択に反映）
+  - **設定UI**: Start画面の「AUTOを有効にする」で永続ON（`localStorage: quiz-options.auto_enabled`）
   - `auto_any=1` : 曲一致を無視して強制適用（**検証用**）
   - `seed=abc` : シード固定（決定論的順序）
   - `qp=1` : 年次バケットパイプライン

--- a/e2e/test_auto_settings_exists.mjs
+++ b/e2e/test_auto_settings_exists.mjs
@@ -1,0 +1,21 @@
+// e2e/test_auto_settings_exists.mjs
+// Assert that Start view contains the AUTO settings checkbox (id="auto-enabled").
+async function main() {
+  const appUrl = process.env.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/';
+  if (!appUrl.endsWith('/app/')) throw new Error(`APP_URL must end with '/app/' (got: ${appUrl})`);
+  const url = `${appUrl}?test=1`;
+  console.log('[E2E auto settings] URL =', url);
+  const res = await fetch(url, { redirect: 'manual' });
+  if (res.status !== 200) throw new Error(`unexpected status: ${res.status}`);
+  const html = await res.text();
+  if (!html.includes('id="auto-enabled"')) {
+    console.log(html.slice(0, 300));
+    throw new Error('AUTO settings checkbox not found');
+  }
+  console.log('[E2E auto settings] ok');
+}
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1173,6 +1173,15 @@ modeEl.addEventListener('change', () => {
   settings.mode = modeEl.value;
   saveSettings();
 });
+const autoEl = document.getElementById('auto-enabled');
+if (autoEl) {
+  // reflect saved state
+  autoEl.checked = !!settings.auto_enabled;
+  autoEl.addEventListener('change', () => {
+    settings.auto_enabled = !!autoEl.checked;
+    saveSettings();
+  });
+}
 
 document.addEventListener('keydown', e => {
   if (e.key === 'Enter') {

--- a/public/app/auto_badge.mjs
+++ b/public/app/auto_badge.mjs
@@ -3,7 +3,13 @@
 
 function isEnabled() {
   const sp = new URLSearchParams(location.search);
-  return sp.get('auto') === '1' || sp.get('daily_auto') === '1';
+  const qs = sp.get('auto') === '1' || sp.get('daily_auto') === '1';
+  let persisted = false;
+  try {
+    const s = JSON.parse(localStorage.getItem('quiz-options')) || {};
+    persisted = !!s.auto_enabled;
+  } catch {}
+  return qs || persisted;
 }
 
 function injectBadge(text = 'AUTO') {
@@ -12,6 +18,7 @@ function injectBadge(text = 'AUTO') {
   badge.id = 'auto-mode-badge';
   badge.setAttribute('role', 'status');
   badge.setAttribute('aria-live', 'polite');
+  badge.setAttribute('aria-label', 'AUTOモードON');
   badge.style.position = 'fixed';
   badge.style.top = '12px';
   badge.style.right = '12px';

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -54,6 +54,13 @@
   <label style="margin-left:8px">
     <input type="checkbox" id="timer20"> タイマー(20s)
   </label>
+  <fieldset style="margin-top:8px">
+    <legend>AUTO mode</legend>
+    <label>
+      <input type="checkbox" id="auto-enabled" data-testid="auto-enabled"> AUTOを有効にする
+    </label>
+    <div class="sr-only" aria-hidden="false">キーボード操作で Tab → Enter だけで回答できます。</div>
+  </fieldset>
   <label>Number of questions
     <select id="count">
       <option value="5">5</option>
@@ -61,28 +68,6 @@
       <option value="20">20</option>
     </select>
   </label>
-  
-  <fieldset id="auto-settings">
-    <legend>AUTO mode</legend>
-    <label><input id="auto-enabled" type="checkbox"> Enable AUTO (show 4 choices when available)</label>
-    <div class="sr-only" aria-live="polite">AUTO setting persisted</div>
-  </fieldset>
-  <script type="module">
-  (function(){
-    try {
-      const SETTINGS_KEY = 'quiz-options';
-      const s = JSON.parse(localStorage.getItem(SETTINGS_KEY) || '{}');
-      const box = document.getElementById('auto-enabled');
-      if (box) {
-        box.checked = s.auto_enabled === true;
-        box.addEventListener('change', ()=> {
-          s.auto_enabled = !!box.checked;
-          localStorage.setItem(SETTINGS_KEY, JSON.stringify(s));
-        });
-      }
-    } catch(_) {}
-  })();
-  </script>
 <button id="start-btn" disabled data-testid="start-btn">Start</button>
   <div id="dataset-error" style="display:none;color:red;"></div>
   <button id="history-btn">History</button>


### PR DESCRIPTION
## Summary
- add Start screen checkbox to persist AUTO mode in localStorage
- read AUTO flag on badge and give it an aria-label
- cover AUTO option with docs, changelog, e2e test and workflow update

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: repository not signed; 403 Forbidden)*
- `node e2e/test_auto_settings_exists.mjs` *(fails: fetch failed: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b68d8ca53c8324974ac7f475b90e2b