### PR TITLE
Add media link for Corridors of Time track

### DIFF
--- a/public/app/mock/dataset.json
+++ b/public/app/mock/dataset.json
@@ -44,7 +44,13 @@
       }
     },
     { "title": "Gusty Garden Galaxy", "game": "スーパーマリオギャラクシー", "composer": "近藤浩治", "year": 2007 },
-    { "title": "Corridors of Time", "game": "クロノ・トリガー", "composer": "光田康典", "year": 1995 },
+    {
+      "title": "Corridors of Time",
+      "game": "クロノ・トリガー",
+      "composer": "光田康典",
+      "year": 1995,
+      "media": { "apple": { "url": "https://music.apple.com/jp/song/324081004", "previewOffset": 0 } }
+    },
     { "title": "Main Theme", "game": "ゼルダの伝説: 時のオカリナ", "composer": "近藤浩治", "year": 1998 }
   ]
 }


### PR DESCRIPTION
## Summary
- add Apple Music media info to Corridors of Time in mock dataset

## Testing
- `npm test` *(fails: clojure not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7aa30a3dc8324a35336b1bba5fb30