### PR TITLE
Allow rendering media without provider metadata

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -771,7 +771,7 @@ function showQuestion() {
   try {
     const media = q?.media || q?.track?.media;
     const slot = document.getElementById('media-slot');
-    if (slot && media && media.provider) {
+    if (slot && media) {
       const ctrl = createMediaControl(media);
       slot.replaceChildren(ctrl);
     }


### PR DESCRIPTION
## Summary
- Render media elements even when provider field is missing

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: The repository is not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b7acb294a8832493a509650fab4c7c