### PR TITLE
docs: record v1.1 completion and v1.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,6 @@ All notable changes to this project will be documented in this file.
 ## 既存のタグ
 - v1.0.1 以前：初期実装（MCQ/自由入力、正規化v1.2、SW更新、Daily/RSS、AUTO、A11yベースライン 等）
 
+## v1.0.2 — 2025-09-02
+
+- v1.1(AUTO可視性) deliverables shipped（AUTOトースト/設定UI/バッジA11y/latest CTA & meta/E2E）

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,7 +25,7 @@
 
 ---
 
-## v1.1 — AUTO モード品質 & UX の底上げ（最優先）
+## v1.1 — AUTO モード品質 & UX の底上げ（最優先） — *(Done 2025-09-02)*
 - Deliverables: AUTO起動トースト、Start設定UI（AUTOを有効にする・永続化）、AUTOバッジのA11y（aria-label）。
 **狙い**: “AUTOで遊ぶ”の価値を安定供給する。
 
@@ -42,7 +42,12 @@
 - 既存 Required への影響ゼロ（独立ワークフロー or Required 非連動のまま）
 
 ---
-
+- AUTO起動トースト（?auto=1 / 永続ON時、1セッション1回表示）
+- Start画面：『AUTOを有効にする』（localStorage: `quiz-options.auto_enabled`）
+- AUTOバッジのA11y強化（`role=status` / `aria-live=polite` / `aria-label`）
+- latest.html：CTA『アプリで今日の1問へ』を表示（ジェネレータ＋postbuildガード）
+- latest.html：`meta name=description` を恒久化（postbuildガード）
+- 軽量E2Eの追加（latest meta / auto settings）、既存E2E・Lighthouseは緑継続
 ## v1.2 — データ拡張 (media/難易度) の土台づくり
 **狙い**: クイズ体験にリッチさとバリエーションを追加。
 


### PR DESCRIPTION
## Summary
- mark AUTO-mode v1.1 roadmap milestone as complete and list shipped items
- add v1.0.2 entry noting AUTO visibility deliverables

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*
- `apt-get install -y clojure` *(fails: Unable to locate package clojure)*

------
https://chatgpt.com/codex/tasks/task_e_68b69dacadb8832493aacc006e8d28cf