### PR TITLE
Add clip start heuristics script and smoke workflow

### DIFF
--- a/.github/workflows/authoring-heuristics-smoke.yml
+++ b/.github/workflows/authoring-heuristics-smoke.yml
@@ -1,0 +1,58 @@
+name: authoring (heuristics smoke)
+
+on:
+  workflow_dispatch:
+    inputs:
+      date:
+        description: 'JST date (YYYY-MM-DD). Empty = today'
+        required: false
+        default: ''
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build site artifacts (EDN→JSON)
+        run: clojure -T:build publish
+
+      - name: Harvest
+        run: node scripts/harvest_candidates.js --out public/app/daily_candidates.jsonl
+
+      - name: Score
+        run: node scripts/score_candidates.js --in public/app/daily_candidates.jsonl --out public/app/daily_candidates_scored.jsonl
+
+      - name: Enrich (media/start if any)
+        run: node scripts/enrich_media_start.js --in public/app/daily_candidates_scored.jsonl --out public/app/daily_candidates_scored_enriched.jsonl
+
+      - name: Heuristics v1 (clip start)
+        run: node scripts/clip_start_heuristics_v1.mjs --in public/app/daily_candidates_scored_enriched.jsonl --out public/app/daily_candidates_scored_enriched_start.jsonl
+
+      - name: Generate daily (draft)
+        run: |
+          if [ -z "${{ inputs.date }}" ]; then
+            DATE=$(TZ=Asia/Tokyo date +%F)
+          else
+            DATE="${{ inputs.date }}"
+          fi
+          node scripts/generate_daily_from_candidates.js --in public/app/daily_candidates_scored_enriched_start.jsonl --date "$DATE"
+
+      - name: Validate authoring
+        run: node scripts/validate_authoring.js
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: authoring-heuristics-${{ github.run_id }}
+          path: |
+            public/app/daily_candidates.jsonl
+            public/app/daily_candidates_scored.jsonl
+            public/app/daily_candidates_scored_enriched.jsonl
+            public/app/daily_candidates_scored_enriched_start.jsonl
+            public/app/daily_auto.json

--- a/docs/CLIP_START_HEURISTICS.md
+++ b/docs/CLIP_START_HEURISTICS.md
@@ -1,0 +1,60 @@
+# Clip Start Heuristics v1
+
+v1.7 で導入する **開始秒の自動推定** の最小ルールです。誤爆を避けるため、既存の `clip.start` がある場合は **既定では上書きしません**（`--force` のみ上書き）。
+
+## 目的
+- 埋め込み再生のみ（YouTube / Apple）という方針を守りつつ、**開始位置のばらつき**を減らす
+- 完全自動運転の前段として **再現性のある単純ルール** を固定化
+
+## ルール（優先順）
+1. **既存 start を尊重**（`--force` がない限り維持）
+2. **キーワードによる推定**
+   - Opening/Prologue/Title/Main Theme/「序曲」「オープニング」「タイトル」→ `0`
+   - Boss/Battle/Stage/Zone/Act/Level/Field/Dungeon/VS/「戦」「ボス」「ステージ」→ `12`
+   - Ending/Credits/Staff Roll/「エンディング」「スタッフロール」→ `20`
+3. **プロバイダ既定**
+   - Apple → `15`
+   - YouTube → `10`
+4. 上記に当たらない場合は **既定 `45`**
+
+> すべて `0 <= start <= 120` に clamp。`clip.duration` は未設定なら `15` を補います（UI側の上限 60 を尊重）。
+
+## CLI
+```bash
+node scripts/clip_start_heuristics_v1.mjs \
+  --in public/app/daily_candidates_scored_enriched.jsonl \
+  --out public/app/daily_candidates_scored_enriched_start.jsonl \
+  --default 45 --max 120
+```
+
+オプション:
+- `--force`  … 既存の `clip.start` を上書き
+- `--default` … マッチしなかったときの既定（既定 45）
+- `--max` … 上限 clamp（既定 120）
+
+## パイプラインへの組み込み
+`enrich_media_start.js` 後、`generate_daily_from_candidates.js` の前に 1 ステップ追加します。
+
+```bash
+node scripts/harvest_candidates.js --out public/app/daily_candidates.jsonl
+node scripts/score_candidates.js --in public/app/daily_candidates.jsonl --out public/app/daily_candidates_scored.jsonl
+node scripts/enrich_media_start.js --in public/app/daily_candidates_scored.jsonl --out public/app/daily_candidates_scored_enriched.jsonl
+node scripts/clip_start_heuristics_v1.mjs \
+  --in public/app/daily_candidates_scored_enriched.jsonl \
+  --out public/app/daily_candidates_scored_enriched_start.jsonl
+node scripts/generate_daily_from_candidates.js \
+  --in public/app/daily_candidates_scored_enriched_start.jsonl \
+  --date $(TZ=Asia/Tokyo date +%F)
+```
+
+## テストの観点（最小）
+- `Opening` を含むと `0` になる
+- `Boss` を含むと `12` になる
+- `Ending` を含むと `20` になる
+- `apple` で `15` / `youtube` で `10` になる
+- 既存 `clip.start=7` がある場合は上書きしない（`--force` でのみ上書き）
+
+## 将来拡張（v2+）
+- 音響解析（無音検出・ピーク・ビート）と組み合わせた補正
+- プレイリスト/動画内のチャプターメタからの抽出
+- QA からのフィードバックループ（bad start の学習）

