### PR TITLE
chore: infer default e2e base URL

### DIFF
--- a/e2e/test_i18n_lang_param_smoke.mjs
+++ b/e2e/test_i18n_lang_param_smoke.mjs
@@ -15,7 +15,17 @@ import { chromium } from 'playwright';
     return u.toString();
   }
 
-  const base = process.env.E2E_BASE_URL || process.env.APP_URL || 'http://127.0.0.1:8080/app/';
+  function defaultBase() {
+    // In CI, prefer GitHub Pages URL derived from repo; locally fall back to localhost.
+    const repo = process.env.GITHUB_REPOSITORY; // e.g., "nantes-rfli/vgm-quiz"
+    if (repo) {
+      const [owner, name] = repo.split('/');
+      return `https://${owner}.github.io/${name}/app/`;
+    }
+    return 'http://127.0.0.1:8080/app/';
+  }
+
+  const base = process.env.E2E_BASE_URL || process.env.APP_URL || defaultBase();
 
   // en
   await page.goto(withLang(base, 'en'));


### PR DESCRIPTION
## Summary
- Derive default E2E base URL from `GITHUB_REPOSITORY` to use GitHub Pages URL in CI

## Testing
- `npm test` *(fails: clojure not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68b973a3be6c8324b18edc4de756e81a