### PR TITLE
ci: allow PR write access for issues export

### DIFF
--- a/.github/workflows/issues-export.yml
+++ b/.github/workflows/issues-export.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   issues: read
+  pull-requests: write
 
 jobs:
   export:


### PR DESCRIPTION
## Summary
- grant `pull-requests: write` permission for issues-export workflow so it can create pull requests

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: The repository is not signed)*
- `apt-get install -y clojure` *(fails: Unable to locate package clojure)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e63d6ed8832491d23c3f56d4e42a