### PR TITLE
Add Intl helpers and i18n key validation

### DIFF
--- a/.github/workflows/i18n-missing-keys.yml
+++ b/.github/workflows/i18n-missing-keys.yml
@@ -1,0 +1,23 @@
+name: i18n (missing keys)
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - 'public/app/**'
+      - 'e2e/**'
+      - 'docs/**'
+      - '.github/workflows/i18n-missing-keys.yml'
+
+jobs:
+  check_missing_keys:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run missing keys checker
+        run: node script/check_i18n_missing_keys.mjs
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -178,7 +178,9 @@
 - ✅ E2E: `e2e (i18n lang param smoke)` 緑
 - ✅ 外部化ステップ1（Start/History/Share の静的ラベル）＋ E2E（labels smoke）
 - ⏳ 外部化ステップ2（再スタート/コピー/シェア結果/見出し 等の静的ラベル） ← 本パッチ
-- ⏳ a11yメッセージのキー化、`Intl.DateTimeFormat` の導入（必要箇所のみ）
+- ✅ `Intl.DateTimeFormat` ヘルパー（`formatDate/Time/DateTime`）を導入（未適用・後続で置換）
+- ✅ Missing Keys チェッカ（CI）導入：`.github/workflows/i18n-missing-keys.yml`
+- ⏳ a11yメッセージのキー化（`#feedback` などを `a11y.*` キーへ）
 
 **DoD**
 - `?lang=en/ja` で `<html lang>` と表示テキストが切り替わる

--- a/docs/STYLEGUIDE_I18N.md
+++ b/docs/STYLEGUIDE_I18N.md
@@ -14,6 +14,7 @@
 - `setLang(lang)` — switch language at runtime; dispatches `i18n:changed`
 - `whenI18nReady()` — Promise resolved when the initial language is applied
 - `applyStaticLabels()` — helper to translate Start/History/Share buttons
+- `getLang()` / `formatDate()` / `formatTime()` / `formatDateTime()` — `Intl.*` を使った軽量フォーマッタ
 
 ## Keys (minimum set in v1.6)
 ```json
@@ -29,6 +30,7 @@
 2. Use `t('…')` instead of hard-coded strings
 3. If it’s a static control, consider adding it to `applyStaticLabels()`
 4. Verify with `e2e (i18n lang param smoke)` and `e2e (i18n static labels smoke)`
+5. 追加・変更で `t('…')` を増やした場合は **i18n Missing Keys**（`node script/check_i18n_missing_keys.mjs`）が PR で自動検出します
 
 ## Non-goals (v1.6)
 - No dataset translations (proper nouns preserved)

--- a/public/app/i18n.mjs
+++ b/public/app/i18n.mjs
@@ -165,3 +165,23 @@ export function applyStaticLabels() {
   trySet(['#result-heading', '#results-heading'], t('heading.result'));
 }
 
+// --- Intl helpers (for step3) ---
+export function getLang() {
+  return currentLang || DEFAULT_LANG;
+}
+
+export function formatDate(date, opts) {
+  const d = date instanceof Date ? date : new Date(date);
+  return new Intl.DateTimeFormat(getLang(), opts || { year: 'numeric', month: 'short', day: 'numeric' }).format(d);
+}
+
+export function formatTime(date, opts) {
+  const d = date instanceof Date ? date : new Date(date);
+  return new Intl.DateTimeFormat(getLang(), opts || { hour: '2-digit', minute: '2-digit' }).format(d);
+}
+
+export function formatDateTime(date, optsDate, optsTime) {
+  const d = date instanceof Date ? date : new Date(date);
+  return `${formatDate(d, optsDate)} ${formatTime(d, optsTime)}`.trim();
+}
+

--- a/script/check_i18n_missing_keys.mjs
+++ b/script/check_i18n_missing_keys.mjs
@@ -1,0 +1,76 @@
+/* Simple missing-keys checker for i18n
+ * Scans code for t('...') / t("...") usage and verifies that keys exist
+ * in locales/en.json and locales/ja.json. Fails on first missing key.
+ */
+
+/* eslint-disable no-console */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const APP_DIR = path.join(ROOT, 'public', 'app');
+const LOCALES_DIR = path.join(APP_DIR, 'locales');
+
+function walk(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(p, out);
+    } else {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+function scanKeysFromFile(fp) {
+  const src = fs.readFileSync(fp, 'utf8');
+  const re = /\bt\((['"])([^'"\n]+)\1\)/g;
+  const keys = [];
+  let m;
+  while ((m = re.exec(src))) {
+    keys.push(m[2]);
+  }
+  return keys;
+}
+
+function readJson(fp) {
+  return JSON.parse(fs.readFileSync(fp, 'utf8'));
+}
+
+function hasKey(obj, dotted) {
+  return dotted
+    .split('.')
+    .reduce((acc, k) => (acc && acc[k] != null ? acc[k] : undefined), obj) != null;
+}
+
+function main() {
+  const files = walk(APP_DIR).filter((f) => /\.(m?js)$/.test(f));
+  const allKeys = new Set();
+  for (const f of files) {
+    if (f.includes('/locales/')) continue; // skip locale json imports inside code dir
+    scanKeysFromFile(f).forEach((k) => allKeys.add(k));
+  }
+  const en = readJson(path.join(LOCALES_DIR, 'en.json'));
+  const ja = readJson(path.join(LOCALES_DIR, 'ja.json'));
+
+  let missing = 0;
+  for (const k of allKeys) {
+    const okEn = hasKey(en, k);
+    const okJa = hasKey(ja, k);
+    if (!okEn || !okJa) {
+      console.error(`✗ Missing key "${k}" in: ${!okEn ? 'en ' : ''}${!okJa ? 'ja' : ''}`.trim());
+      missing++;
+    }
+  }
+  if (missing > 0) {
+    console.error(`Found ${missing} missing i18n key(s).`);
+    process.exit(1);
+  }
+  console.log(`✓ i18n keys OK (${allKeys.size} referenced)`);
+}
+
+main();
+


### PR DESCRIPTION
## Summary
- expose language-aware `formatDate`, `formatTime` and `formatDateTime` helpers
- introduce a script and workflow to flag missing i18n keys across locales
- document the new helpers and automated i18n key check in style guide and roadmap

## Testing
- `node script/check_i18n_missing_keys.mjs`
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b97e7e75e88324b77a7b312b48a25a