### PR TITLE
docs: add UI style guide and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@
     <img alt="Pages" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/pages.yml/badge.svg?branch=main">
   </a>
 </p>
+<!-- Status badges (UI & Issues) -->
+<p>
+  <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e-ui-responsive-smoke.yml">
+    <img alt="E2E UI Responsive Smoke" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/e2e-ui-responsive-smoke.yml/badge.svg">
+  </a>
+  <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/sync-issues.yml">
+    <img alt="Issues Sync" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/sync-issues.yml/badge.svg?branch=main">
+  </a>
+  <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/issues-export.yml">
+    <img alt="Issues Export" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/issues-export.yml/badge.svg">
+  </a>
+  <a href="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/issues-validate.yml">
+    <img alt="Issues Validate" src="https://github.com/nantes-rfli/vgm-quiz/actions/workflows/issues-validate.yml/badge.svg">
+  </a>
+</p>
 
 ## Operations / Runbook
 日々の運用で迷いやすいポイントは **[docs/ops.md](docs/ops.md)** に集約しています。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -266,6 +266,23 @@
 - **結果からの“発見”導線**（S–M）
 - **季節/テーマ週**（S）
 
+## v1.5 UI/Responsive polish — Progress (2025-09-04 JST)
+
+**Done**
+- Design tokens “boot”（未使用導入）
+- 44px タッチターゲット（トークン化）
+- `#choices` 2→3→4 列固定（CSSオーバーライド）
+- マイクロトランジション（opacity/transform + reduced-motion対応）
+- History ビューの軽微な整形（ストライプ/hover）
+- Light コントラスト微調整（panel/border/accent/focus）
+- E2E: `e2e/test_ui_responsive_smoke.mjs` 追加（44px / 列数）
+
+**Next (optional)**
+- READMEにUIテストのバッジ追加（可視化）
+- さらなる配色微調整（必要なら）
+
+> Tracking label: `roadmap:v1.5`（Issues → docs/issues/STATE.md も参照）
+
 ## v1.7 — Authoring Automation（MVP）
 - Status: **Planned**
 - Scope: “**毎日1問**”を**完全自動**で作成・公開。**埋め込み再生のみ**（Apple Music / 公式YouTube）前提で、既存アプリは変更せず供給ラインを自動化。

--- a/docs/STYLEGUIDE_UI.md
+++ b/docs/STYLEGUIDE_UI.md
@@ -1,0 +1,46 @@
+# UI Style Guide (v1.5)
+
+> 本ガイドは **CSSのみ** での軽量ポリッシュ方針をまとめたものです。JSは増やさない方針。
+
+## Design Tokens
+- 変数は `:root` に定義（既に導入済み）。
+- 代表トークン
+  - Spacing: `--space-1..6`（4/8/12/16/24/32）
+  - Radius: `--radius-1..3`（8/12/16）
+  - Shadow: `--shadow-1..2`
+  - Typography: `--font-size-sm/base/lg`
+  - Motion: `--duration-fast/base`, `--easing-out`
+  - Layout: `--container-max`, `--grid-gap`, `--touch-target` (=44px)
+
+## Color / Themes
+- ダーク/ライトは `prefers-color-scheme` をベースに、**`data-theme="dark|light"`** で強制切替を可能に。
+- Light の最小調整（v1.5）
+  - `--panel: #f9fafb`
+  - `--border: #d1d5db`
+  - `--accent: #1d4ed8`
+  - `--focus: #1e40af`
+- 目的: **コントラストAA目安**（本文 ≥ 4.5:1、UIラベル ≥ 3:1）を満たす方向へ、最小差分で調整。
+
+## Responsive Grid
+- `#choices` は **2→3→4 列**固定（モバイルファースト）
+  - `<=599px: 2列` / `600–899px: 3列` / `>=900px: 4列`
+  - 実装: `grid-template-columns: repeat(N, …)`
+- Gap は `var(--grid-gap)` を使用。
+
+## Touch Targets
+- 主要操作（ボタン/選択肢）は **最小 44px**。
+  - 実装: `button { min-height: var(--touch-target) }`（既定 44px）
+  - 視覚サイズは変えず、**当たり判定だけ**広げる方針。
+
+## Motion
+- トランジションは **opacity/transform のみ**、`120–160ms / ease-out`。
+- `prefers-reduced-motion: reduce` のときは **全トランジション/アニメーション無効化**。
+
+## History View
+- 可読性のため、**薄いストライプ**と **hoverシャドウ** を付与。
+- 枠線は `--border`、角丸は `--radius-1`。
+
+## テスト / メトリクス
+- E2E: `e2e/test_ui_responsive_smoke.mjs`（44px / 2→3→4列）
+- Lighthouse: TBT/MPFID/Bootup 変化なし、Contrast の警告増なし
+- a11y スモーク（静的）は既存のまま緑維持


### PR DESCRIPTION
## Summary
- document UI/Responsive polish guidelines in new STYLEGUIDE_UI doc
- track v1.5 UI/Responsive progress in roadmap
- surface UI test and issue workflows with README badges

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b92051fae4832483a6c9ba44eb9993