### PR TITLE
Defer alias loading until quiz start

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1271,7 +1271,8 @@ checkOnLoad();
 {
   const ric = window.requestIdleCallback || (cb => setTimeout(cb, 1));
   ric(() => { try { datasetPromise = loadDataset(); } catch(e){} });
-  ric(() => { try { ensureAliases(); } catch(e){} });
+  // [perf] defer aliases: load after Start button (startQuiz)
+  // ric(() => { try { ensureAliases(); } catch(e){} });
 }
 
 navigator.serviceWorker?.addEventListener('message', async (e)=>{


### PR DESCRIPTION
## Summary
- Defer alias loading by commenting out ensureAliases call and note to load after Start button

## Testing
- `npm test` *(fails: clojure: not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68b803683f288324af931f2caa5336cf