### PR TITLE
perf(app): lazy load auto helpers and media player

### DIFF
--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -58,3 +58,7 @@ Nightly run (desktop). Budgets & asserts enabled.
 - E2E（`e2e/test_share.js`）は **meta / JS / `<a href>`** のいずれかで当日（JST）への遷移を検出するように緩和済み。
 - 手動実行直後などタイミング差がある場合、**前日**への遷移も暫定許容（後続の daily 実行で当日化される前提）。
 - CDN/Pages キャッシュを避けるため、検証時は `?e2e=<timestamp>` と no-cache ヘッダで取得する。
+
+### パフォーマンス最適化（lazy import）
+- `public/app/boot_auto.mjs` を導入し、`?auto=1` / `?daily_auto=1` のときのみ `auto_*` モジュールを読み込みます（初期表示のリクエスト・パースを削減）。
+- メディア再生UI（`media_player.mjs`）は、問題にメディアがある場合にだけ **動的 import** で読み込みます（通常の初期表示時は読み込まない）。

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1,6 +1,6 @@
 import { normalize as normalizeV2 } from './normalize.mjs';
 import { orderByYearBucket } from './question_pipeline.mjs';
-import { createMediaControl } from './media_player.mjs';
+// lazy import on demand from './media_player.mjs'
 
 let tracks = [];
 let questions = [];
@@ -772,8 +772,12 @@ function showQuestion() {
     const media = q?.media || q?.track?.media;
     const slot = document.getElementById('media-slot');
     if (slot && media) {
-      const ctrl = createMediaControl(media);
-      slot.replaceChildren(ctrl);
+      import('./media_player.mjs').then(({ createMediaControl }) => {
+        try {
+          const ctrl = createMediaControl(media);
+          slot.replaceChildren(ctrl);
+        } catch (e) { console.warn('[media] render failed', e); }
+      }).catch(e => console.warn('[media] lazy load failed', e));
     }
   } catch (_) {}
   clearInterval(timerId);

--- a/public/app/boot_auto.mjs
+++ b/public/app/boot_auto.mjs
@@ -1,0 +1,13 @@
+// Conditionally load auto-mode helpers to avoid cost when unused.
+const params = new URLSearchParams(location.search || '');
+const isAuto = params.get('auto') === '1' || params.get('daily_auto') === '1';
+
+if (isAuto) {
+  // Load in parallel; they are independent and small.
+  await Promise.all([
+    import('./auto_choices_loader.mjs'),
+    import('./auto_badge.mjs'),
+    import('./auto_toast.mjs')
+  ]).catch(e => console.warn('[auto] boot load failed', e));
+}
+

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -10,10 +10,8 @@
 <link rel="manifest" href="manifest.webmanifest">
 <!-- ESM の事前解決は modulepreload を使う。credentials 警告回避に crossorigin を明示 -->
 <link rel="modulepreload" href="app.js" crossorigin="anonymous">
-<!-- Load auto choices (no-op unless ?auto=1 or ?daily_auto=1) BEFORE mc.js so it can consult overrides -->
-<script type="module" src="./auto_choices_loader.mjs"></script>
-<script type="module" src="./auto_badge.mjs"></script>
-<script type="module" src="./auto_toast.mjs"></script>
+<!-- Load AUTO helpers lazily to avoid extra network/parse work -->
+<script type="module" src="./boot_auto.mjs"></script>
 
   <script>
     // Conditionally load test API when ?mock=1


### PR DESCRIPTION
## Summary
- load auto-mode helpers only when AUTO mode is active
- defer media player import until a question uses media
- document lazy import optimizations

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ef97ee048324b7c684824d644fed