--- a/scripts/clip_start_heuristics_v1.mjs
+++ b/scripts/clip_start_heuristics_v1.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * clip_start_heuristics_v1.mjs
+ * 最小ルールベースの開始秒推定。
+ *
+ * 入力:  JSONL（1行=1候補）
+ *   - 期待フィールド（存在すれば利用）: title, track.name, game.name, clip{provider,id,start,duration}
+ * 出力:  JSONL（clip.start が無い/auto の場合に限り推定して付与。--force で上書き）
+ *
+ * ルール（優先順）:
+ *  1) 既存 start が数値なら尊重（--force がない限り上書きしない）
+ *  2) タイトル/トラック名のキーワード:
+ *     - "Opening","Prologue","Title","Main Theme","序曲","オープニング","タイトル" → 0
+ *     - "Boss","Battle","Stage","Zone","Act","Level","Field","Dungeon","VS","戦","ボス","ステージ" → 12
+ *     - "Ending","Credits","Staff Roll","エンディング","スタッフロール","スタッフ ロール" → 20
+ *  3) プロバイダ特性:
+ *     - apple: プレビュー想定で 15 を既定候補（短い導入を避ける）
+ *     - youtube: 10 を既定候補
+ *  4) 何も当たらなければ defaultStart（既定=45）
+ *
+ * 制約:
+ *  - 出力 start は 0 <= start <= maxStart（既定=120）に clamp。
+ *  - duration が存在すれば 1 <= duration <= 60 を尊重（変更しない）。
+ *
+ * 使い方:
+ *  node scripts/clip_start_heuristics_v1.mjs --in input.jsonl --out output.jsonl [--default 45] [--max 120] [--force]
+ */
+import fs from 'node:fs';
+import readline from 'node:readline';
+function parseArgs(argv) {
+  const args = { default: 45, max: 120, force: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--in') args.in = argv[++i];
+    else if (a === '--out') args.out = argv[++i];
+    else if (a === '--default') args.default = Number(argv[++i]);
+    else if (a === '--max') args.max = Number(argv[++i]);
+    else if (a === '--force') args.force = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+function usage() {
+  console.log(`Usage:
+  node scripts/clip_start_heuristics_v1.mjs --in input.jsonl --out output.jsonl [--default 45] [--max 120] [--force]
+`);
+}
+const args = parseArgs(process.argv);
+if (args.help || !args.in || !args.out) {
+  usage();
+  process.exit(args.help ? 0 : 1);
+}
+function clamp(n, lo, hi) {
+  return Math.max(lo, Math.min(hi, n));
+}
+function hasNumericStart(clip) {
+  return clip && typeof clip.start === 'number' && Number.isFinite(clip.start);
+}
+function textOf(entry) {
+  const parts = [];
+  if (entry?.title) parts.push(String(entry.title));
+  if (entry?.track?.name) parts.push(String(entry.track.name));
+  if (entry?.game?.name) parts.push(String(entry.game.name));
+  return parts.join(' • ').toLowerCase();
+}
+function keywordStart(text) {
+  // 先に「冒頭系」
+  const opening = /(opening|prologue|title|main\s*theme|序曲|ｵｰﾌﾟﾆﾝｸﾞ|オープニング|タイトル)/i;
+  if (opening.test(text)) return 0;
+  // 次に「ボス/戦闘/面」
+  const battle = /(boss|battle|stage|zone|act|level|field|dungeon|\bvs\b|戦|ボス|ステージ)/i;
+  if (battle.test(text)) return 12;
+  // 末尾系
+  const ending = /(ending|credits|staff\s*roll|エンディング|スタッフ.?ロール)/i;
+  if (ending.test(text)) return 20;
+  return null;
+}
+function providerDefault(provider) {
+  if (!provider) return null;
+  const p = String(provider).toLowerCase();
+  if (p.includes('apple')) return 15;
+  if (p.includes('youtube')) return 10;
+  return null;
+}
+function guessStart(entry, { defaultStart = 45, maxStart = 120 } = {}) {
+  const t = textOf(entry);
+  const k = keywordStart(t);
+  if (k != null) return clamp(k, 0, maxStart);
+  const p = providerDefault(entry?.clip?.provider);
+  if (p != null) return clamp(p, 0, maxStart);
+  return clamp(defaultStart, 0, maxStart);
+}
+async function run(inputPath, outputPath, { defaultStart, max, force }) {
+  const rl = readline.createInterface({
+    input: fs.createReadStream(inputPath, { encoding: 'utf8' }),
+    crlfDelay: Infinity,
+  });
+  const out = fs.createWriteStream(outputPath, { encoding: 'utf8' });
+  let total = 0;
+  let updated = 0;
+  for await (const line of rl) {
+    if (!line.trim()) { out.write('\n'); continue; }
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch (e) {
+      console.error('[WARN] skip invalid JSON line');
+      continue;
+    }
+    total++;
+    obj.clip = obj.clip || {};
+    const hadNumeric = hasNumericStart(obj.clip);
+    if (!hadNumeric || force) {
+      const s = guessStart(obj, { defaultStart, maxStart: max });
+      if (!Number.isFinite(obj.clip.duration)) {
+        // duration 未設定なら最小安全値 15 をセット（UI側で上限60を尊重）
+        obj.clip.duration = 15;
+      }
+      obj.clip.start = s;
+      updated++;
+    }
+    out.write(JSON.stringify(obj) + '\n');
+  }
+  out.end();
+  console.log(`[heuristics] total=${total} updated=${updated} default=${defaultStart} max=${max} force=${force}`);
+}
+run(args.in, args.out, { defaultStart: args.default, max: args.max, force: args.force }).catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add clip_start_heuristics_v1.mjs to estimate clip start times from keywords and provider defaults
- document heuristics and pipeline integration
- add authoring-heuristics smoke workflow to validate the new step

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*
- `node scripts/clip_start_heuristics_v1.mjs --in /tmp/in.jsonl --out /tmp/out.jsonl`

------
https://chatgpt.com/codex/tasks/task_e_68b9eda3d420832485b0ef0e8f3e1657