### PR TITLE
chore: configure lighthouse budgets in settings

### DIFF
--- a/.lighthouserc.budgets.json
+++ b/.lighthouserc.budgets.json
@@ -5,7 +5,10 @@
       "url": [
         "https://nantes-rfli.github.io/vgm-quiz/app/",
         "https://nantes-rfli.github.io/vgm-quiz/daily/latest.html?no-redirect=1"
-      ]
+      ],
+      "settings": {
+        "budgetsPath": "lighthouse/budgets.json"
+      }
     },
     "assert": {
       "preset": "lighthouse:recommended",
@@ -14,12 +17,6 @@
           "warn",
           {
             "minScore": 0.85
-          }
-        ],
-        "budgets": [
-          "warn",
-          {
-            "budgetsFile": "lighthouse/budgets.json"
           }
         ],
         "errors-in-console": [
@@ -47,6 +44,12 @@
           "warn",
           {
             "maxLength": 1
+          }
+        ],
+        "performance-budget": [
+          "warn",
+          {
+            "minScore": 1
           }
         ]
       }


### PR DESCRIPTION
## Summary
- configure Lighthouse to load budgets via collect settings
- add performance-budget assertion

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e507d5708324a139205203eecb70