### PR TITLE
Use latest Clojure CLI in authoring smoke workflow

### DIFF
--- a/.github/workflows/authoring-heuristics-smoke.yml
+++ b/.github/workflows/authoring-heuristics-smoke.yml
@@ -21,9 +21,11 @@ jobs:
           java-version: '21'
 
       - name: Setup Clojure CLI
-        uses: DeLaGuardo/setup-clojure@12
+        uses: DeLaGuardo/setup-clojure@13.4
         with:
-          cli: 1.11.1.1439
+          # Use the latest stable Clojure CLI per action docs
+          # https://github.com/DeLaGuardo/setup-clojure
+          cli: latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- use the latest setup-clojure action and CLI for the authoring smoke workflow

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f19b2a048324b1fd48c7f0b53f98