### PR TITLE
ci: add workflow to apply apple overrides

### DIFF
--- a/.github/workflows/tools-apple-enrich.yml
+++ b/.github/workflows/tools-apple-enrich.yml
@@ -1,0 +1,44 @@
+name: tools: apply apple overrides
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  enrich:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Apply Apple overrides (if present)
+        run: |
+          if [ -f "data/apple_overrides.jsonc" ] && [ -f "scripts/enrich/apple_enrich.mjs" ]; then
+            echo "[apply] merging overrides into build/dataset.json"
+            node scripts/enrich/apple_enrich.mjs build/dataset.json data/apple_overrides.jsonc --write build/dataset.json
+          else
+            echo "No overrides or enrich script found; skipping."
+            exit 0
+          fi
+
+      - name: Commit changes (if any)
+        run: |
+          set -euxo pipefail
+          if ! git diff --quiet -- build/dataset.json; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add build/dataset.json
+            git commit -m "chore(data): apply apple overrides to build/dataset.json"
+            git push
+          else
+            echo "No changes to commit."
+          fi


### PR DESCRIPTION
## Summary
- add workflow to merge Apple override data into dataset

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ea6a1efc83248cc735a3ab46f969