### PR TITLE
test: add normalization edge cases and app CTA

### DIFF
--- a/e2e/test_normalize_cases.mjs
+++ b/e2e/test_normalize_cases.mjs
@@ -24,6 +24,31 @@ const same = (a, b, msg) => assert.equal(n(a), n(b), msg || `${a} == ${b}`);
   // 句読点・空白
   same('Chrono  Trigger!!  ', 'chrono trigger', 'punct & spaces');
 
+  // JP/EN mix & fullwidth
+  same('Ｆｉｎａｌ Ｆａｎｔａｓｙ VII', 'Final Fantasy 7', 'Fullwidth letters + Roman→Arabic');
+  same('ロックマン＆フォルテ', 'ロックマン and フォルテ', 'Fullwidth ＆ becomes and');
+
+  // Articles: only leading
+  same('An Untitled Story', 'untitled story', 'strip leading "An"');
+  same('Legend of The Galactic Heroes', 'legend of the galactic heroes', 'inner "the" must remain (no strip)');
+
+  // Dashes & wave dashes
+  same('metal gear solid — peace walker', 'metal gear solid - peace walker', 'em-dash equals hyphen');
+  same('chrono〜trigger', 'chrono trigger', 'JP wave dash treated as separator');
+
+  // Roman numerals boundaries (word edges)
+  same('Street Fighter II Turbo', 'Street Fighter 2 Turbo', 'Roman II -> 2 at word boundary');
+  same('RockyIV', 'Rocky 4', 'Roman IV attached to word should normalize'); // if safe boundary, space inserted
+
+  // Slashes & punctuation clusters
+  same('Kingdom Hearts 358/2 Days', 'Kingdom Hearts 358 2 Days', 'Slashes removed');
+
+  // Long vowel mark (ー) collapse
+  same('ドンキーコーーング', 'ドンキーコング', 'Long vowel marks collapsed');
+
+  // Ampersand variants
+  same('Castlevania ＆ Dracula X', 'Castlevania & Dracula X', 'Fullwidth & equals ASCII & -> and');
+
   console.log('[OK] normalize v1.2 assertions passed');
 })();
 

--- a/scripts/generate_daily_index.js
+++ b/scripts/generate_daily_index.js
@@ -74,6 +74,7 @@ function jstISO(d = new Date()) {
   <script>(function(){try{var p=new URLSearchParams(location.search||"");if(p.get("no-redirect")==="1")return;var delay=parseInt(p.get("redirectDelayMs")||"0",10);if(isNaN(delay)||delay<0)delay=0;setTimeout(function(){location.replace(${JSON.stringify('./'+d+'.html')});},delay);}catch(e){}})();</script>
 </head><body>
   <p>Redirecting to <a href="./${d}.html">${d}</a> …</p>
+  <p><a id="cta-latest-app" href="../app/?daily=${d}">アプリで今日の1問へ</a></p>
 </body></html>`;
 
   fs.writeFileSync(path.join(outDir, 'index.html'), mkIndex());


### PR DESCRIPTION
## Summary
- add comprehensive normalization edge case tests for fullwidth letters, dashes, numerals, vowels, slashes, and ampersands
- link daily redirect page to app's daily quiz

## Testing
- `npm test` *(fails: clojure not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*
- `node scripts/generate_daily_index.js`

------
https://chatgpt.com/codex/tasks/task_e_68b693e621908324806374c92a0b4563