### PR TITLE
Add authoring pipeline validation and docs

### DIFF
--- a/.github/workflows/authoring-validate.yml
+++ b/.github/workflows/authoring-validate.yml
@@ -1,0 +1,62 @@
+name: authoring (validate)
+
+on:
+  workflow_dispatch:
+    inputs:
+      date:
+        description: 'Target date (YYYY-MM-DD). Default = today (JST).'
+        required: false
+        type: string
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java (Temurin 21)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@12.5
+        with:
+          cli: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build dataset (clojure -T:build publish)
+        run: clojure -T:build publish
+
+      - name: Harvest → Score → Enrich → Generate (draft)
+        id: gen
+        run: |
+          DATE="${{ github.event.inputs.date }}"
+          if [ -z "$DATE" ]; then DATE="$(TZ=Asia/Tokyo date +%F)"; fi
+          echo "date=$DATE"
+          node scripts/harvest_candidates.js --out public/app/daily_candidates.jsonl
+          node scripts/score_candidates.js --in public/app/daily_candidates.jsonl --out public/app/daily_candidates_scored.jsonl
+          node scripts/enrich_media_start.js --in public/app/daily_candidates_scored.jsonl --out public/app/daily_candidates_scored_enriched.jsonl
+          node scripts/generate_daily_from_candidates.js --in public/app/daily_candidates_scored_enriched.jsonl --date "$DATE"
+
+      - name: Validate authoring bundle
+        run: node scripts/validate_authoring.js
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: authoring-validate
+          path: |
+            public/app/daily_candidates.jsonl
+            public/app/daily_candidates_scored.jsonl
+            public/app/daily_candidates_scored_enriched.jsonl
+            public/app/daily_auto.json
+
+      - name: Summary
+        run: |
+          node -e "const j=require('./public/app/daily_auto.json'); const by=j.by_date||{}; const d=Object.keys(by).sort().pop(); if(d){ const v=by[d]; console.log('### authoring (validate)\n- date: **'+d+'**\n- pick:', v.title, '/', v.game, '/', v.composer, '\n- difficulty:', v.difficulty??'n/a', '\n- choices composer:', (v.choices?.composer||[]).length, '\n- choices game:', (v.choices?.game||[]).length); } else { console.log('### authoring (validate)\n- no dates found'); }"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -199,7 +199,7 @@
 8. static-checker-missing-keys：未翻訳/未使用キー検出スクリプト
 9. docs-styleguide-i18n-roadmap：STYLEGUIDE/ROADMAP の更新
 ## v1.7 — Authoring Automation（MVP）
-- Status: **Planned**
+- Status: **In Progress (started 2025-09-05)**
 - Scope: “**毎日1問**”を**完全自動**で作成・公開。**埋め込み再生のみ**（Apple Music / 公式YouTube）前提で、既存アプリは変更せず供給ラインを自動化。
 
 **機能/変更**

