### PR TITLE
chore: tighten lighthouse budget

### DIFF
--- a/lighthouse/budgets.json
+++ b/lighthouse/budgets.json
@@ -4,17 +4,17 @@
     "resourceCounts": [
       {
         "resourceType": "total",
-        "budget": 180
+        "budget": 160
       }
     ],
     "resourceSizes": [
       {
         "resourceType": "total",
-        "budget": 2400
+        "budget": 2200
       },
       {
         "resourceType": "script",
-        "budget": 1400
+        "budget": 1200
       }
     ]
   }


### PR DESCRIPTION
## Summary
- tighten lighthouse resource budgets to encourage smaller bundles

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7dff9eb008324baf6767e14ce1f8e