### PR TITLE
ci: use PAT for daily-auto extended PR

### DIFF
--- a/.github/workflows/daily-auto-extended.yml
+++ b/.github/workflows/daily-auto-extended.yml
@@ -106,6 +106,8 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
+          # Use PAT to ensure downstream PR workflows (required checks) are triggered
+          token: ${{ secrets.DAILY_PR_PAT }}
           add-paths: |
             public/app/daily_auto.json
           branch: ${{ inputs.pr_branch_prefix }}-${{ github.run_id }}


### PR DESCRIPTION
## Summary
- use PAT token when creating daily-auto-extended PR so downstream checks run

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3d7e39348324b162c4baf1a99f57