### PR TITLE
test: add fallback for result dialog in live region e2e

### DIFF
--- a/e2e/test_i18n_a11y_live_region_smoke.mjs
+++ b/e2e/test_i18n_a11y_live_region_smoke.mjs
@@ -50,7 +50,15 @@ import { chromium } from 'playwright';
   } catch {
     await choiceLoc.click({ force: true });
   }
-  await page.waitForSelector('#result-view[role="dialog"]', { state: 'visible', timeout: TIMEOUT });
+  // If result dialog doesn't appear promptly, programmatic click as final fallback
+  try {
+    await page.waitForSelector('#result-view[role="dialog"]', { state: 'visible', timeout: 8000 });
+  } catch {
+    try {
+      await page.$eval('#choices button', (el) => el && el.click());
+    } catch {}
+    await page.waitForSelector('#result-view[role="dialog"]', { state: 'visible', timeout: 8000 });
+  }
   const liveOpenedJa = await page.textContent('#feedback');
   if (!/結果/.test(liveOpenedJa || '')) {
     throw new Error(`JA live region did not announce results: "${liveOpenedJa}"`);


### PR DESCRIPTION
## Summary
- improve reliability of live region smoke test by retrying choice click when result dialog fails to appear

## Testing
- `npm test` *(fails: clojure: not found)*
- `node e2e/test_i18n_a11y_live_region_smoke.mjs` *(fails: Cannot find package 'playwright')*
- `npm install playwright` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c0ba14488324b5a93a37cecbdd89