### PR TITLE
chore(issues): add id assignment script and workflow

### DIFF
--- a/.github/workflows/issues-ids-assign.yml
+++ b/.github/workflows/issues-ids-assign.yml
@@ -1,0 +1,41 @@
+name: issues (ids assign)
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  assign-ids:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Assign missing issue ids in docs/issues/*.json
+        run: node script/assign_issue_ids.mjs
+      - name: Create PR for id assignment
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.CPR_PAT }}
+          commit-message: "chore(issues): assign ids to docs/issues/*.json"
+          title: "chore(issues): assign ids to docs/issues/*.json"
+          body: "Automated id assignment for issue specs"
+          branch: bot/issues-ids-${{ github.run_id }}
+          delete-branch: true
+          labels: |
+            bot
+            chore
+          add-paths: |
+            docs/issues/*.json
+      - name: Enable auto-merge (squash)
+        if: steps.cpr.outputs.pull-request-url != ''
+        env:
+          GH_TOKEN: ${{ secrets.CPR_PAT }}
+        run: gh pr merge --auto --squash "${{ steps.cpr.outputs.pull-request-url }}"

--- a/script/assign_issue_ids.mjs
+++ b/script/assign_issue_ids.mjs
@@ -1,0 +1,82 @@
+/**
+ * assign_issue_ids.mjs
+ * Add `"id"` to docs/issues/*.json items that don't have it, using a stable slug from title.
+ * - slug: normalize NFKD → strip diacritics → [a-z0-9-] only → collapse dashes → trim → lower
+ * - fallback: sha1(title).slice(0,8) when slug becomes empty
+ * - dedupe: append -2, -3... if id already exists in this run
+ */
+import fs from 'node:fs';
+import crypto from 'node:crypto';
+import path from 'node:path';
+
+const DIR = 'docs/issues';
+
+function slugify(title) {
+  const base = title.normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '') // diacritics
+    .replace(/＆/g, 'and')
+    .replace(/[・･]/g, '-') // japanese middle dot variants to dash
+    .replace(/[^A-Za-z0-9]+/g, '-') // non-alnum to dash
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase();
+  if (base) return base;
+  return 'i-' + crypto.createHash('sha1').update(title).digest('hex').slice(0,8);
+}
+
+function withId(obj, id) {
+  if (Object.prototype.hasOwnProperty.call(obj, 'id')) return obj;
+  // Put id first to keep diffs readable
+  return { id, ...obj };
+}
+
+function main() {
+  if (!fs.existsSync(DIR)) {
+    console.log('No docs/issues directory');
+    process.exit(0);
+  }
+  const files = fs.readdirSync(DIR).filter(f => f.endsWith('.json'));
+  if (files.length === 0) {
+    console.log('No issue spec files');
+    process.exit(0);
+  }
+  let total = 0;
+  for (const f of files) {
+    const p = path.join(DIR, f);
+    let data;
+    try {
+      data = JSON.parse(fs.readFileSync(p, 'utf-8'));
+    } catch (e) {
+      console.error(`Skip ${f}: JSON parse error: ${e.message}`);
+      continue;
+    }
+    if (!Array.isArray(data)) continue;
+    const taken = new Set(data.map(x => x.id).filter(Boolean));
+    let changed = 0;
+    const out = data.map(item => {
+      if (item.id) return item;
+      const base = slugify(item.title || '');
+      let id = base;
+      let i = 1;
+      while (taken.has(id)) {
+        i += 1;
+        id = `${base}-${i}`;
+      }
+      taken.add(id);
+      changed += 1;
+      return withId(item, id);
+    });
+    if (changed > 0) {
+      fs.writeFileSync(p, JSON.stringify(out, null, 2) + '\n');
+      console.log(`Updated ${f}: +${changed} id(s)`);
+      total += changed;
+    } else {
+      console.log(`No change: ${f}`);
+    }
+  }
+  if (total === 0) {
+    console.log('No ids needed.');
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add script to slugify issue titles and assign missing ids
- add workflow to automate id assignment via pull request

## Testing
- `node script/assign_issue_ids.mjs`
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b926b388008324a17f02fc4914540f