### PR TITLE
feat: add asset usage scanner

### DIFF
--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -43,6 +43,11 @@ Nightly run (desktop). Budgets & asserts enabled.
 - View the job **Summary** for the temporary-public report URL.
 - Artifact **lighthouse-report/report.html** is saved for 7 days.
 
+### アセットの未使用チェック（スキャン）
+- コマンド: `npm run scan:assets`
+- 仕組み: `public/` 配下の画像/フォント/音声を列挙し、リポ内のテキストから参照をグリッドサーチ。参照が見つからないものを候補として出力（**自動削除はしない**）。
+- 使い方: まず候補をレビュー → 問題なければ手動削除し、E2E/Pagesを確認。
+
 ### latest.html（運用メモ）
 - 生成物は **JS リダイレクト（`location.replace('./YYYY-MM-DD.html')`）** 方式でも良い（従来の `<meta http-equiv="refresh">` も可）。
 - E2E（`e2e/test_share.js`）は **meta / JS / `<a href>`** のいずれかで当日（JST）への遷移を検出するように緩和済み。

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "scripts": {
     "test": "clojure -M:test",
     "e2e": "node e2e/test.js",
-    "smoke": "node scripts/smoke-html.js && node scripts/smoke-daily.js"
+    "smoke": "node scripts/smoke-html.js && node scripts/smoke-daily.js",
+    "scan:assets": "node tools/asset-usage-scan.js"
   },
   "devDependencies": {
     "cheerio": "1.0.0"

--- a/tools/asset-usage-scan.js
+++ b/tools/asset-usage-scan.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Asset usage scanner (best-effort, static grep).
+ * - Scans public/* for asset files
+ * - Greps repo text files for references to those paths
+ * - Prints a report of potentially unused assets
+ *
+ * Usage: node tools/asset-usage-scan.js
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.cwd();
+const PUBLIC = path.join(ROOT, 'public');
+
+/** file extensions considered "assets" */
+const ASSET_EXT = new Set([
+  '.png','.jpg','.jpeg','.gif','.webp','.svg','.ico',
+  '.mp3','.wav','.m4a','.mp4','.webm',
+  '.woff','.woff2','.ttf','.otf'
+]);
+
+/** directories to skip entirely */
+const SKIP_DIRS = new Set(['.git', 'node_modules', '.github', 'e2e']);
+/** text-like extensions we will search through */
+const TEXT_EXT = new Set(['.html','.htm','.css','.js','.mjs','.json','.md','.yml','.yaml','.txt']);
+
+/** whitelist patterns (regex) that mark assets as implicitly used (e.g., SW cache patterns) */
+const WHITELIST_REGEX = [
+  /\/ogp\/daily-\d{4}-\d{2}-\d{2}\.png/,
+  /\/app\/icons\/app-icon\.svg/,
+];
+
+function* walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(p);
+    } else {
+      yield p;
+    }
+  }
+}
+
+function isTextFile(p) {
+  const ext = path.extname(p).toLowerCase();
+  return TEXT_EXT.has(ext);
+}
+function isAssetFile(p) {
+  const ext = path.extname(p).toLowerCase();
+  return ASSET_EXT.has(ext);
+}
+
+function rel(p) {
+  return p.replace(ROOT, '').replace(/^[\\/]/, '').replace(/\\/g, '/');
+}
+
+function collectAssets() {
+  const assets = [];
+  for (const p of walk(PUBLIC)) {
+    if (isAssetFile(p)) assets.append ? assets.append(rel(p)) : assets.push(rel(p));
+  }
+  return assets;
+}
+
+function* iterTextFiles() {
+  for (const p of walk(ROOT)) {
+    if (p.startsWith(PUBLIC)) continue; // don't scan binary assets themselves
+    if (isTextFile(p)) yield p;
+  }
+}
+
+function searchRefs(assets) {
+  const refMap = new Map(assets.map(a => [a, 0]));
+  const texts = Array.from(iterTextFiles());
+  for (const file of texts) {
+    let text;
+    try {
+      text = fs.readFileSync(file, 'utf8');
+    } catch { continue; }
+    for (const a of assets) {
+      if (text.includes(a) || text.includes('/' + a) || text.includes(a.replace(/^public\//, ''))) {
+        refMap.set(a, (refMap.get(a) || 0) + 1);
+      }
+    }
+  }
+  // whitelist
+  for (const a of assets) {
+    for (const re of WHITELIST_REGEX) {
+      if (re.test('/' + a)) {
+        refMap.set(a, (refMap.get(a) || 0) + 1);
+        break;
+      }
+    }
+  }
+  return refMap;
+}
+
+function main() {
+  if (!fs.existsSync(PUBLIC)) {
+    console.error('public/ not found. Run from repo root.');
+    process.exit(1);
+  }
+  const assets = collectAssets();
+  const refMap = searchRefs(assets);
+  const unused = assets.filter(a => (refMap.get(a) || 0) === 0);
+  console.log('# Asset usage scan');
+  console.log(`Assets scanned: ${assets.length}`);
+  console.log(`Potentially unused: ${unused.length}`);
+  if (unused.length) {
+    console.log('\n## Candidates to review (no references found):');
+    unused.sort().forEach(a => console.log('-', a));
+  } else {
+    console.log('\nNo unused assets detected.');
+  }
+  process.exit(0);
+}
+
+if (require.main === module) main();
+


### PR DESCRIPTION
## Summary
- add `scan:assets` npm script to check for unused assets
- implement asset usage scanner for `public/` images, fonts, and audio files
- document how to run the asset scanner in the ops runbook

## Testing
- `npm test` *(fails: clojure: not found)*
- `npm run scan:assets`


------
https://chatgpt.com/codex/tasks/task_e_68b7e7b7cbd083248e73e4d839671df7