### PR TITLE
chore: add lhci query to lighthouse URL

### DIFF
--- a/.lighthouserc.budgets.json
+++ b/.lighthouserc.budgets.json
@@ -3,7 +3,7 @@
     "collect": {
       "numberOfRuns": 1,
       "url": [
-        "https://nantes-rfli.github.io/vgm-quiz/app/",
+        "https://nantes-rfli.github.io/vgm-quiz/app/?lhci=1",
         "https://nantes-rfli.github.io/vgm-quiz/daily/latest.html?no-redirect=1"
       ],
       "settings": {


### PR DESCRIPTION
## Summary
- ensure Lighthouse CI collects app URL with `?lhci=1`

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b800e8efb48324b2207e41af91cdf4