### PR TITLE
test: add alias normalization collision check

### DIFF
--- a/.github/workflows/e2e-light-regressions.yml
+++ b/.github/workflows/e2e-light-regressions.yml
@@ -52,6 +52,9 @@ jobs:
           APP_URL: ${{ inputs.app_url || vars.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/' }}
         run: node e2e/test_auto_settings_exists.mjs
 
+      - name: Check alias canonical no collision (normalized)
+        run: node e2e/test_alias_no_norm_collision.mjs
+
       - name: Upload artifacts on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/e2e/test_alias_no_norm_collision.mjs
+++ b/e2e/test_alias_no_norm_collision.mjs
@@ -1,0 +1,39 @@
+// e2e/test_alias_no_norm_collision.mjs
+// Goal: ensure alias canonical keys do not collide after normalization.
+// This is a thin smoke test complementing JSON validators.
+import { readFileSync } from 'fs';
+import { fileURLToPath, pathToFileURL } from 'url';
+import path from 'path';
+
+async function loadNormalize() {
+  const modUrl = pathToFileURL(path.resolve('public/app/normalize.mjs')).href;
+  const mod = await import(modUrl);
+  return mod.normalize || mod.default || mod.norm || ((s)=>s);
+}
+
+async function main() {
+  const normalize = await loadNormalize();
+  const aliases = JSON.parse(readFileSync('public/app/aliases_local.json','utf-8'));
+  const seen = new Map();
+  let collisions = [];
+  for (const key of Object.keys(aliases)) {
+    const nk = normalize(key);
+    const prev = seen.get(nk);
+    if (prev && prev !== key) {
+      collisions.push([prev, key, nk]);
+    } else {
+      seen.set(nk, key);
+    }
+  }
+  if (collisions.length) {
+    console.error('[alias norm-collision] Found canonical key collisions after normalization:');
+    for (const [a,b,n] of collisions) console.error(`  - "${a}" vs "${b}" -> "${n}"`);
+    throw new Error(`alias canonical collisions: ${collisions.length}`);
+  }
+  console.log('[alias norm-collision] ok');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add smoke test ensuring alias canonical keys don't collide after normalization
- run alias normalization collision check in e2e light regressions workflow

## Testing
- `node e2e/test_alias_no_norm_collision.mjs`
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a85e09e48324b778f46dcb85ec1b