### PR TITLE
feat: support match-based Apple overrides

### DIFF
--- a/resources/data/apple_overrides.jsonc
+++ b/resources/data/apple_overrides.jsonc
@@ -1,0 +1,16 @@
+// Match by title (and optionally game). This format is supported by apple_enrich.mjs.
+[
+  {
+    // クロノ・トリガー（メインテーマ） — title で一致させる
+    "match": { "title": "クロノ・トリガー" },
+    "media": {
+      "apple": {
+        // Any one of url / embedUrl / previewUrl being truthy enables Apple path.
+        "url": "https://music.apple.com/jp/song/%E3%82%AF%E3%83%AD%E3%83%8E-%E3%83%88%E3%83%AA%E3%82%AC%E3%83%BC/324080961",
+        // "embedUrl": "https://embed.music.apple.com/jp/song/324080961",
+        // "previewUrl": "",
+        "previewOffset": 0
+      }
+    }
+  }
+]

--- a/scripts/enrich/apple_enrich.mjs
+++ b/scripts/enrich/apple_enrich.mjs
@@ -25,26 +25,48 @@ const dataset = readJsonMaybeJsonc(datasetPath);
 const overrides = readJsonMaybeJsonc(overridesPath);
 
 let count = 0;
+
+function applyApple(t, ov) {
+  t.media = t.media || {};
+  t.media.apple = { ...(t.media.apple || {}), ...(ov.media?.apple || {}) };
+  count++;
+}
+
+function norm(s) { return (s ?? "").toString().trim().toLowerCase(); }
+
+function byKeyMerge(arr, map) {
+  for (const t of arr) {
+    const key = t.id || t.slug || t.uid;
+    if (!key) continue;
+    const ov = map[key];
+    if (!ov) continue;
+    applyApple(t, ov);
+  }
+}
+
+function byMatchMerge(arr, arrOverrides) {
+  for (const ov of arrOverrides) {
+    const m = ov.match || {};
+    const mt = norm(m.title);
+    const mg = norm(m.game);
+    if (!mt && !mg) continue;
+    for (const t of arr) {
+      const tt = norm(t.title);
+      const tg = norm(t.game);
+      if ((mt ? tt === mt : true) && (mg ? tg === mg : true)) {
+        applyApple(t, ov);
+      }
+    }
+  }
+}
+
 if (Array.isArray(dataset)) {
-  for (const t of dataset) {
-    const key = t.id || t.slug || t.uid;
-    if (!key) continue;
-    const ov = overrides[key];
-    if (!ov) continue;
-    t.media = t.media || {};
-    t.media.apple = { ...(t.media.apple || {}), ...(ov.media?.apple || {}) };
-    count++;
-  }
-} else if (dataset && dataset.tracks) {
-  for (const t of dataset.tracks) {
-    const key = t.id || t.slug || t.uid;
-    if (!key) continue;
-    const ov = overrides[key];
-    if (!ov) continue;
-    t.media = t.media || {};
-    t.media.apple = { ...(t.media.apple || {}), ...(ov.media?.apple || {}) };
-    count++;
-  }
+  if (Array.isArray(overrides)) byMatchMerge(dataset, overrides);
+  else if (overrides && typeof overrides === 'object') byKeyMerge(dataset, overrides);
+} else if (dataset && Array.isArray(dataset.tracks)) {
+  const arr = dataset.tracks;
+  if (Array.isArray(overrides)) byMatchMerge(arr, overrides);
+  else if (overrides && typeof overrides === 'object') byKeyMerge(arr, overrides);
 } else {
   console.error("Unsupported dataset shape. Expected array or {tracks: []}.");
   process.exit(1);


### PR DESCRIPTION
## Summary
- extend apple_enrich.mjs to merge Apple media overrides by key or by title/game match
- add sample Apple Music override file

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f638b42483249e61a22785ad77b2