### PR TITLE
docs: add authoring ops guide and update roadmap

### DIFF
--- a/docs/OPERATIONS_AUTHORING.md
+++ b/docs/OPERATIONS_AUTHORING.md
@@ -1,0 +1,45 @@
+# OPERATIONS — Authoring (v1.7)
+
+本書は v1.7「Authoring Automation（MVP）」の**運用ガイド**です。Docs が正本です。更新が必要になったらこのファイルを修正してください。
+
+## 目的
+- “毎日1問”の自動生成を **安全に** 運用する（まずは下書き→段階公開）。
+- リポ汚染・誤公開を防ぐため、**validate（検証）**と**publish（PR）**を分ける。
+
+## ワークフロー一覧
+- **authoring (validate)** — 生成パイプラインを実行し、**構造/整合チェック**を行って **Artifacts に保存**。リポは更新しない。
+- **daily (auto, candidates→score→generate)** — 生成パイプラインを実行し、`apply_to_main=true` のとき **`public/app/daily_auto.json` への PR を自動作成**（`false` なら Artifact のみ）。
+
+## 推奨オペレーション
+1. Actions → **authoring (validate)** を実行  
+   - 入力: なし（Date は JST 今日に解決）  
+   - 成果: `daily_candidates*.jsonl` と `daily_auto.json` が **Artifacts** に出力
+2. 目視確認（曲・作曲者・メディア埋め込みの妥当性、choices/difficulty の粗チェック）
+3. 問題なければ Actions → **daily (auto, candidates→score→generate)** を **apply_to_main=true** で実行  
+   - 任意で `with_choices=true` / `allow_heuristic_media=true` を指定  
+   - 結果: `public/app/daily_auto.json` の PR が作成され、既存設定があれば自動マージ
+
+## トラブルシュート
+- **PRが作成されない**  
+  - `apply_to_main=true` になっているか確認  
+  - リポに **`secrets.DAILY_PR_PAT`** が設定されているか確認（`peter-evans/create-pull-request` が使用）
+- **メディア未解決（mediaOK=0）**  
+  - allowlist/seed を増やす  
+  - `allow_heuristic_media=true` を試す（安全な既定の範囲・45sガード付き）
+- **重複/似問が多い**  
+  - ⚙️ normalize/aliases の同期を確認  
+  - 直近30日重複ガードは `daily_auto.json` 側で機能（詳細はスクリプト参照）
+
+## ローカル実行（参考）
+```bash
+clojure -T:build publish
+node scripts/harvest_candidates.js --out public/app/daily_candidates.jsonl
+node scripts/score_candidates.js --in public/app/daily_candidates.jsonl --out public/app/daily_candidates_scored.jsonl
+node scripts/enrich_media_start.js --in public/app/daily_candidates_scored.jsonl --out public/app/daily_candidates_scored_enriched.jsonl
+node scripts/generate_daily_from_candidates.js --in public/app/daily_candidates_scored_enriched.jsonl --date $(TZ=Asia/Tokyo date +%F)
+```
+
+## 付記
+- v1.7は **埋め込み再生のみ**（YouTube/Apple プレビュー）の原則を維持します。
+- 公開手順は将来、`daily (auto)` の cron 化で自動化可能（まずは手動運用で検証）。
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -199,7 +199,7 @@
 8. static-checker-missing-keys：未翻訳/未使用キー検出スクリプト
 9. docs-styleguide-i18n-roadmap：STYLEGUIDE/ROADMAP の更新
 ## v1.7 — Authoring Automation（MVP）
-- Status: **In Progress (started 2025-09-05)**
+- Status: **In Progress (2025-09-05)**
 - Scope: “**毎日1問**”を**完全自動**で作成・公開。**埋め込み再生のみ**（Apple Music / 公式YouTube）前提で、既存アプリは変更せず供給ラインを自動化。
 
 **機能/変更**
@@ -224,6 +224,12 @@
 **依存関係**
 - v1.6 i18n ベースライン（UIテキスト/ラベルの多言語化）。
 - 既存 normalize / aliases / E2E 基盤。
+
+**運用メモ（v1.7）**
+- `authoring (validate)`: 生成物を **検証して artifact 化のみ**。リポのファイルは更新しない。
+- `daily (auto, candidates→score→generate)`: 入力 `apply_to_main=true` のとき **`public/app/daily_auto.json` へのPRを作成**。false のときは artifact のみ。
+- 推奨フロー: **validate → 目視 → daily(auto) with apply_to_main**。必要に応じて `with_choices` / `allow_heuristic_media` をON。
+- 既存 `daily.json` 系パイプラインとは分離運用（既存ユーザー体験を壊さない）。
 
 **初期Issue分解（案）**
 1. harvester-min：公式ソースの収集器（レート制御・失敗時リトライ）


### PR DESCRIPTION
## Summary
- document v1.7 authoring automation workflow and operations
- record operational notes in the roadmap and mark v1.7 as in progress

## Testing
- `npm test` *(fails: clojure not found)*
- `apt-get update` *(fails: repository unsigned/403)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b9ebc75e5c8324b2426bd646f8e3a8