### PR TITLE
Add static accessibility smoke test and improve markup

### DIFF
--- a/.github/workflows/e2e-a11y-smoke.yml
+++ b/.github/workflows/e2e-a11y-smoke.yml
@@ -1,0 +1,17 @@
+name: e2e (a11y static smoke)
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  a11y-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run static a11y checks
+        env:
+          APP_URL: ${{ vars.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/?test=1&mock=1&autostart=0&lhci=1' }}
+        run: node e2e/test_a11y_smoke_static.mjs

--- a/e2e/test_a11y_smoke_static.mjs
+++ b/e2e/test_a11y_smoke_static.mjs
@@ -1,0 +1,23 @@
+// On-demand a11y static smoke (no browser).
+// Checks markup for key ARIA attributes on the live site.
+const base0 = process.env.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app/?test=1&mock=1&autostart=0&lhci=1';
+(async () => {
+  const res = await fetch(base0, { headers: { 'Cache-Control': 'no-cache' } });
+  const html = await res.text();
+
+  function must(re, desc) {
+    if (!re.test(html)) {
+      console.error('[FAIL]', desc);
+      process.exit(1);
+    } else {
+      console.log('[OK]', desc);
+    }
+  }
+
+  must(/id="feedback"[^>]*role="status"[^>]*aria-live="polite"[^>]*aria-atomic="true"/s, '#feedback is a live region');
+  must(/id="choices"[^>]*role="group"[^>]*aria-label="Choices"/s, '#choices has role=group');
+  must(/id="history-view"[^>]*role="region"[^>]*aria-labelledby="history-heading"/s, 'history is a region with labelledby');
+  must(/id="result-view"[^>]*role="dialog"[^>]*aria-modal="true"/s, 'result is a modal dialog');
+
+  console.log('A11y static smoke OK');
+})();

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -72,7 +72,8 @@
   <button id="export-aliases-btn">Export alias proposals (.edn)</button>
 </div>
 
-<div id="history-view" style="display:none">
+<div id="history-view" style="display:none" role="region" aria-labelledby="history-heading">
+  <h2 id="history-heading" class="visually-hidden">History</h2>
   <ul id="history-list"></ul>
   <button id="clear-history-btn">Clear history</button>
   <button id="history-back-btn" aria-controls="start-view">Back</button>
@@ -95,7 +96,7 @@
   <div id="countdown" aria-live="polite" aria-atomic="true" style="display:none; margin-top:6px;" data-testid="countdown"></div>
   <div id="media-slot" aria-label="audio preview area"></div>
   <div id="prompt" role="status" aria-live="polite" aria-atomic="true" data-testid="prompt"></div>
-  <div id="choices" style="display:none; margin-top:8px">
+  <div id="choices" style="display:none; margin-top:8px" role="group" aria-label="Choices">
     <button class="choice" aria-label="choice 1"></button>
     <button class="choice" aria-label="choice 2"></button>
     <button class="choice" aria-label="choice 3"></button>
@@ -141,6 +142,8 @@
     outline: 2px solid;
     outline-offset: 2px;
   }
+
+  .visually-hidden{position:absolute!important;width:1px;height:1px;margin:-1px;border:0;padding:0;white-space:nowrap;clip-path:inset(100%);clip:rect(0 0 0 0);overflow:hidden}
 </style>
 
 </main>


### PR DESCRIPTION
## Summary
- mark history view as an ARIA region with hidden heading
- group quiz answer choices and add visually hidden utility class
- add static a11y smoke test and workflow

## Testing
- `npm test` *(fails: clojure: not found)*
- `APP_URL='http://localhost:9000/app/?test=1&mock=1&autostart=0&lhci=1' node e2e/test_a11y_smoke_static.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b810b94f6c8324854a23a4c378efe0