### PR TITLE
chore: update daily latest redirect

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Ensure CTA in latest.html
         run: node scripts/ensure_latest_cta.js
 
+      - name: Update latest.html to today (JST)
+        run: node scripts/update_latest_html.js
+
       - name: Generate Daily RSS feed
         run: node scripts/generate_daily_feed.js
       - name: Create Pull Request

--- a/public/app/mock_api.js
+++ b/public/app/mock_api.js
@@ -11,7 +11,7 @@
   }
 
   const aliasUrls = [
-    '/vgm-quiz/public/build/aliases.json', // GitHub Pages base path
+    '/vgm-quiz/build/aliases.json', // GitHub Pages base path
     '/vgm-quiz/public/app/aliases_local.json',
     // Fallbacks for local runs (served from repo root or app/)
     '/public/build/aliases.json',

--- a/scripts/update_latest_html.js
+++ b/scripts/update_latest_html.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// Update public/daily/latest.html to redirect to today's page (JST).
+const fs = require('fs');
+const path = require('path');
+
+function todayJST() {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Tokyo', year: 'numeric', month: '2-digit', day: '2-digit'
+  });
+  const p = Object.fromEntries(fmt.formatToParts(new Date()).map(x => [x.type, x.value]));
+  return `${p.year}-${p.month}-${p.day}`;
+}
+
+(function main() {
+  const root = process.cwd();
+  const dailyDir = path.join(root, 'public', 'daily');
+  const latestPath = path.join(dailyDir, 'latest.html');
+  const d = todayJST();
+  if (!fs.existsSync(dailyDir)) fs.mkdirSync(dailyDir, { recursive: true });
+
+  const html = [
+    '<!doctype html>',
+    '<html lang="ja"><head>',
+    '  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">',
+    '  <meta name="description" content="VGM Quiz のデイリーページ（最新）。ゲーム音楽の1日1問にすぐアクセスできます。">',
+    '  <title>VGM Quiz — Daily latest</title>',
+    `  <meta http-equiv="refresh" content="0; url=./${d}.html">`,
+    '</head><body>',
+    `  <p>Redirecting to <a href="./${d}.html">${d}</a> …</p>`,
+    `  <p><a id="cta-latest-app" href="../app/?daily=${d}">アプリで今日の1問へ</a></p>`,
+    '</body></html>'
+  ].join('\n');
+
+  fs.writeFileSync(latestPath, html, 'utf8');
+  console.log('[update_latest] wrote', path.relative(root, latestPath), '->', d);
+})();


### PR DESCRIPTION
## Summary
- ensure daily latest.html is regenerated for today's date in the scheduled workflow
- add update_latest_html.js utility for writing the redirect
- adjust mock API alias path for GitHub Pages

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b79909c96c8324bb80a2a54cc2b8b4