### PR TITLE
Tighten lighthouse budgets and expand normalization parity samples

### DIFF
--- a/docs/lighthouse-budgets.md
+++ b/docs/lighthouse-budgets.md
@@ -9,9 +9,9 @@
 ## しきい値（初期）
 - `categories:performance >= 0.85`（warn）
 - Budgets（warn）
-  - `total` size ≤ **2.5MB**
-  - `script` size ≤ **1.5MB**
-  - `resource count (total)` ≤ **200**
+  - `total` size ≤ **2.4MB**
+  - `script` size ≤ **1.4MB**
+  - `resource count (total)` ≤ **180**
 
 > Required には入れていません。必要に応じてしきい値は段階的に引き締めてください。
 

--- a/lighthouse/budgets.json
+++ b/lighthouse/budgets.json
@@ -2,11 +2,20 @@
   {
     "path": "/*",
     "resourceCounts": [
-      { "resourceType": "total",   "budget": 200 }
+      {
+        "resourceType": "total",
+        "budget": 180
+      }
     ],
     "resourceSizes": [
-      { "resourceType": "total",   "budget": 2500 },
-      { "resourceType": "script",  "budget": 1500 }
+      {
+        "resourceType": "total",
+        "budget": 2400
+      },
+      {
+        "resourceType": "script",
+        "budget": 1400
+      }
     ]
   }
 ]

--- a/scripts/test_normalize_parity.js
+++ b/scripts/test_normalize_parity.js
@@ -80,6 +80,15 @@ async function main() {
     'Pokémon Red & Blue',
     'NieR:Automata',
     'Castlevania IV',
+    'Ｆｉｎａｌ Ｆａｎｔａｓｙ VII',
+    'ポケットモンスター\u3000青',
+    'ドラゴン・クエストIII',
+    'Street Fighter II Turbo',
+    'Castlevania ＆ Dracula X',
+    'chrono〜trigger',
+    'RockyIV',
+    'Metal Gear Solid — Peace Walker',
+    'Kingdom Hearts 358/2 Days'
   ];
   let mismatches = [];
   for (const s of samples) {


### PR DESCRIPTION
## Summary
- add varied sample strings to normalization parity test
- reduce lighthouse budgets for total resources and script size
- update documentation to match tighter budget limits

## Testing
- `node scripts/test_normalize_parity.js`
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a5333588832497d8b021493e840e