### PR TITLE
feat(a11y): describe choices via prompt

### DIFF
--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -66,3 +66,13 @@ Nightly run (desktop). Budgets & asserts enabled.
 ### Lighthouse: uses-long-cache-ttl の扱い
 - GitHub Pages 既定や外部起因で TTL が短いことがあるため、監査は **WARN かつ上限 12件** まで許容。
 - 実ユーザー体験に影響が小さいため、退行検知の針としてのみ使用（fail はしない）。
+
+### Pages manual deploy verification (no-cache examples)
+
+```bash
+# latest.html should redirect to today's JST page (follow redirects)
+curl -L -s -D - -o /dev/null -H 'Cache-Control: no-cache' "https://nantes-rfli.github.io/vgm-quiz/daily/latest.html?e2e=$(date +%s)"
+
+# Or just inspect headers without following (Location must be ./YYYY-MM-DD.html)
+curl -sI -H 'Cache-Control: no-cache' "https://nantes-rfli.github.io/vgm-quiz/daily/latest.html?e2e=$(date +%s)"
+```

--- a/e2e/test_a11y_smoke_static.mjs
+++ b/e2e/test_a11y_smoke_static.mjs
@@ -16,6 +16,7 @@ const base0 = process.env.APP_URL || 'https://nantes-rfli.github.io/vgm-quiz/app
 
   must(/id="feedback"[^>]*role="status"[^>]*aria-live="polite"[^>]*aria-atomic="true"/s, '#feedback is a live region');
   must(/id="choices"[^>]*role="group"[^>]*aria-label="Choices"/s, '#choices has role=group');
+  must(/id="choices"[^>]*aria-describedby="prompt"/s, '#choices is described by #prompt');
   must(/id="history-view"[^>]*role="region"[^>]*aria-labelledby="history-heading"/s, 'history is a region with labelledby');
   must(/id="result-view"[^>]*role="dialog"[^>]*aria-modal="true"/s, 'result is a modal dialog');
 

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -96,7 +96,7 @@
   <div id="countdown" aria-live="polite" aria-atomic="true" style="display:none; margin-top:6px;" data-testid="countdown"></div>
   <div id="media-slot" aria-label="audio preview area"></div>
   <div id="prompt" role="status" aria-live="polite" aria-atomic="true" data-testid="prompt"></div>
-  <div id="choices" style="display:none; margin-top:8px" role="group" aria-label="Choices">
+  <div id="choices" style="display:none; margin-top:8px" role="group" aria-label="Choices" aria-describedby="prompt">
     <button class="choice" aria-label="choice 1"></button>
     <button class="choice" aria-label="choice 2"></button>
     <button class="choice" aria-label="choice 3"></button>


### PR DESCRIPTION
## Summary
- associate the choices group with the quiz prompt via `aria-describedby`
- assert the relationship in the a11y smoke test
- document pages manual deploy verification steps

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: The repository is not signed)*
- `node e2e/test_a11y_smoke_static.mjs` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b827a15b14832480c9695de2bdb4bc