### PR TITLE
feat: translate static buttons and add i18n smoke test

### DIFF
--- a/.github/workflows/e2e-i18n-labels-smoke.yml
+++ b/.github/workflows/e2e-i18n-labels-smoke.yml
@@ -1,0 +1,30 @@
+name: e2e (i18n static labels smoke)
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "30 18 * * *" # UTC 18:30 ≒ JST 03:30
+
+jobs:
+  e2e_i18n_labels_smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Playwright (module + browsers)
+        run: |
+          npm init -y >/dev/null 2>&1 || true
+          npm i --no-save playwright
+          npx playwright install --with-deps
+
+      - name: Run i18n static labels smoke
+        env:
+          E2E_BASE_URL: ${{ vars.E2E_BASE_URL }}
+          APP_URL: ${{ vars.APP_URL }}
+        run: node e2e/test_i18n_static_labels_smoke.mjs
+

--- a/docs/STYLEGUIDE_I18N.md
+++ b/docs/STYLEGUIDE_I18N.md
@@ -1,0 +1,37 @@
+# I18N Style Guide (v1.6 Baseline)
+
+## Key principles
+- **Keys are stable**: `domain.area.leaf` (e.g., `ui.start`, `app.title`, `a11y.ready`)
+- **Fallback to EN** is mandatory; never produce empty strings.
+- **en embedded** in code → no extra request on first load; other locales are fetched.
+
+## Detection order
+`?lang=xx` → `localStorage('lang')` → `navigator.language` → `en`
+
+## Runtime API
+- `initI18n()` — detect + load + set `<html lang>` + set `document.title`
+- `t(key, params?)` — read a key, with EN fallback; `{name}` variables are replaced
+- `setLang(lang)` — switch language at runtime; dispatches `i18n:changed`
+- `whenI18nReady()` — Promise resolved when the initial language is applied
+- `applyStaticLabels()` — helper to translate Start/History/Share buttons
+
+## Keys (minimum set in v1.6)
+```json
+{
+  "app": { "title": "VGM Quiz" },
+  "ui":  { "start": "Start", "history": "History", "share": "Share" },
+  "a11y": { "ready": "Ready. Press Start to begin." }
+}
+```
+
+## Adding UI text
+1. Add EN/JA to `public/app/locales/*.json` (same key path)
+2. Use `t('…')` instead of hard-coded strings
+3. If it’s a static control, consider adding it to `applyStaticLabels()`
+4. Verify with `e2e (i18n lang param smoke)` and `e2e (i18n static labels smoke)`
+
+## Non-goals (v1.6)
+- No dataset translations (proper nouns preserved)
+- No plural rules/MessageFormat (to be evaluated later)
+- No RTL handling (en/ja only)
+

--- a/e2e/test_i18n_static_labels_smoke.mjs
+++ b/e2e/test_i18n_static_labels_smoke.mjs
@@ -1,0 +1,42 @@
+import { chromium } from 'playwright';
+
+(async () => {
+  const TIMEOUT = 30000;
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  function urlWith(base, lang) {
+    const u = new URL(base);
+    const p = u.searchParams;
+    p.set('test', '1');
+    p.set('mock', '1');
+    p.set('autostart', '0');
+    p.set('lang', lang);
+    return u.toString();
+  }
+
+  function defaultBase() {
+    const repo = process.env.GITHUB_REPOSITORY;
+    if (repo) {
+      const [owner, name] = repo.split('/');
+      return `https://${owner}.github.io/${name}/app/`;
+    }
+    return 'http://127.0.0.1:8080/app/';
+  }
+
+  const base = process.env.E2E_BASE_URL || process.env.APP_URL || defaultBase();
+
+  // EN labels
+  await page.goto(urlWith(base, 'en'));
+  await page.waitForFunction(() => document.documentElement.lang === 'en', null, { timeout: TIMEOUT });
+  const startEn = await page.textContent('[data-testid="start-btn"], #start-btn, button#start, button[data-action="start"]');
+  if (!startEn || !/start/i.test(startEn.trim())) throw new Error(`unexpected Start label (en): "${startEn}"`);
+
+  // JA labels
+  await page.goto(urlWith(base, 'ja'));
+  await page.waitForFunction(() => document.documentElement.lang === 'ja', null, { timeout: TIMEOUT });
+  const startJa = await page.textContent('[data-testid="start-btn"], #start-btn, button#start, button[data-action="start"]');
+  if (!startJa || !/スタート/.test(startJa.trim())) throw new Error(`unexpected Start label (ja): "${startJa}"`);
+
+  await browser.close();
+})();

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1,6 +1,16 @@
 // i18n baseline (v1.6)
-import { initI18n } from './i18n.mjs';
+import { initI18n, whenI18nReady, applyStaticLabels } from './i18n.mjs';
 void initI18n(); // non-blocking; updates <html lang> & document.title
+whenI18nReady().then(() => {
+  // Try immediately, then after first paint, then once again after 500ms for safety
+  try { applyStaticLabels(); } catch {}
+  try { requestAnimationFrame(() => applyStaticLabels()); } catch {}
+  setTimeout(() => { try { applyStaticLabels(); } catch {} }, 500);
+});
+// Re-apply on language change (future-proofing)
+window.addEventListener('i18n:changed', () => {
+  try { applyStaticLabels(); } catch {}
+});
 
 // --- perf helpers ---
 async function parseJsonOffMainThread(text) {

--- a/public/app/i18n.mjs
+++ b/public/app/i18n.mjs
@@ -26,6 +26,7 @@ const EMBEDDED_EN = {
 
 let currentLang = DEFAULT_LANG;
 let dict = EMBEDDED_EN;
+let _initPromise = null;
 
 function normalizeLang(raw) {
   if (!raw) return DEFAULT_LANG;
@@ -114,10 +115,40 @@ export async function setLang(lang) {
   try {
     document.title = t('app.title');
   } catch {}
+  try {
+    window.dispatchEvent(new CustomEvent('i18n:changed', { detail: { lang: next } }));
+  } catch {}
 }
 
 export async function initI18n() {
   const lang = detectLang();
-  await setLang(lang);
+  _initPromise = setLang(lang);
+  await _initPromise;
+}
+
+export function whenI18nReady() {
+  return _initPromise || Promise.resolve();
+}
+
+// --- Optional helpers for v1.6 step1: apply common static labels ---
+export function applyStaticLabels() {
+  // Buttons that exist before quiz starts or in header/footer.
+  const trySet = (selectorList, text) => {
+    for (const sel of selectorList) {
+      const el = document.querySelector(sel);
+      if (el) {
+        if ('value' in el && (el.tagName === 'INPUT' || el.tagName === 'BUTTON')) {
+          // For safety, set both value and textContent if applicable
+          try { el.value = text; } catch {}
+        }
+        if ('textContent' in el) el.textContent = text;
+        return true;
+      }
+    }
+    return false;
+  };
+  trySet(['[data-testid="start-btn"]', '#start-btn', 'button#start', 'button[data-action="start"]'], t('ui.start'));
+  trySet(['#history-btn', '[data-testid="history-btn"]'], t('ui.history'));
+  trySet(['#share-btn', '[data-testid="share-btn"]'], t('ui.share'));
 }
 


### PR DESCRIPTION
## Summary
- translate Start/History/Share buttons based on active locale
- expose `whenI18nReady` and dispatch `i18n:changed` events
- add Playwright smoke test and workflow for static button labels
- document i18n conventions

## Testing
- `npm test` *(fails: clojure not found)*
- `node e2e/test_i18n_static_labels_smoke.mjs` *(fails: Cannot find package 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68b9767f1c38832493068602322b99b3