### PR TITLE
Lock multiple-choice grid layout to fixed column counts

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -286,6 +286,18 @@
 
   .visually-hidden{position:absolute!important;width:1px;height:1px;margin:-1px;border:0;padding:0;white-space:nowrap;clip-path:inset(100%);clip:rect(0 0 0 0);overflow:hidden}
 
+  /* === v1.5: lock #choices to 2→3→4 columns (mobile-first) === */
+  #choices {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  @media (min-width: 600px) {
+    #choices { grid-template-columns: repeat(3, 1fr); }
+  }
+  @media (min-width: 900px) {
+    #choices { grid-template-columns: repeat(4, 1fr); }
+  }
+  /* === end v1.5 fixed columns === */
+
 
   @media (prefers-reduced-motion: reduce) {
     * { transition: none !important; animation: none !important; }


### PR DESCRIPTION
## Summary
- fix the multiple-choice grid to consistently display 2, 3, and 4 columns at 0px, 600px, and 900px widths respectively

## Testing
- `npm test` *(fails: clojure: not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68b9047c804883249b5c15b7c64add7c