### PR TITLE
Add distractor post-processing script and docs

### DIFF
--- a/.github/workflows/authoring-heuristics-smoke.yml
+++ b/.github/workflows/authoring-heuristics-smoke.yml
@@ -56,6 +56,15 @@ jobs:
           fi
           node scripts/generate_daily_from_candidates.js --in public/app/daily_candidates_scored_enriched_start.jsonl --date "$DATE"
 
+      - name: Distractors v1 (post-process)
+        run: |
+          if [ -z "${{ inputs.date }}" ]; then
+            DATE=$(TZ=Asia/Tokyo date +%F)
+          else
+            DATE="${{ inputs.date }}"
+          fi
+          node scripts/distractors_v1_post.mjs --in public/app/daily_auto.json --date "$DATE"
+
       - name: Validate authoring
         run: node scripts/validate_authoring.js
 

--- a/docs/DISTRACTORS_V1.md
+++ b/docs/DISTRACTORS_V1.md
@@ -1,0 +1,54 @@
+# Distractors v1（誤答生成の最小ルール）
+
+v1.7 の **4択肢** を安定供給するための最小実装。`daily_auto.json` 生成後に **当日分だけ** post-process して、`items[*].choices` を補完/強化する。
+
+## 目的
+- 候補が少ない日でも **4択を埋める**（正解＋誤答3）
+- **似すぎ/遠すぎ**を避けるためのシンプルなスコアリング
+- 既存生成物に干渉しない（不足時のみ補う／`--force` で再生成）
+
+## 生成ルール（MVP）
+- 正解: `answers.canonical`
+- 候補プール: `daily_auto.by_date[*].items[*].answers.canonical`（全期間横断）
+- スコア:
+  - +2: 同作曲者（`track.composer` 一致）
+  - +1: 同シリーズ/同ゲーム（`game.series` or `game.name` 部分一致）
+  - +0.5: 年が近い（`|year - year'| <= 2`）
+- 3件に満たなければランダム補完（重複/正解除外）
+
+## 使い方
+```bash
+node scripts/distractors_v1_post.mjs \
+  --in public/app/daily_auto.json \
+  --date $(TZ=Asia/Tokyo date +%F)
+```
+
+オプション:
+- `--out`: 別ファイルへ書き出す（省略時は上書き）
+- `--force`: 既に choices があっても再生成
+
+## パイプラインへの挿入位置（例）
+```bash
+# 生成までは従来どおり
+node scripts/generate_daily_from_candidates.js \
+  --in public/app/daily_candidates_scored_enriched_start.jsonl \
+  --date $(TZ=Asia/Tokyo date +%F)
+
+# 生成後に当日分だけ choices を補完
+node scripts/distractors_v1_post.mjs \
+  --in public/app/daily_auto.json \
+  --date $(TZ=Asia/Tokyo date +%F)
+
+# その後にバリデーション
+node scripts/validate_authoring.js
+```
+
+## 品質と制約
+- `choices` は **正解を必ず含む4件**（ユニーク）
+- 既存 `choices` が十分（4件かつ正解含む）なら触らない（`--force` を除く）
+- 似すぎの抑制は簡易（v1）。将来は多様性ペナルティや重複防止を強化
+
+## 将来拡張（v2+）
+- 問いの種類別（曲名当て/ゲーム当て/作曲者当て）で候補集合と類似度指標を切替
+- 別名・表記揺れ（ローマ数字/長音/CJK空白）に基づく **近似誤答** の統制
+- 候補の豊富化（許可リスト拡張・seed拡充・近似/関連度の学習化）

