### PR TITLE
chore: install Playwright in i18n smoke workflow

### DIFF
--- a/.github/workflows/e2e-i18n-smoke.yml
+++ b/.github/workflows/e2e-i18n-smoke.yml
@@ -16,6 +16,12 @@ jobs:
         with:
           node-version: 20
 
+      - name: Install Playwright (module + browsers)
+        run: |
+          npm init -y >/dev/null 2>&1 || true
+          npm i --no-save playwright
+          npx playwright install --with-deps
+
       - name: Run i18n lang param smoke
         env:
           E2E_BASE_URL: ${{ vars.E2E_BASE_URL }}


### PR DESCRIPTION
## Summary
- install Playwright and browsers before running i18n smoke tests

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b96b0f72348324884d0034fbdf5d3c