### PR TITLE
Rename media player inner slot

### DIFF
--- a/public/app/media_player.mjs
+++ b/public/app/media_player.mjs
@@ -18,7 +18,7 @@ function buildAppleEmbed(media){
   root.dataset.provider = 'apple';
   root.setAttribute('role','group');
   root.setAttribute('aria-label','Media player (Apple Music)');
-  const slot = document.createElement('div'); slot.id = 'media-slot'; root.appendChild(slot);
+  const slot = document.createElement('div'); slot.id = 'media-inner'; root.appendChild(slot);
 
   const stubOnly = isFlagOn('test') || isFlagOn('lhci') || isFlagOn('nomedia');
   if (stubOnly){
@@ -79,7 +79,7 @@ function buildYouTubeEmbed(media){
   root.dataset.provider = 'youtube';
   root.setAttribute('role','group');
   root.setAttribute('aria-label','Media player (YouTube)');
-  const slot = document.createElement('div'); slot.id = 'media-slot'; root.appendChild(slot);
+  const slot = document.createElement('div'); slot.id = 'media-inner'; root.appendChild(slot);
 
   const stubOnly = isFlagOn('test') || isFlagOn('lhci') || isFlagOn('nomedia');
   if (stubOnly){


### PR DESCRIPTION
## Summary
- avoid duplicate IDs by renaming inner media slot to `media-inner`

## Testing
- `npm test` *(fails: clojure: not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68b7b1e38a7c8324a21381d81b04565a