### PR TITLE
ci: force add apple enrich build outputs

### DIFF
--- a/.github/workflows/tools-apple-enrich.yml
+++ b/.github/workflows/tools-apple-enrich.yml
@@ -62,10 +62,12 @@ jobs:
 
       - name: Commit changes (if any)
         run: |
+          set -e
           if ! git diff --quiet -- public/build/dataset.json public/build/version.json; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add public/build/dataset.json public/build/version.json
+            # public/build is ignored; force-add just these two files
+            git add -f public/build/dataset.json public/build/version.json
             git commit -m "chore(data): build & apply apple overrides (dataset + version.json)"
             git push
           else


### PR DESCRIPTION
## Summary
- ensure apple enrich workflow stops on failure and force-add build outputs

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fec7b9cc832480049020e2ab8d3f