### PR TITLE
Add static AUTO badge a11y regression test

### DIFF
--- a/.github/workflows/e2e-light-regressions.yml
+++ b/.github/workflows/e2e-light-regressions.yml
@@ -60,6 +60,11 @@ jobs:
       - name: Check alias canonical no collision (normalized)
         run: node e2e/test_alias_no_norm_collision.mjs
 
+      - name: Check AUTO badge a11y (static)
+        env:
+          APP_URL: ${{ inputs.app_url || vars.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/' }}
+        run: node e2e/test_auto_badge_a11y_static.mjs
+
       - name: Upload artifacts on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/docs/e2e-light-regressions.md
+++ b/docs/e2e-light-regressions.md
@@ -42,4 +42,5 @@
 ## 関連
 - `docs/ci.md` – CI全体像
 - `docs/ops-runbook.md` – 運用フロー
-- `docs/urls-and-params.md` / `docs/urls-and-params.md` – URL/クエリ仕様
+- `docs/urls-and-params.md`（正本） – URL/クエリ仕様
+- **AUTO badge a11y (static)** — `public/app/auto_badge.mjs` 内に a11y 属性（`role` / `aria-live` / `aria-label`）が含まれることをチェック。

--- a/e2e/test_auto_badge_a11y_static.mjs
+++ b/e2e/test_auto_badge_a11y_static.mjs
@@ -1,0 +1,20 @@
+// e2e/test_auto_badge_a11y_static.mjs
+// Static check: public/app/auto_badge.mjs contains a11y attributes for the badge.
+async function main() {
+  const appUrl = process.env.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/';
+  if (!appUrl.endsWith('/app/')) throw new Error(`APP_URL must end with '/app/' (got: ${appUrl})`);
+  const url = `${appUrl}auto_badge.mjs`;
+  console.log('[E2E auto badge a11y] URL =', url);
+
+  const res = await fetch(url, { redirect: 'manual' });
+  if (res.status !== 200) throw new Error(`unexpected status: ${res.status}`);
+  const js = await res.text();
+  const must = ['role', 'aria-live', 'aria-label'];
+  const missing = must.filter(s => !js.includes(s));
+  if (missing.length) {
+    console.log(js.slice(0, 400));
+    throw new Error('auto_badge.mjs missing a11y attributes: ' + missing.join(', '));
+  }
+  console.log('[E2E auto badge a11y] ok');
+}
+main().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- add end-to-end script that fetches `auto_badge.mjs` and asserts presence of ARIA role/label attributes
- wire new test into `e2e-light-regressions` workflow
- document AUTO badge accessibility check in e2e light regression docs

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository InRelease not signed)*
- `node e2e/test_auto_badge_a11y_static.mjs` *(fails: fetch ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b7578e848324b7c372161877d744