--- a/docs/STYLEGUIDE_AUTHORING.md
+++ b/docs/STYLEGUIDE_AUTHORING.md
@@ -1,0 +1,82 @@
+# STYLEGUIDE — Authoring (v1.7 MVP)
+
+目的: **毎日1問**を“安全に・再現可能に”自動生成するための **作問データ規約** と **運用手順** を定義する。
+
+## 入力ソース（候補）
+- **手動シード**: `public/app/daily_candidates.jsonl` に1行=1候補を追記可能。
+- **自動収集（既存）**: `scripts/harvest_candidates.js` が `public/build/dataset.json` から候補を生成。
+- **許可リスト**（将来拡張）: 公式YouTube/Apple限定の収集を段階導入。第三者アップロードは対象外。
+
+### 候補の1行（JSONL）最低限
+```json
+{
+  "title": "曲名",
+  "game": "作品名",
+  "composer": "作曲者",
+  "platform": "任意",
+  "year": 1995,
+  "media": null,
+  "source": "dataset",
+  "norm": {
+    "title": "正規化後",
+    "game": "正規化後",
+    "composer": "正規化後"
+  }
+}
+```
+- `norm.*` は既存の正規化（波ダッシュ/長音/CJK間スペース/ローマ数字/「ン」前後の長音）を適用。
+- **ユニークキー**: `norm.title|norm.game|norm.composer`。重複は除外。
+
+## 中間加工（概要）
+- `scripts/score_candidates.js` … 難易度の仮スコア付与。`media.start` が無ければ仮に 45s を入れる。
+- `scripts/enrich_media_start.js` … URLパラメータ/キーワードから開始秒推定。`--allow-heuristic-media` で `media` 自体を生成可。
+- `scripts/generate_daily_from_candidates.js` … 指定日分を `public/app/daily_auto.json` の `by_date` にマージ（30日重複防止、破壊的編集なし）。
+
+## 出力（UIが読む日次ドラフト）
+`public/app/daily_auto.json`:
+```json
+{
+  "by_date": {
+    "YYYY-MM-DD": {
+      "title": "…",
+      "game": "…",
+      "composer": "…",
+      "platform": null,
+      "year": 1995,
+      "media": null,
+      "source": "dataset",
+      "norm": { "title": "…", "game": "…", "composer": "…" },
+      "difficulty": 4,
+      "choices": {
+        "composer": ["A","B","C","(正解)"],
+        "game": ["A","B","C","(正解)"]
+      }
+    }
+  }
+}
+```
+
+## ルール（初版）
+- **埋め込み再生のみ**: `media.provider` は `youtube` または `apple`（`auto` は内部用）。`id` が空のものは弾く。
+- **clip-start**: `?t=`/`?start=`/`#t=` を優先 → キーワード（Opening=0s, Boss=10–15s 等）→ 既定45s。
+- **ダミー選択肢（初版）**: 同シリーズ/作曲者/年代から近傍を4択化。**正解は choices.* に必ず含める**。
+- **難易度（初版）**: シンプル合成値（年代・別名密度など）。スケールは暫定（0–100 or small int）でよいが **数値** であること。
+- **信頼性**: 公式チャンネル/レーベル優先。出典URLは `sources`（将来項目）に保持。
+
+## DoD（v1.7）
+- ローカル/CIで **harvest→score→enrich→generate→validate** が再現可能。
+- `daily_auto.json` に**当日分**が存在し、`choices`/`difficulty` が埋まる（最低限の質保証）。
+- `scripts/validate_authoring.js` が**構造/ユニーク/埋め込み整合**を確認して成功（CI緑）。
+
+## 実行例（ローカル）
+```bash
+clojure -T:build publish
+node scripts/harvest_candidates.js --out public/app/daily_candidates.jsonl
+node scripts/score_candidates.js --in public/app/daily_candidates.jsonl --out public/app/daily_candidates_scored.jsonl
+node scripts/enrich_media_start.js --in public/app/daily_candidates_scored.jsonl --out public/app/daily_candidates_scored_enriched.jsonl
+node scripts/generate_daily_from_candidates.js --in public/app/daily_candidates_scored_enriched.jsonl --date $(TZ=Asia/Tokyo date +%F)
+node scripts/validate_authoring.js
+```
+
+—  
+*Started: 2025-09-05*

