### PR TITLE
Enhance basic accessibility and document guidelines

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -114,7 +114,9 @@
   - **リグレッション**：v1系既存問題の難易度分布が**極端に崩れない**（中央値±10pt以内）。
 
 ## v1.4 — アクセシビリティ & i18n（最小）
-- Next: アクセシビリティ最小セット（フォーカス可視化/ランドマーク/aria/読み上げスモーク）
+- Status: **In progress**
+- Scope: A11y minimal set (focus, landmarks, labels, live regions, keyboard)
+- Tests: a11y smoke (static) + existing E2E a11y
 **狙い**: 既存のキーボード操作 Baseline を**壊さず**、a11y をハードニング。
 
 **現状**

--- a/docs/a11y.md
+++ b/docs/a11y.md
@@ -1,0 +1,21 @@
+# Accessibility (v1.4 minimal)
+
+This project aims to provide an accessible experience with a lightweight markup-first approach.
+
+## What we guarantee (minimal set)
+- **Keyboard**: All actions are reachable via keyboard; visible focus with `:focus-visible` outline.
+- **Landmarks**: `<main id="main">` is present; footer has `role="contentinfo"`; skip link `Skip to main content` exists.
+- **Labels**: Form controls have a label or `aria-label`/`aria-describedby`. Choice buttons expose `aria-pressed`.
+- **Live regions**: Feedback (#feedback) and toasts use `role="status" aria-live="polite"` (atomic where needed).
+- **Dialogs**: Result view uses `role="dialog"` + `aria-modal="true"` and gets focus on open, returns it on close.
+
+## Developer checklist
+- When adding buttons, prefer text content; if icon-only, add `aria-label`.
+- If adding new toasts or HUD text that changes dynamically, ensure `aria-live="polite"` or `assertive` if urgent.
+- Use `aria-controls` for view-switching buttons when it helps users understand context changes.
+- Do not remove the skip link or `:focus-visible` outline.
+
+## Testing
+- E2E smoke: `e2e/test_free_aria.js`, `e2e/test_keyboard_flow_smoke.mjs`, `e2e/test_results_modal_a11y.mjs`.
+- Manual: Try Tab/Shift+Tab through the UI; verify focus stays visible and meaningful order is kept.
+

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -66,16 +66,16 @@
       <option value="20">20</option>
     </select>
   </label>
-<button id="start-btn" disabled data-testid="start-btn">Start</button>
+<button id="start-btn" disabled data-testid="start-btn" aria-controls="question-view">Start</button>
   <div id="dataset-error" style="display:none;color:red;"></div>
-  <button id="history-btn">History</button>
+  <button id="history-btn" aria-controls="history-view">History</button>
   <button id="export-aliases-btn">Export alias proposals (.edn)</button>
 </div>
 
 <div id="history-view" style="display:none">
   <ul id="history-list"></ul>
   <button id="clear-history-btn">Clear history</button>
-  <button id="history-back-btn">Back</button>
+  <button id="history-back-btn" aria-controls="start-view">Back</button>
 </div>
 
 <div id="question-view" style="display:none" data-testid="quiz-view">
@@ -105,7 +105,7 @@
   <input id="answer" type="text" autocomplete="off" aria-describedby="prompt" autofocus data-testid="answer">
   <button id="submit-btn" data-testid="submit-btn">Submit</button>
   <button id="next-btn" style="display:none">Next</button>
-  <div id="feedback"></div>
+  <div id="feedback" role="status" aria-live="polite" aria-atomic="true"></div>
   <button id="propose-alias-btn" style="display:none">別名として提案</button>
 </div>
 
@@ -123,7 +123,7 @@
     <button id="share-result-btn" data-testid="share-result-btn" style="display:none">共有…</button>
     <span id="copy-toast" role="status" aria-live="polite" style="margin-left:8px;"></span>
   </div>
-  <button id="restart-btn">Restart</button>
+  <button id="restart-btn" aria-controls="start-view">Restart</button>
 </div>
 
 <footer id="version" role="contentinfo"></footer>


### PR DESCRIPTION
## Summary
- Wire up view-switching buttons with `aria-controls` and mark feedback and restart areas as accessible live regions
- Update roadmap with status and scope for minimal accessibility work and add a dedicated a11y guidance document

## Testing
- `npm test` *(fails: clojure: not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68b80e3af4b48324b673c46afd24ae1b