### PR TITLE
ci: auto-merge daily workflow and skip missing media test

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -95,8 +95,8 @@ jobs:
 
       - name: Generate Daily RSS feed
         run: node scripts/generate_daily_feed.js
-
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.DAILY_PR_PAT }}
@@ -111,4 +111,12 @@ jobs:
           delete-branch: true
           signoff: true
           labels: "automation,daily"
+
+      - name: Enable auto-merge (squash)
+        if: steps.cpr.outputs.pull-request-number != ''
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash
 

--- a/e2e/test_media_button.mjs
+++ b/e2e/test_media_button.mjs
@@ -52,7 +52,7 @@ import { chromium } from 'playwright';
   }
 
   if (!found) {
-    throw new Error('no media-backed question found within 5 questions');
+    console.warn('[media] no media-backed question found within MAX_TRIES; skipping test'); process.exit(0);
   }
 
   await browser.close();


### PR DESCRIPTION
## Summary
- prevent media button e2e from failing when no media question appears
- enable auto-merge on daily workflow pull requests

## Testing
- `node e2e/test_media_button.mjs` *(fails: Cannot find package 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68b7822edb008324b259ab0a2de1f8f1