### PR TITLE
feat: add step2 i18n labels and e2e test

### DIFF
--- a/.github/workflows/e2e-i18n-labels-step2.yml
+++ b/.github/workflows/e2e-i18n-labels-step2.yml
@@ -1,0 +1,30 @@
+name: e2e (i18n labels step2)
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "35 18 * * *" # UTC 18:35 ≒ JST 03:35
+
+jobs:
+  e2e_i18n_labels_step2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Playwright (module + browsers)
+        run: |
+          npm init -y >/dev/null 2>&1 || true
+          npm i --no-save playwright
+          npx playwright install --with-deps
+
+      - name: Run i18n labels step2 smoke
+        env:
+          E2E_BASE_URL: ${{ vars.E2E_BASE_URL }}
+          APP_URL: ${{ vars.APP_URL }}
+        run: node e2e/test_i18n_labels_step2_smoke.mjs
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,7 +18,7 @@
 | v1.3 | **Done (2025-09-03)** | Budgets引き締め、Lazy import、Worker JSON parse、LHCI配線修正 | — |
 | v1.4 | **Done (2025-09-04)** | A11y最小セット（live region/roles/labels/`aria-describedby`）＋ダイアログのフォーカストラップ/復帰＋背景 inert + scroll lock＋a11y static checker（static smoke） | — |
 | v1.5 | **Done (2025-09-04)** | UI/Responsive polish（トークン/44px/2→3→4列/微トランジション/ライト調整/E2E緑） | — |
-| v1.6 | **Planned** | — | i18nベースライン（UI文言辞書/言語選択/`<html lang>` 等） |
+| v1.6 | **In progress** | — | i18nベースライン（UI文言辞書/言語選択/`<html lang>` 等） |
 
 ## 現状 (v1.0.x Stabilization) — 完了/運用中
 - キーボード操作（Tab/Enter/Space の基本操作）: **実装済み（Baseline）**
@@ -161,6 +161,7 @@
 
 > **実装反映済み**: `e2e (ui responsive smoke)`, `e2e (ui motion reduce)` は緑、README にバッジ追加済み。詳細は **`docs/STYLEGUIDE_UI.md`** を参照。
 ## v1.6 — i18n ベースライン
+**Status:** In progress
 **狙い**: UIテキスト/ラベルを辞書化し、言語切替（ja/en）を可能にする。初期バンドルの悪化は避け、`en` 同梱・`ja` 遅延ロードの方針。
 
 **機能/変更**
@@ -170,6 +171,14 @@
 - 主要画面の文言を段階的に外部化（Start/History/Share → クイズ本文へ）
 - 日付/数値表示を `Intl.DateTimeFormat/NumberFormat` に統一
 - a11y メッセージ（live region など）をキー管理に統合
+
+**Progress**
+- ✅ i18nコア（`public/app/i18n.mjs`）と最小辞書（`locales/en, ja`）導入
+- ✅ `document.title` と `<html lang>` の切替（`?lang=` / `localStorage`）
+- ✅ E2E: `e2e (i18n lang param smoke)` 緑
+- ✅ 外部化ステップ1（Start/History/Share の静的ラベル）＋ E2E（labels smoke）
+- ⏳ 外部化ステップ2（再スタート/コピー/シェア結果/見出し 等の静的ラベル） ← 本パッチ
+- ⏳ a11yメッセージのキー化、`Intl.DateTimeFormat` の導入（必要箇所のみ）
 
 **DoD**
 - `?lang=en/ja` で `<html lang>` と表示テキストが切り替わる

