### PR TITLE
Offload dataset JSON parsing to worker

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1,3 +1,26 @@
+// --- perf helpers ---
+async function parseJsonOffMainThread(text) {
+  try {
+    // Use a dedicated worker to avoid blocking main thread with JSON.parse
+    const url = new URL('./workers/json_parse_worker.js', import.meta.url);
+    const worker = new Worker(url, { type: 'module' });
+    return await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => { try { worker.terminate(); } catch (_) {} ; reject(new Error('parse timeout')); }, 15000);
+      worker.onmessage = (ev) => {
+        clearTimeout(timer);
+        try { worker.terminate(); } catch (_) {}
+        const { ok, data, error } = ev.data || {};
+        if (ok) resolve(data);
+        else reject(new Error(error || 'parse failed'));
+      };
+      worker.onerror = (e) => { clearTimeout(timer); try { worker.terminate(); } catch (_) {} ; reject(e); };
+      worker.postMessage(text);
+    });
+  } catch (e) {
+    // Fallback: parse on main thread
+    return JSON.parse(text);
+  }
+}
 import { normalize as normalizeV2 } from './normalize.mjs';
 import { orderByYearBucket } from './question_pipeline.mjs';
 // lazy import on demand from './media_player.mjs'
@@ -529,7 +552,8 @@ async function loadDataset() {
       try { console.info('[MOCK_DATASET] using', datasetUrl); } catch (_) {}
     }
     const res = await fetch(datasetUrl, { cache: 'no-store' });
-    const data = await res.json();
+    const txt = await res.text();
+    const data = await parseJsonOffMainThread(txt);
     tracks = data.tracks || data; // 互換
     datasetLoaded = true;
     updateStartButton();

--- a/public/app/workers/json_parse_worker.js
+++ b/public/app/workers/json_parse_worker.js
@@ -1,0 +1,10 @@
+// JSON parse worker (module)
+self.onmessage = (ev) => {
+  try {
+    const text = ev.data;
+    const data = JSON.parse(text);
+    self.postMessage({ ok: true, data });
+  } catch (err) {
+    self.postMessage({ ok: false, error: String(err && err.message || err) });
+  }
+};


### PR DESCRIPTION
## Summary
- Parse dataset JSON via a dedicated worker to avoid blocking the main thread
- Fallback to `JSON.parse` if worker creation fails
- Add a JSON parsing worker module

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68b7f52ebb00832493aef0c0cbf4802e