### PR TITLE
test: verify latest daily CTA link

### DIFF
--- a/.github/workflows/e2e-light-regressions.yml
+++ b/.github/workflows/e2e-light-regressions.yml
@@ -42,6 +42,11 @@ jobs:
           DATE: ${{ inputs.date }}
         run: node e2e/test_share_cta_visibility.mjs
 
+      - name: Check /daily/latest.html CTA presence
+        env:
+          APP_URL: ${{ inputs.app_url || vars.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/' }}
+        run: node e2e/test_latest_cta_presence.mjs
+
       - name: Check /daily/latest.html meta description
         env:
           APP_URL: ${{ inputs.app_url || vars.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/' }}

--- a/e2e/test_latest_cta_presence.mjs
+++ b/e2e/test_latest_cta_presence.mjs
@@ -1,0 +1,25 @@
+// e2e/test_latest_cta_presence.mjs
+// Assert that /daily/latest.html?no-redirect=1 includes a CTA link to the app (#cta-latest-app).
+async function main() {
+  const appUrl = process.env.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/';
+  if (!appUrl.endsWith('/app/')) throw new Error(`APP_URL must end with '/app/' (got: ${appUrl})`);
+  const dailyBase = appUrl.replace('/app/', '/daily/');
+  const url = `${dailyBase}latest.html?no-redirect=1`;
+  console.log('[E2E latest cta] URL =', url);
+
+  const res = await fetch(url, { redirect: 'manual' });
+  if (res.status !== 200) throw new Error(`unexpected status: ${res.status}`);
+  const html = await res.text();
+
+  const hasId = html.includes('id="cta-latest-app"');
+  const hasText = html.toLowerCase().includes('アプリで今日の1問へ');
+  if (!hasId && !hasText) {
+    console.log(html.slice(0, 400));
+    throw new Error('#cta-latest-app CTA not found in latest.html');
+  }
+  console.log('[E2E latest cta] ok');
+}
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add E2E test ensuring `/daily/latest.html?no-redirect=1` exposes CTA for app
- run new test in light-regressions workflow

## Testing
- `node e2e/test_latest_cta_presence.mjs` *(fails: ENETUNREACH)*
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ab9f01548324b31529c2fb864eb3