### PR TITLE
feat: add asset scan workflow

### DIFF
--- a/.github/workflows/asset-scan.yml
+++ b/.github/workflows/asset-scan.yml
@@ -1,0 +1,62 @@
+name: asset-scan (on-demand & PR)
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - 'public/**'
+      - 'tools/asset-usage-scan.js'
+      - 'package.json'
+      - 'docs/**'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run asset usage scan
+        run: |
+          node tools/asset-usage-scan.js | tee scan.txt
+
+      - name: Upload scan result
+        uses: actions/upload-artifact@v4
+        with:
+          name: asset-scan
+          path: scan.txt
+
+      - name: Warn in job summary if unused assets exist
+        run: |
+          if grep -q "Potentially unused: 0" scan.txt; then
+            echo "No unused assets detected." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### Unused assets detected" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            sed -n '1,200p' scan.txt >> $GITHUB_STEP_SUMMARY
+            echo "
+(…truncated if long. Full output in artifact.)" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "::warning::Unused assets detected. See Job Summary or artifact 'asset-scan'."
+          fi
+
+      - name: Comment on PR with scan (short)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('scan.txt','utf8');
+            const head = body.split('\n').slice(0, 200).join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '### Asset usage scan\n```
+' + head + '\n```\n(Full output attached as artifact in the workflow run.)'
+            });

--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -43,6 +43,11 @@ Nightly run (desktop). Budgets & asserts enabled.
 - View the job **Summary** for the temporary-public report URL.
 - Artifact **lighthouse-report/report.html** is saved for 7 days.
 
+### アセットスキャン（GitHubでの実行）
+- **手動実行**: Actions → **asset-scan (on-demand & PR)** → Run workflow
+- **PRトリガ**: `public/**` 等に変更があるPRで自動実行し、結果を Job Summary とPRコメント・Artifact に出力
+- **削除フロー**: 出力の候補をレビュー → 不要なら削除PRを作成 → E2E / Pages / lighthouse を確認
+
 ### アセットの未使用チェック（スキャン）
 - コマンド: `npm run scan:assets`
 - 仕組み: `public/` 配下の画像/フォント/音声を列挙し、リポ内のテキストから参照をグリッドサーチ。参照が見つからないものを候補として出力（**自動削除はしない**）。


### PR DESCRIPTION
## Summary
- add asset-scan workflow to detect unused assets and comment results
- document GitHub asset scan usage in ops runbook

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b7e936e618832487117f95b3fc45d5