### PR TITLE
Add UI responsive smoke workflow

### DIFF
--- a/.github/workflows/e2e-ui-responsive-smoke.yml
+++ b/.github/workflows/e2e-ui-responsive-smoke.yml
@@ -1,0 +1,31 @@
+name: e2e (ui responsive smoke)
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Base URL of /app/ (default: GitHub Pages)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  ui-responsive-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install Playwright (ephemeral)
+        run: |
+          npm i -D playwright@^1
+          npx playwright install --with-deps chromium
+      - name: Run UI responsive smoke
+        env:
+          APP_URL: ${{ github.event.inputs.base_url }}
+        run: |
+          node e2e/test_ui_responsive_smoke.mjs


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run UI responsive smoke test with Playwright

## Testing
- `npm test` *(fails: command not found)*
- `clojure -M:test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9087069c48324a2feee20a43b080e