--- a/scripts/distractors_v1_post.mjs
+++ b/scripts/distractors_v1_post.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * distractors_v1_post.mjs
+ * daily_auto.json 生成後に、当日分の items[*].choices を補完/強化する軽量ポストプロセッサ。
+ *
+ * 入力:  --in  public/app/daily_auto.json
+ *        --date YYYY-MM-DD (JST基準。未指定なら今日)
+ * 出力:  上書き保存（--out 指定時は別ファイルへ）
+ *
+ * 方針（MVP）:
+ *  - 正解: item.answers.canonical を採用
+ *  - 候補プール: daily_auto.by_date[*].items の answers.canonical を横断収集
+ *  - スコアリング（高い順に採用）:
+ *      +2: 同作曲者（track.composer が一致）
+ *      +1: 同シリーズ/同ゲーム（game.series または game.name が部分一致）
+ *     +0.5: 年が近い（|year - year'| <= 2）
+ *  - 3件に満たない場合はランダム補完（重複・同値・正解は除外）
+ *  - 既に choices が十分揃っている場合は変更しない（--force で再生成）
+ *
+ * 制約・守ること:
+ *  - choices 内に正解（canonical）を必ず含める
+ *  - choices はユニーク 4 件を目標（重複を除去）
+ *  - 既存の item 構造は壊さない（choices のみ変更）
+ */
+
+import fs from 'node:fs/promises';
+
+function todayJST() {
+  const now = new Date();
+  const tz = 'Asia/Tokyo';
+  const z = new Intl.DateTimeFormat('en-CA', { timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit' })
+    .formatToParts(now)
+    .reduce((o, p) => (o[p.type] = p.value, o), {});
+  return `${z.year}-${z.month}-${z.day}`;
+}
+
+function parseArgs(argv) {
+  const a = { force: false };
+  for (let i = 2; i < argv.length; i++) {
+    const t = argv[i];
+    if (t === '--in') a.in = argv[++i];
+    else if (t === '--out') a.out = argv[++i];
+    else if (t === '--date') a.date = argv[++i];
+    else if (t === '--force') a.force = true;
+  }
+  if (!a.in) throw new Error('missing --in <daily_auto.json>');
+  if (!a.date) a.date = todayJST();
+  return a;
+}
+
+function norm(s) {
+  return String(s || '').trim().toLowerCase();
+}
+
+function uniq(arr) {
+  return [...new Set(arr)];
+}
+
+function sample(arr, k, rng=Math.random) {
+  const a = arr.slice();
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a.slice(0, k);
+}
+
+function pickDistractors(target, pool, k = 3) {
+  const correct = norm(target.answers?.canonical);
+  const series = norm(target.game?.series || target.game?.name);
+  const composer = norm(target.track?.composer);
+  const year = Number(target.game?.year) || null;
+
+  const scored = [];
+  for (const cand of pool) {
+    const ans = norm(cand.answers?.canonical);
+    if (!ans || ans === correct) continue;
+
+    let score = 0;
+    const c_series = norm(cand.game?.series || cand.game?.name);
+    const c_composer = norm(cand.track?.composer);
+    const c_year = Number(cand.game?.year) || null;
+
+    if (composer && c_composer && composer === c_composer) score += 2;
+    if (series && c_series && (series === c_series || c_series.includes(series) || series.includes(c_series))) score += 1;
+    if (year != null && c_year != null && Math.abs(year - c_year) <= 2) score += 0.5;
+
+    scored.push({ cand, score, ans });
+  }
+
+  // スコア降順 → 同点はランダム
+  scored.sort((a, b) => b.score - a.score || (Math.random() - 0.5));
+
+  const picked = [];
+  const seen = new Set([correct]);
+  for (const s of scored) {
+    if (picked.length >= k) break;
+    if (seen.has(s.ans)) continue;
+    seen.add(s.ans);
+    picked.push(s.cand.answers.canonical);
+  }
+
+  // 不足分はランダムに補完
+  if (picked.length < k) {
+    const remain = uniq(pool.map(c => c.answers?.canonical).filter(Boolean))
+      .filter(a => !seen.has(norm(a)));
+    picked.push(...sample(remain, k - picked.length));
+  }
+
+  return uniq(picked).slice(0, k);
+}
+
+async function run() {
+  const args = parseArgs(process.argv);
+  const raw = await fs.readFile(args.in, 'utf8');
+  const json = JSON.parse(raw);
+  const by = json.by_date || [];
+
+  // プール作成（全期間から抽出）
+  const pool = [];
+  for (const d of by) {
+    for (const it of d.items || []) {
+      if (it?.answers?.canonical) pool.push(it);
+    }
+  }
+
+  const target = by.find(d => d.date === args.date);
+  if (!target) {
+    console.warn(`[warn] by_date has no ${args.date}; nothing to do.`);
+  } else {
+    let touched = 0;
+    for (const item of target.items || []) {
+      const correct = item?.answers?.canonical;
+      if (!correct) continue;
+
+      const hasChoices = Array.isArray(item.choices) && item.choices.includes(correct) && item.choices.length >= 4;
+      if (hasChoices && !args.force) continue;
+
+      const ds = pickDistractors(item, pool, 3);
+      const choices = [correct, ...ds];
+      // シャッフル（安易に決め打ち順にならないよう）
+      for (let i = choices.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [choices[i], choices[j]] = [choices[j], choices[i]];
+      }
+      item.choices = uniq(choices).slice(0, 4);
+      // 念のため正解が含まれているか再確認
+      if (!item.choices.includes(correct)) {
+        item.choices[0] = correct;
+      }
+      touched++;
+    }
+    console.log(`[distractors] date=${args.date} items=${target.items?.length ?? 0} updated=${touched}`);
+  }
+
+  const outPath = args.out || args.in;
+  await fs.writeFile(outPath, JSON.stringify(json, null, 2), 'utf8');
+}
+
+run().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `distractors_v1_post.mjs` to fill in choices after daily generation
- document Distractors v1 rules and usage
- invoke post-processing step in authoring workflow

## Testing
- `node scripts/distractors_v1_post.mjs --in tmp/sample_daily.json --date 2024-05-01`
- `npm test` *(fails: `clojure: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f398375483249d5ec8a3443ebbe2