### PR TITLE
Split trailing Roman numerals in normalization

### DIFF
--- a/public/app/normalize.mjs
+++ b/public/app/normalize.mjs
@@ -61,6 +61,9 @@ export function normalize(str) {
   s = romanToArabicSafe(s);
   s = arabicToRomanSafe(s);
 
+  // 単語末尾にローマ数字(II, III, IV, VI, etc)が続く場合は区切る（例: rockyiv -> rocky iv）
+  s = s.replace(/([a-z])([ivxlcdm]{2,})(?![a-z0-9])/g, '$1 $2');
+
   // CJK間のスペースは削除（英単語間は保持）
   // Hiragana/Katakana/Han/compat & 長音記号の間の空白を除去
   s = s.replace(/(?<=[\u3040-\u30FF\u3400-\u9FFF\uF900-\uFAFF\uFF66-\uFF9Dー])\s+(?=[\u3040-\u30FF\u3400-\u9FFF\uF900-\uFAFF\uFF66-\uFF9Dー])/g, '');


### PR DESCRIPTION
## Summary
- ensure normalization separates trailing Roman numerals from preceding words

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b797714d6483248a998795ac6a19bf