### PR TITLE
docs: document PAT for automated PRs

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -2,6 +2,11 @@
 
 ## Workflows
 
+### PR authoring token (tools-apple-enrich)
+- `tools-apple-enrich` で作成する自動PRは、**GITHUB_TOKEN ではなく PAT (`CPR_PAT`) を使用**します。
+- 目的：PR作成イベントが **pull_request** の Required を確実に発火させるため（待機中の回避）。
+- ブランチは毎回 `bot/apple-enrich-${{ github.run_id }}` のように**ユニーク**に作成します（古いPRとの干渉防止）。
+
 - **`ci-fast.yml`** – main branch: `clojure -T:build publish` → `clojure -M:test`
 - **`ci-fast-pr.yml`** – PR軽量チェック（Required: `ci-fast-pr-build`）
 - **`pages.yml`** – main への push / 手動で `public/` を GitHub Pages に配信（配信前に **daily index/RSS** を再生成）

--- a/docs/github-admin.md
+++ b/docs/github-admin.md
@@ -15,8 +15,17 @@ If you rename jobs or workflows, update Rulesets so PRs don’t get stuck in “
 
 ## Secrets
 
-- `DAILY_PR_PAT` – Personal Access Token (classic), **repo** scope is enough. Used by `daily.yml` to author PRs as you.
+- `DAILY_PR_PAT`
+  - Personal Access Token (classic), **repo** scope is enough. Used by `daily.yml` to author PRs as you.
   - Renew before it expires; if it expires the PR author becomes `github-actions[bot]` and the daily PR may fail.
+
+- `CPR_PAT` – Fine-grained Personal Access Token used by **tools-apple-enrich** to create PRs (so that **Required checks trigger**).
+  - **Repository access**: Only this repo
+  - **Permissions** (minimum):
+    - Contents: **Read and write**
+    - Pull requests: **Read and write**
+    - Issues: **Read and write**（ラベル付与をする場合）
+  - Classic PAT を使う場合は `repo` スコープで代替可
 
 ## Pages
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,3 +16,12 @@
 
 ## PR が作られない
 - 差分が無い場合は正常。Summary に `(no changes / not created)` が出る。
+
+
+## Required が「待機中」から進まない（自動PR）
+- 自動PRを **GITHUB_TOKEN** で作成すると、状況によって `pull_request` ワークフローが**発火しない**ケースがあります。
+- 対処：
+  1. PR作成は **Fine-grained PAT (`CPR_PAT`)** を使用（`peter-evans/create-pull-request` の `with.token`）。
+  2. PRブランチは毎回ユニーク（`bot/apple-enrich-${{ github.run_id }}`）。
+  3. 既存PRが“待機中”なら **Close→Reopen** または **空コミット**（`git commit --allow-empty && git push`）で再通知。
+- Pages/CI/E2E の **Required 名**（`pages-pr-build` / `ci-fast-pr-build` / `required-check`）と **Job名** が一致しているかも点検。


### PR DESCRIPTION
## Summary
- note required PATs (`DAILY_PR_PAT`, `CPR_PAT`) for automation
- explain using PAT over GITHUB_TOKEN for tools-apple-enrich
- add troubleshooting steps when required checks stay waiting

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b712e6664c83249f7f1b40059d81bb