--- a/schema/auto.bundle.v1.json
+++ b/schema/auto.bundle.v1.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nantes-rfli.github.io/vgm-quiz/schema/auto.bundle.v1.json",
+  "title": "daily_auto bundle (v1)",
+  "type": "object",
+  "required": [
+    "by_date"
+  ],
+  "properties": {
+    "by_date": {
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "title",
+          "game",
+          "composer",
+          "norm",
+          "source"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "game": {
+            "type": "string"
+          },
+          "composer": {
+            "type": "string"
+          },
+          "platform": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "year": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "media": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "provider",
+                  "id"
+                ],
+                "properties": {
+                  "provider": {
+                    "type": "string",
+                    "enum": [
+                      "youtube",
+                      "apple",
+                      "auto"
+                    ]
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "start": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "duration": {
+                    "type": "number",
+                    "minimum": 1
+                  }
+                },
+                "additionalProperties": true
+              }
+            ]
+          },
+          "source": {
+            "type": "string"
+          },
+          "norm": {
+            "type": "object",
+            "required": [
+              "title",
+              "game",
+              "composer"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "game": {
+                "type": "string"
+              },
+              "composer": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          },
+          "difficulty": {
+            "type": [
+              "number",
+              "integer"
+            ]
+          },
+          "choices": {
+            "type": "object",
+            "properties": {
+              "composer": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "game": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schema/candidate.entry.v1.json
+++ b/schema/candidate.entry.v1.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nantes-rfli.github.io/vgm-quiz/schema/candidate.entry.v1.json",
+  "title": "Authoring Candidate Entry (v1)",
+  "description": "One candidate per line (JSONL). Minimal contract for v1.7 pipeline.",
+  "type": "object",
+  "required": [
+    "title",
+    "game",
+    "composer",
+    "norm",
+    "source"
+  ],
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "game": {
+      "type": "string",
+      "minLength": 1
+    },
+    "composer": {
+      "type": "string",
+      "minLength": 1
+    },
+    "platform": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "year": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 1970,
+      "maximum": 2100
+    },
+    "media": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "required": [
+            "provider",
+            "id"
+          ],
+          "properties": {
+            "provider": {
+              "type": "string",
+              "enum": [
+                "youtube",
+                "apple",
+                "auto"
+              ]
+            },
+            "id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "start": {
+              "type": "number",
+              "minimum": 0
+            },
+            "duration": {
+              "type": "number",
+              "minimum": 1
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1
+    },
+    "norm": {
+      "type": "object",
+      "required": [
+        "title",
+        "game",
+        "composer"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "game": {
+          "type": "string",
+          "minLength": 1
+        },
+        "composer": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": true
+    },
+    "difficulty": {
+      "type": [
+        "number",
+        "integer"
+      ]
+    },
+    "choices": {
+      "type": "object",
+      "properties": {
+        "composer": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "game": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/validate_authoring.js
+++ b/scripts/validate_authoring.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * Lightweight validator for authoring pipeline outputs.
+ * - Validate JSONL candidates (structure, required fields, uniqueness)
+ * - Validate daily_auto.json (structure, choices include canonical, media sanity)
+ * No external deps; CI-friendly.
+ */
+const fs = require('fs');
+
+function readJSON(p){ return JSON.parse(fs.readFileSync(p,'utf-8')); }
+function exists(p){ try{ fs.accessSync(p); return true; }catch{ return false; } }
+
+function readJSONL(p){
+  const out = [];
+  const txt = fs.readFileSync(p,'utf-8');
+  for (const raw of txt.split(/\r?\n/)){
+    const s = raw.trim();
+    if (!s) continue;
+    try{
+      out.push(JSON.parse(s));
+    }catch(e){
+      throw new Error(`Invalid JSONL line: ${s.slice(0,200)}`);
+    }
+  }
+  return out;
+}
+
+function isNonEmptyStr(x){ return typeof x==='string' && x.trim().length>0; }
+function isValidDateKey(k){ return /^\d{4}-\d{2}-\d{2}$/.test(k); }
+
+function checkMedia(m){
+  if (m == null) return null;
+  const errs = [];
+  const prov = m.provider;
+  if (!isNonEmptyStr(prov) || !['youtube','apple','auto'].includes(prov)){
+    errs.push('media.provider invalid');
+  }
+  if (!isNonEmptyStr(m.id)) errs.push('media.id missing');
+  if (m.start != null){
+    if (typeof m.start !== 'number' || !(m.start>=0) || !(m.start < 36000)) errs.push('media.start out of range');
+  }
+  if (m.duration != null){
+    if (typeof m.duration !== 'number' || !(m.duration>0) || !(m.duration < 7200)) errs.push('media.duration out of range');
+  }
+  return errs.length ? errs : null;
+}
+
+function validateCandidates(file){
+  if (!exists(file)) return { skipped:true, summary:'candidates file not found' };
+  const seen = new Set();
+  let n=0, errors=[];
+  for (const c of readJSONL(file)){
+    n++;
+    if (!isNonEmptyStr(c.title)) errors.push(`[c${n}] title missing`);
+    if (!isNonEmptyStr(c.game)) errors.push(`[c${n}] game missing`);
+    if (!isNonEmptyStr(c.composer)) errors.push(`[c${n}] composer missing`);
+    if (!c.norm || !isNonEmptyStr(c.norm.title) || !isNonEmptyStr(c.norm.game) || !isNonEmptyStr(c.norm.composer)){
+      errors.push(`[c${n}] norm.* missing`);
+    }
+    const key = c.norm ? `${c.norm.title}|${c.norm.game}|${c.norm.composer}` : '';
+    if (key && seen.has(key)) errors.push(`[c${n}] duplicate key ${key}`);
+    seen.add(key);
+    const merrs = checkMedia(c.media);
+    if (merrs) errors.push(`[c${n}] `+merrs.join(', '));
+  }
+  return { count:n, errors };
+}
+
+function validateDailyAuto(file){
+  if (!exists(file)) return { skipped:true, summary:'daily_auto.json not found' };
+  const j = readJSON(file);
+  const by = j.by_date || {};
+  const dates = Object.keys(by);
+  const errors = [];
+  let choicesOK=0, mediaOK=0;
+  for (const d of dates){
+    if (!isValidDateKey(d)) errors.push(`[by_date.${d}] invalid date key`);
+    const v = by[d] || {};
+    if (!isNonEmptyStr(v.title)) errors.push(`[${d}] title missing`);
+    if (!isNonEmptyStr(v.game)) errors.push(`[${d}] game missing`);
+    if (!isNonEmptyStr(v.composer)) errors.push(`[${d}] composer missing`);
+    if (!v.norm || !isNonEmptyStr(v.norm.title) || !isNonEmptyStr(v.norm.game) || !isNonEmptyStr(v.norm.composer)){
+      errors.push(`[${d}] norm.* missing`);
+    }
+    if (v.choices && typeof v.choices === 'object'){
+      const comp = Array.isArray(v.choices.composer) ? v.choices.composer : [];
+      const game = Array.isArray(v.choices.game) ? v.choices.game : [];
+      if (comp.length>0 && !comp.includes(v.composer)) errors.push(`[${d}] choices.composer must include canonical composer`);
+      if (game.length>0 && !game.includes(v.game)) errors.push(`[${d}] choices.game must include canonical game`);
+      if (comp.length>0 || game.length>0) choicesOK++;
+    }
+    const merrs = checkMedia(v.media);
+    if (merrs) errors.push(`[${d}] `+merrs.join(', '));
+    else if (v.media) mediaOK++;
+    if (v.difficulty!=null && typeof v.difficulty !== 'number'){
+      errors.push(`[${d}] difficulty must be a number`);
+    }
+  }
+  return { dates: dates.length, choicesOK, mediaOK, errors };
+}
+
+(function main(){
+  try{
+    const cand = validateCandidates('public/app/daily_candidates.jsonl');
+    const auto = validateDailyAuto('public/app/daily_auto.json');
+    const lines = [];
+    lines.push('## Authoring validation summary');
+    if (!cand.skipped) lines.push(`- candidates: ${cand.count} lines, errors=${cand.errors.length}`);
+    else lines.push(`- candidates: (skipped) ${cand.summary}`);
+    if (!auto.skipped) lines.push(`- daily_auto: ${auto.dates} dates, choicesOK=${auto.choicesOK}, mediaOK=${auto.mediaOK}, errors=${auto.errors.length}`);
+    else lines.push(`- daily_auto: (skipped) ${auto.summary}`);
+    const allErrs = [...(cand.errors||[]), ...((auto.errors)||[])];
+    if (allErrs.length>0){
+      lines.push('\n### Errors');
+      for (const e of allErrs.slice(0,200)) lines.push(`- ${e}`);
+    }
+    console.log(lines.join('\n'));
+    if (allErrs.length>0) process.exit(1);
+  }catch(e){
+    console.error(e.stack||String(e));
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- document authoring pipeline and candidate format
- add JSON schemas for authoring candidates and daily bundle
- introduce validation script and workflow to check generated data
- mark v1.7 roadmap as in progress

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: repository not signed)*
- `node scripts/validate_authoring.js`

------
https://chatgpt.com/codex/tasks/task_e_68b9e3fbd4548324936d9cf7a22041d0