### PR TITLE
Add required e2e meta description check

### DIFF
--- a/.github/workflows/e2e-light-required.yml
+++ b/.github/workflows/e2e-light-required.yml
@@ -1,0 +1,23 @@
+name: e2e (light required)
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  required-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Check /daily/latest.html meta description (required)
+        env:
+          APP_URL: ${{ vars.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/' }}
+        run: node e2e/test_daily_latest_meta.mjs

--- a/docs/ci-status.md
+++ b/docs/ci-status.md
@@ -17,3 +17,8 @@
 
 - **daily.json generator (JST)**  
   *(既存ワークフロー名に合わせて必要なら差し替えてください)*
+
+### Required にするチェック（推奨・最小）
+- **e2e (light required) / required-check** をブランチプロテクションの **Required** に設定すると、
+  Pages の `latest.html` に `meta[name=description]` が常に存在することを PR 時に保証できます。
+  （軽量・安定で、他のチェックは非ブロッキングのまま運用可能）


### PR DESCRIPTION
## Summary
- add e2e (light required) workflow that checks latest.html meta description
- document required check setup in CI status docs

## Testing
- `npm test` *(fails: clojure: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b6b35beef08324a543373edf40e09b