### PR TITLE
chore: bypass cache for latest share test

### DIFF
--- a/e2e/test_share.js
+++ b/e2e/test_share.js
@@ -77,7 +77,9 @@ function jstISO() {
   }
 
   // 4) latest.html は常に当日へ meta refresh（手動でも生成される想定）
-  const respLatest = await page.request.get(latestUrl);
+  const respLatest = await page.request.get(`${latestUrl}?e2e=${Date.now()}`, {
+    headers: { 'Cache-Control': 'no-cache', 'Pragma': 'no-cache' }
+  });
   if (respLatest.status() === 200) {
     const html = await respLatest.text();
     const refreshToday = new RegExp(`http-equiv=["']refresh["'][^>]+url=\\./${date}\\.html`).test(html);


### PR DESCRIPTION
## Summary
- avoid caching when fetching latest daily share page in E2E tests

## Testing
- `npm test` *(fails: clojure: not found)*
- `APP_URL=http://localhost node e2e/test_share.js` *(fails: Cannot find module 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68b7bf1d59ec8324a0522013bcd8e570