### PR TITLE
feat: add issue sync and export workflows

### DIFF
--- a/.github/workflows/issues-export.yml
+++ b/.github/workflows/issues-export.yml
@@ -1,0 +1,36 @@
+name: issues (export)
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 15 * * *" # ≒ JST 00:00
+
+permissions:
+  contents: write
+  issues: read
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Export issues snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node script/export_issues.mjs
+      - name: Commit snapshot if changed
+        run: |
+          set -euxo pipefail
+          if ! git diff --quiet -- docs/issues/STATE.md docs/issues/state.json; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add docs/issues/STATE.md docs/issues/state.json
+            git commit -m "docs(issues): export snapshot"
+            git push
+          else
+            echo "No changes to commit."
+          fi

--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -1,0 +1,28 @@
+name: issues (sync)
+
+on:
+  workflow_dispatch: {}
+  push:
+    paths:
+      - 'docs/issues/*.json'
+      - 'script/sync_issues.mjs'
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Sync issues from docs/issues/*.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          node script/sync_issues.mjs

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -1,0 +1,17 @@
+# Issues sync & snapshot
+
+`docs/issues/*.json` にIssueの雛形を置き、GitHub Actionsで **自動登録/更新** します。
+さらに、GitHub上のIssue状況を **スナップショット** として `docs/issues/STATE.md` / `state.json` に書き出せます。
+
+## 使い方（Sync）
+- 追加/変更したいIssueは `docs/issues/*.json` を編集してPR（Codex経由でOK）
+- マージするとワークフローが走り、**タイトル一致**で既存Issueを更新 or 新規作成
+- ラベルが無ければ自動作成（色は仮）
+- 手動実行: Actions → **issues (sync)** → Run workflow
+
+## 使い方（Snapshot）
+- Actions → **issues (export)** を実行 or スケジュール発火（UTC 15:00 ≒ JST 00:00）
+- `docs/issues/STATE.md` と `docs/issues/state.json` が更新されます
+- 以後、zip を渡すだけで、最新のIssue状況を外部から把握可能
+
+> 運用ルール（推奨）: 正本は docs/。GitHubのIssue編集は基本せず、JSON→PRで同期する。

--- a/docs/issues/v1_5.json
+++ b/docs/issues/v1_5.json
@@ -1,0 +1,72 @@
+[
+  {
+    "title": "UI: デザイントークンをCSSで統一",
+    "labels": [
+      "roadmap:v1.5",
+      "area:ui",
+      "responsive"
+    ],
+    "body": "### Scope\n- :rootにデザイントークン（色/余白/角丸）定義\n- ボタン/入力/カード等を変数参照へ置換（JS変更なし）\n\n### DoD\n- 主要画面がトークン参照へ移行\n- 既存E2Eすべて緑、Lighthouseスコア維持以上\n\n### Notes\n- パフォーマンス・a11yへ影響しないこと"
+  },
+  {
+    "title": "UI: モバイルで44pxタッチターゲットを担保",
+    "labels": [
+      "roadmap:v1.5",
+      "area:ui",
+      "a11y"
+    ],
+    "body": "### Scope\n- 主要クリック要素（ボタン/選択肢）のmin-height/line-height調整\n\n### DoD\n- 代表要素で44px以上をCSSで確認\n- a11y静的スモーク緑維持、既存操作に副作用なし"
+  },
+  {
+    "title": "UI: #choices グリッド2→3→4列のレスポンシブ",
+    "labels": [
+      "roadmap:v1.5",
+      "area:ui",
+      "responsive"
+    ],
+    "body": "### Scope\n- CSSメディアクエリで段階的カラム数切り替え\n- DOM/JS変更なし\n\n### DoD\n- 幅狭/中/広の3条件で列数が期待通り（軽量DOM検証 or スクショDiff）\n- 既存E2E緑"
+  },
+  {
+    "title": "UI: Historyテーブルのストライプ/ホバー",
+    "labels": [
+      "roadmap:v1.5",
+      "area:ui"
+    ],
+    "body": "### Scope\n- CSSのみで視認性向上（背景交互/hoverわずか）\n\n### DoD\n- コントラストが概ねWCAG AAを満たす\n- Lighthouse a11yで回帰なし"
+  },
+  {
+    "title": "UI: 微小トランジション（opacity/transformのみ）",
+    "labels": [
+      "roadmap:v1.5",
+      "area:ui",
+      "perf"
+    ],
+    "body": "### Scope\n- 主要ボタン/ダイアログ開閉へCSSトランジションを限定的に追加\n- レイアウト影響プロパティは禁止\n\n### DoD\n- Main-thread/TBT悪化なし（Lighthouse変動が許容内）"
+  },
+  {
+    "title": "UI: ライトテーマのコントラスト微調整",
+    "labels": [
+      "roadmap:v1.5",
+      "area:ui",
+      "a11y"
+    ],
+    "body": "### Scope\n- 背景/本文/アクセント色のコントラスト見直し\n\n### DoD\n- Lighthouse a11yで新規コントラスト警告なし"
+  },
+  {
+    "title": "Tests: UI/Responsive最小スモーク追加（JS不増を担保）",
+    "labels": [
+      "roadmap:v1.5",
+      "type:test",
+      "responsive"
+    ],
+    "body": "### Scope\n- 静的スモークに列数/44px相当の簡易チェックを追加、または軽量の新スモークを作成\n\n### DoD\n- v1.5項目の回帰検知が可能\n- 既存E2Eは緑のまま"
+  },
+  {
+    "title": "Docs: STYLEGUIDE/ROADMAP反映（v1.5方針とDoD）",
+    "labels": [
+      "roadmap:v1.5",
+      "type:docs"
+    ],
+    "body": "### Scope\n- JSを増やさない方針・perf/a11y回帰防止のガードレールを明文化\n\n### DoD\n- Docs lint/リンクチェック緑\n- PRテンプレから参照可能"
+  }
+]

--- a/docs/issues/v1_7.json
+++ b/docs/issues/v1_7.json
@@ -1,0 +1,63 @@
+[
+  {
+    "title": "Authoring: harvester-min（公式ソース収集器）",
+    "labels": [
+      "roadmap:v1.7",
+      "area:pipeline"
+    ],
+    "body": "### Scope\n- 公式YouTube/Apple API優先で収集\n- レート制御・失敗時リトライ\n\n### DoD\n- 最低1件の有効候補を日次で獲得可能\n- 失敗時の理由をログ/サマリで確認可能"
+  },
+  {
+    "title": "Authoring: clip-start-heuristics-v1",
+    "labels": [
+      "roadmap:v1.7",
+      "area:pipeline",
+      "type:test"
+    ],
+    "body": "### Scope\n- t=/start=>メタ=>既定値の優先順位\n- 異常値ガード\n- ユニットテスト\n\n### DoD\n- 代表ケースで期待値\n- エッジケースでフェイルセーフ"
+  },
+  {
+    "title": "Authoring: difficulty-v1（簡易スコア）",
+    "labels": [
+      "roadmap:v1.7",
+      "area:pipeline",
+      "type:test"
+    ],
+    "body": "### Scope\n- 年代/別名密度/シリーズ知名度などから 0–100\n- Node/Browserパリティ\n- 分布チェック\n\n### DoD\n- 既存問題の分布が中央値±10pt以内\n- テスト緑"
+  },
+  {
+    "title": "Authoring: distractors-v1（ダミー生成）",
+    "labels": [
+      "roadmap:v1.7",
+      "area:pipeline"
+    ],
+    "body": "### Scope\n- 同年代/作曲者/シリーズ近傍から抽出\n- 最低品質ガード\n\n### DoD\n- 明らかに不適切な選択肢が混入しない（軽量ルールベース）"
+  },
+  {
+    "title": "Authoring: authoring-schema（生成JSONスキーマ）",
+    "labels": [
+      "roadmap:v1.7",
+      "type:test",
+      "area:pipeline"
+    ],
+    "body": "### Scope\n- 生成JSONのスキーマ定義\n- schema検証\n\n### DoD\n- CIでschemaバリデーションが走る"
+  },
+  {
+    "title": "Authoring: daily-publish（日次JSON/OGP生成と配置）",
+    "labels": [
+      "roadmap:v1.7",
+      "area:ops",
+      "type:test"
+    ],
+    "body": "### Scope\n- `public/daily/YYYY-MM-DD.json` と OGPを生成\n- latest連携・E2Eスモーク追加\n\n### DoD\n- `schedule: daily` で1問生成が安定\n- 失敗時のスキップと通知"
+  },
+  {
+    "title": "Authoring: ops-docs（運用手順と監視ポイント）",
+    "labels": [
+      "roadmap:v1.7",
+      "type:docs",
+      "area:ops"
+    ],
+    "body": "### Scope\n- Secrets/PAT、失敗時の手順、監視ディシプリン\n\n### DoD\n- Docs整備 & link-check緑"
+  }
+]

--- a/script/export_issues.mjs
+++ b/script/export_issues.mjs
@@ -1,0 +1,105 @@
+/**
+ * Export a snapshot of roadmap Issues into docs/issues/STATE.md and state.json
+ * - Filters issues that have at least one label starting with "roadmap:"
+ * - Groups by roadmap label (e.g., v1.5, v1.7)
+ * - Writes both machine-readable JSON and human-readable Markdown
+ */
+import fs from 'node:fs';
+
+const TOKEN = process.env.GITHUB_TOKEN;
+const REPO = process.env.GITHUB_REPOSITORY;
+if (!TOKEN || !REPO) {
+  console.error("GITHUB_TOKEN or GITHUB_REPOSITORY missing");
+  process.exit(1);
+}
+
+const [owner, repo] = REPO.split('/');
+const headers = {
+  'Authorization': `Bearer ${TOKEN}`,
+  'Accept': 'application/vnd.github+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+};
+
+async function gh(pathname) {
+  const res = await fetch(`https://api.github.com${pathname}`, { headers });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${res.status} ${res.statusText}: ${pathname}\n${text}`);
+  }
+  return res.json();
+}
+
+async function listIssues() {
+  const gather = async (state) => gh(`/repos/${owner}/${repo}/issues?state=${state}&per_page=100&sort=updated&direction=desc`);
+  const open = await gather('open');
+  const closed = await gather('closed');
+  return [...open, ...closed].filter(x => !x.pull_request);
+}
+
+function toRecord(x) {
+  const roadmap = (x.labels || [])
+    .map(l => typeof l === 'string' ? l : l.name)
+    .filter(n => n && n.startsWith('roadmap:'));
+  if (roadmap.length === 0) return null;
+  return {
+    number: x.number,
+    title: x.title,
+    state: x.state,
+    html_url: x.html_url,
+    labels: (x.labels || []).map(l => typeof l === 'string' ? l : l.name),
+    assignees: (x.assignees || []).map(a => a.login),
+    milestone: x.milestone?.title || null,
+    updated_at: x.updated_at,
+    roadmap,
+  };
+}
+
+function groupByRoadmap(recs) {
+  const m = new Map();
+  for (const r of recs) {
+    for (const tag of r.roadmap) {
+      const key = tag.replace('roadmap:', '');
+      if (!m.has(key)) m.set(key, []);
+      m.get(key).push(r);
+    }
+  }
+  for (const [k, arr] of m.entries()) {
+    arr.sort((a,b) => b.updated_at.localeCompare(a.updated_at));
+  }
+  return m;
+}
+
+function mdTable(rows) {
+  const header = "| # | Title | State | Labels | Assignees | Updated |\n|---:|---|---|---|---|---|\n";
+  return header + rows.map(r => {
+    const labels = r.labels.join(", ");
+    const ass = r.assignees.join(", ");
+    return `| ${r.number} | [${r.title}](${r.html_url}) | ${r.state} | ${labels} | ${ass} | ${r.updated_at} |`;
+  }).join("\n") + "\n";
+}
+
+async function main() {
+  const issues = await listIssues();
+  const recs = issues.map(toRecord).filter(Boolean);
+  const grouped = groupByRoadmap(recs);
+
+  const outDir = 'docs/issues';
+  fs.mkdirSync(outDir, { recursive: true });
+
+  fs.writeFileSync(`${outDir}/state.json`, JSON.stringify({ exported_at: new Date().toISOString(), items: recs }, null, 2));
+
+  let md = `# Issues snapshot\n\nExported at: ${new Date().toISOString()}\n\n`;
+  const keys = Array.from(grouped.keys()).sort();
+  for (const k of keys) {
+    md += `## ${k}\n\n`;
+    md += mdTable(grouped.get(k));
+    md += "\n";
+  }
+  fs.writeFileSync(`${outDir}/STATE.md`, md, 'utf-8');
+  console.log("Wrote docs/issues/STATE.md and state.json");
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/script/sync_issues.mjs
+++ b/script/sync_issues.mjs
@@ -1,0 +1,147 @@
+/**
+ * Sync GitHub issues from JSON specs in docs/issues/*.json
+ * - Idempotent by title: if an issue with the same title exists, update labels/body; else create.
+ * - Labels are auto-created if missing.
+ * - Uses GITHUB_TOKEN / GITHUB_REPOSITORY.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ISSUES_DIR = 'docs/issues';
+const REPO = process.env.GITHUB_REPOSITORY;
+const TOKEN = process.env.GITHUB_TOKEN;
+
+if (!REPO || !TOKEN) {
+  console.error('Missing GITHUB_REPOSITORY or GITHUB_TOKEN');
+  process.exit(1);
+}
+
+const headers = {
+  'Authorization': `Bearer ${TOKEN}`,
+  'Accept': 'application/vnd.github+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+};
+
+async function gh(pathname, init = {}) {
+  const url = `https://api.github.com${pathname}`;
+  const res = await fetch(url, {
+    ...init,
+    headers: { ...headers, ...(init.headers || {}) },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${res.status} ${res.statusText} for ${pathname}: ${text}`);
+  }
+  return res.json();
+}
+
+function readSpecs() {
+  if (!fs.existsSync(ISSUES_DIR)) return [];
+  const files = fs.readdirSync(ISSUES_DIR).filter(f => f.endsWith('.json'));
+  let items = [];
+  for (const f of files) {
+    const full = `${ISSUES_DIR}/${f}`;
+    const data = JSON.parse(fs.readFileSync(full, 'utf-8'));
+    if (Array.isArray(data)) items.push(...data);
+  }
+  return items;
+}
+
+async function ensureLabels(owner, repo, labels) {
+  const existing = await gh(`/repos/${owner}/${repo}/labels?per_page=100`);
+  const names = new Set(existing.map(l => l.name));
+  for (const lab of labels) {
+    if (!names.has(lab.name)) {
+      await gh(`/repos/${owner}/${repo}/labels`, {
+        method: 'POST',
+        body: JSON.stringify({
+          name: lab.name,
+          color: lab.color || '0e8a16',
+          description: lab.description || '',
+        }),
+      });
+      names.add(lab.name);
+    }
+  }
+}
+
+async function listIssuesByTitle(owner, repo) {
+  let all = [];
+  for (const state of ['open','closed']) {
+    const arr = await gh(`/repos/${owner}/${repo}/issues?state=${state}&per_page=100`);
+    all = all.concat(arr.filter(x => !x.pull_request));
+  }
+  const map = new Map();
+  for (const it of all) map.set(it.title, it);
+  return map;
+}
+
+function deDupe(arr) {
+  return Array.from(new Set(arr));
+}
+
+function normalizeIssue(i) {
+  return {
+    title: i.title.trim(),
+    body: (i.body || '').trim(),
+    labels: deDupe(i.labels || []),
+  };
+}
+
+async function main() {
+  const [owner, repo] = REPO.split('/');
+  const specs = readSpecs().map(normalizeIssue);
+  if (specs.length === 0) {
+    console.log('No issue specs found.');
+    return;
+  }
+
+  const labelSet = new Set();
+  for (const s of specs) for (const l of s.labels) labelSet.add(l);
+  const labelDefs = Array.from(labelSet).map(name => {
+    const color = name.startsWith('roadmap:') ? '7fdbff'
+      : name.startsWith('area:') ? 'b10dc9'
+      : name.startsWith('type:') ? 'ff851b'
+      : '0e8a16';
+    return { name, color };
+  });
+  await ensureLabels(owner, repo, labelDefs);
+
+  const byTitle = await listIssuesByTitle(owner, repo);
+
+  for (const s of specs) {
+    const existing = byTitle.get(s.title);
+    if (!existing) {
+      const created = await gh(`/repos/${owner}/${repo}/issues`, {
+        method: 'POST',
+        body: JSON.stringify({
+          title: s.title,
+          body: s.body,
+          labels: s.labels,
+        }),
+      });
+      console.log(`Created #${created.number}: ${created.title}`);
+    } else {
+      const currentLabels = existing.labels?.map(l => l.name) || [];
+      const needBody = (existing.body || '').trim() !== s.body;
+      const needLabels = JSON.stringify(deDupe(currentLabels.sort())) !== JSON.stringify(deDupe(s.labels.slice().sort()));
+      if (needBody || needLabels) {
+        const updated = await gh(`/repos/${owner}/${repo}/issues/${existing.number}`, {
+          method: 'PATCH',
+          body: JSON.stringify({
+            body: needBody ? s.body : undefined,
+            labels: needLabels ? s.labels : undefined,
+          }),
+        });
+        console.log(`Updated #${updated.number}: ${updated.title}`);
+      } else {
+        console.log(`No change: #${existing.number} ${existing.title}`);
+      }
+    }
+  }
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add workflow to sync GitHub issues from docs/spec JSON
- add workflow to export roadmap issue snapshots to docs
- document issue sync process and provide v1.5 / v1.7 issue specs

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68b8df03ec2c8324be13359bbc96ff11