--- a/e2e/test_i18n_labels_step2_smoke.mjs
+++ b/e2e/test_i18n_labels_step2_smoke.mjs
@@ -1,0 +1,78 @@
+import { chromium } from 'playwright';
+
+(async () => {
+  const TIMEOUT = 30000;
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  function urlWith(base, lang) {
+    const u = new URL(base);
+    const p = u.searchParams;
+    p.set('test', '1');
+    p.set('mock', '1');
+    p.set('autostart', '0');
+    p.set('lang', lang);
+    return u.toString();
+  }
+
+  function defaultBase() {
+    const repo = process.env.GITHUB_REPOSITORY;
+    if (repo) {
+      const [owner, name] = repo.split('/');
+      return `https://${owner}.github.io/${name}/app/`;
+    }
+    return 'http://127.0.0.1:8080/app/';
+  }
+
+  const base = process.env.E2E_BASE_URL || process.env.APP_URL || defaultBase();
+
+  // Helper: read text if element exists
+  async function readIfExists(selector) {
+    const el = await page.$(selector);
+    if (!el) return null;
+    return (await el.textContent())?.trim() ?? null;
+  }
+
+  // JA labels
+  await page.goto(urlWith(base, 'ja'));
+  await page.waitForFunction(() => document.documentElement.lang === 'ja', null, { timeout: TIMEOUT });
+
+  const checksJa = [
+    { sel: '[data-testid="start-btn"], #start-btn, button#start, button[data-action="start"]', re: /スタート/ },
+    { sel: '#history-heading', re: /履歴/ },
+    { sel: '#result-heading, #results-heading', re: /結果/ },
+    { sel: '#share-result-btn, [data-testid="share-result-btn"]', re: /シェア/ },
+    { sel: '#copy-result-btn, [data-testid="copy-result-btn"]', re: /コピー/ },
+    { sel: '#restart-btn, [data-testid="restart-btn"], button[data-action="restart"]', re: /(リスタート|もう一度)/ },
+  ];
+
+  for (const c of checksJa) {
+    const text = await readIfExists(c.sel);
+    if (text && !c.re.test(text)) {
+      throw new Error(`Unexpected JA label for ${c.sel}: "${text}"`);
+    }
+  }
+
+  // EN labels
+  await page.goto(urlWith(base, 'en'));
+  await page.waitForFunction(() => document.documentElement.lang === 'en', null, { timeout: TIMEOUT });
+
+  const checksEn = [
+    { sel: '[data-testid="start-btn"], #start-btn, button#start, button[data-action="start"]', re: /start/i },
+    { sel: '#history-heading', re: /history/i },
+    { sel: '#result-heading, #results-heading', re: /result/i },
+    { sel: '#share-result-btn, [data-testid="share-result-btn"]', re: /share/i },
+    { sel: '#copy-result-btn, [data-testid="copy-result-btn"]', re: /copy/i },
+    { sel: '#restart-btn, [data-testid="restart-btn"], button[data-action="restart"]', re: /restart/i },
+  ];
+
+  for (const c of checksEn) {
+    const text = await readIfExists(c.sel);
+    if (text && !c.re.test(text)) {
+      throw new Error(`Unexpected EN label for ${c.sel}: "${text}"`);
+    }
+  }
+
+  await browser.close();
+})();
+

--- a/public/app/i18n.mjs
+++ b/public/app/i18n.mjs
@@ -150,5 +150,18 @@ export function applyStaticLabels() {
   trySet(['[data-testid="start-btn"]', '#start-btn', 'button#start', 'button[data-action="start"]'], t('ui.start'));
   trySet(['#history-btn', '[data-testid="history-btn"]'], t('ui.history'));
   trySet(['#share-btn', '[data-testid="share-btn"]'], t('ui.share'));
+
+  // --- Step2: common labels that may exist conditionally ---
+  trySet(['#restart-btn', '[data-testid="restart-btn"]', 'button[data-action="restart"]'], t('ui.restart'));
+  trySet(['#copy-result-btn', '[data-testid="copy-result-btn"]'], t('ui.copyResult'));
+  trySet(['#share-result-btn', '[data-testid="share-result-btn"]'], t('ui.shareResult'));
+  trySet(['#next-btn', '[data-testid="next-btn"]'], t('ui.next'));
+  trySet(['#back-btn', '[data-testid="back-btn"]'], t('ui.back'));
+  trySet(['#ok-btn', '[data-testid="ok-btn"]'], t('ui.ok'));
+  trySet(['#cancel-btn', '[data-testid="cancel-btn"]'], t('ui.cancel'));
+
+  // Headings
+  trySet(['#history-heading'], t('heading.history'));
+  trySet(['#result-heading', '#results-heading'], t('heading.result'));
 }
 

--- a/public/app/locales/en.json
+++ b/public/app/locales/en.json
@@ -5,7 +5,18 @@
   "ui": {
     "start": "Start",
     "history": "History",
-    "share": "Share"
+    "share": "Share",
+    "restart": "Restart",
+    "copyResult": "Copy result",
+    "shareResult": "Share result",
+    "next": "Next",
+    "back": "Back",
+    "ok": "OK",
+    "cancel": "Cancel"
+  },
+  "heading": {
+    "history": "History",
+    "result": "Results"
   },
   "a11y": {
     "ready": "Ready. Press Start to begin."

--- a/public/app/locales/ja.json
+++ b/public/app/locales/ja.json
@@ -5,7 +5,18 @@
   "ui": {
     "start": "スタート",
     "history": "履歴",
-    "share": "シェア"
+    "share": "シェア",
+    "restart": "リスタート",
+    "copyResult": "結果をコピー",
+    "shareResult": "結果をシェア",
+    "next": "次へ",
+    "back": "戻る",
+    "ok": "OK",
+    "cancel": "キャンセル"
+  },
+  "heading": {
+    "history": "履歴",
+    "result": "結果"
   },
   "a11y": {
     "ready": "準備OK。スタートを押すと開始します。"


### PR DESCRIPTION
## Summary
- localize restart, result-sharing, navigation and dialog buttons plus headings
- translate new labels in English and Japanese locales
- add Playwright smoke test and scheduled workflow
- mark i18n roadmap as in progress with progress bullets

## Testing
- `npm test` *(fails: command not found)*
- `node e2e/test_i18n_labels_step2_smoke.mjs` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b979ef69388324b42102d42edcb733