### PR TITLE
Clarify mock API alias path comments

### DIFF
--- a/public/app/mock_api.js
+++ b/public/app/mock_api.js
@@ -11,10 +11,9 @@
   }
 
   const aliasUrls = [
-    '/vgm-quiz/build/aliases.json', // GitHub Pages base path
+    '/vgm-quiz/build/aliases.json',        // GitHub Pages base path (correct)
     '/vgm-quiz/public/app/aliases_local.json',
-    // Fallbacks for local runs (served from repo root or app/)
-    '/public/build/aliases.json',
+    '/public/build/aliases.json',          // local dev fallbacks
     '/public/app/aliases_local.json'
   ];
 


### PR DESCRIPTION
## Summary
- clarify GitHub Pages base alias path comment
- mark local development alias path fallbacks

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b5f69bdc832481f4b1c470a97359