### PR TITLE
chore: defer dataset and alias loading

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -20,6 +20,7 @@ let score = 0;
 let awaitingNext = false;
 let currentRunId = null;
 let datasetLoaded = false;
+let datasetPromise = null;
 const aliases = {};
 let questionMode = 'free'; // multiple choice mode uses 'multiple-choice'
 let timerId = null;
@@ -1215,8 +1216,11 @@ updateStartButton();
 console.log('features', { mode: questionMode === 'multiple-choice' ? 'MC' : 'Free', timer: useTimer ? '20s' : 'off' });
 
 checkOnLoad();
-loadDataset();
-loadAliases();
+{
+  const ric = window.requestIdleCallback || (cb => setTimeout(cb, 1));
+  ric(() => { try { datasetPromise = loadDataset(); } catch(e){} });
+  ric(() => { try { loadAliases(); } catch(e){} });
+}
 
 navigator.serviceWorker?.addEventListener('message', async (e)=>{
   if(e.data?.type==='version-refreshed'){


### PR DESCRIPTION
## Summary
- defer dataset and alias loading using requestIdleCallback to avoid blocking
- expose datasetPromise for tracking dataset load completion

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f3003ea083249498388bc4496b13