### PR TITLE
feat: normalize seed entries

### DIFF
--- a/docs/ALLOWLIST_SEED.md
+++ b/docs/ALLOWLIST_SEED.md
@@ -39,6 +39,9 @@ node scripts/merge_seed_candidates.mjs \
 node scripts/score_candidates.js --in public/app/daily_candidates_merged.jsonl --out public/app/daily_candidates_scored.jsonl
 ```
 
+> 補足: `merge_seed_candidates.mjs` は seed 行に **最小限の `norm` フィールド**（composer/series/game/title/answer）を自動付与します。  
+> 既存の `harvest` 生成物と同等のインターフェースになるため、下流の `score_candidates.js` / `pipeline/difficulty.js` が安全に処理できます。
+
 ## 重複判定
 - 正規化した `provider|id|answers.canonical` をキーに一意化
 - 正規化は **小文字化・空白圧縮・ダッシュ統一・波チルダ統一** の軽量版（詳細はコード参照）

--- a/scripts/merge_seed_candidates.mjs
+++ b/scripts/merge_seed_candidates.mjs
@@ -51,7 +51,7 @@ function readJsonl(path) {
   return arr;
 }
 
-function norm(s) {
+function normText(s) {
   return String(s || '')
     .toLowerCase()
     .replace(/\s+/g, ' ')
@@ -64,7 +64,28 @@ function keyOf(entry) {
   const p = entry?.clip?.provider || entry?.provider;
   const id = entry?.clip?.id || entry?.id;
   const ans = entry?.answers?.canonical || entry?.title || entry?.track?.name;
-  return `${norm(p)}|${norm(id)}|${norm(ans)}`;
+  return `${normText(p)}|${normText(id)}|${normText(ans)}`;
+}
+
+function ensureNorm(entry) {
+  // 下流(score/difficulty)が参照する最小限の正規化フィールドを補う
+  entry.norm = entry.norm || {};
+  const composer = entry?.track?.composer;
+  const series = entry?.game?.series;
+  const game = entry?.game?.name;
+  const title = entry?.title || entry?.track?.name || entry?.game?.name;
+  const answer = entry?.answers?.canonical;
+
+  if (!entry.norm.composer) entry.norm.composer = normText(composer);
+  if (!entry.norm.series) entry.norm.series = normText(series || game);
+  if (!entry.norm.game) entry.norm.game = normText(game);
+  if (!entry.norm.title) entry.norm.title = normText(title);
+  if (!entry.norm.answer) entry.norm.answer = normText(answer);
+
+  // 念のため clip.provider も正規化の別名を置いておく（使われることがあるため）
+  if (!entry.norm.provider) entry.norm.provider = normText(entry?.clip?.provider || entry?.provider);
+
+  return entry;
 }
 
 function allowFilter(entry, allow) {
@@ -111,6 +132,7 @@ function run() {
   let added = 0, skipped = 0;
   for (const s of seeds) {
     if (!allowFilter(s, allow)) { skipped++; continue; }
+    ensureNorm(s);
     const k = keyOf(s);
     if (seen.has(k)) { skipped++; continue; }
     base.push(s);


### PR DESCRIPTION
## Summary
- enrich seed merge script with norm field injection
- document automatic norm field addition for seed candidates

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4db02d448324b7e60a2d661e13f2