### PR TITLE
chore(data): apply apple overrides to dataset

### DIFF
--- a/public/build/version.json
+++ b/public/build/version.json
@@ -1,1 +1,1 @@
-{"dataset_version":1,"content_hash":"dev","generated_at":"2025-01-01T00:00:00Z","commit":"dev"}
+{"dataset_version":1,"content_hash":"dac17ee2abfe03e82d9e436a072f13fda8454793a99ce0be3df5b21b19f770a9","generated_at":"2025-09-02T15:47:18.081108533Z","commit":"0e78fee1041770a20771d00345dfda4bb8863cc4"}


### PR DESCRIPTION
This PR was generated by tools-apple-enrich.
- Built dataset via `clj -T:build publish`
- Applied overrides from `resources/data/apple_overrides.jsonc`
- Refreshed `public/build/version.json` content hash