### PR TITLE
Refactor daily postprocess scripts for flattened entries

### DIFF
--- a/scripts/difficulty_v1_post.mjs
+++ b/scripts/difficulty_v1_post.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * difficulty_v1_post.mjs
- * daily_auto.json 生成後に、当日分 items[*].difficulty を 0.0..1.0 で補完する軽量ポストプロセッサ。
+ * daily_auto.json 生成後に、当日分 difficulty を 0.0..1.0 で補完する軽量ポストプロセッサ。
  *
  * 入力:  --in  public/app/daily_auto.json
  *        --date YYYY-MM-DD (JST基準。未指定なら今日)
@@ -48,38 +48,37 @@ function parseArgs(argv) {
 function clamp(x, lo=0, hi=1) { return Math.max(lo, Math.min(hi, x)); }
 function norm(s) { return String(s || '').trim().toLowerCase(); }
 
-function normalizeByDate(by_date) {
-  if (Array.isArray(by_date)) {
-    return by_date
-      .map((d) => {
-        if (d && typeof d === 'object' && 'date' in d) return d;
-        if (typeof d === 'string') return { date: d, items: [] };
-        return d;
-      })
-      .filter(Boolean);
+function getEntries(by_date){
+  if (Array.isArray(by_date)){
+    return by_date.map(d => {
+      if (d && typeof d === 'object' && 'date' in d){
+        const entry = Array.isArray(d.items) ? d.items[0] : d;
+        return { date: d.date, entry };
+      }
+      return null;
+    }).filter(Boolean);
   }
-  if (by_date && typeof by_date === 'object') {
+  if (by_date && typeof by_date === 'object'){
     return Object.entries(by_date).map(([date, v]) => {
-      const items = Array.isArray(v?.items) ? v.items : Array.isArray(v) ? v : [];
-      return { date, items };
+      const entry = Array.isArray(v?.items) ? v.items[0] : v;
+      return { date, entry };
     });
   }
   return [];
 }
 
-function buildFrequencies(by) {
+function buildFrequencies(entries) {
   const composer = new Map();
   const series = new Map();
   const game = new Map();
-  for (const d of by) {
-    for (const it of d.items || []) {
-      const c = norm(it.track?.composer);
-      const s = norm(it.game?.series || it.game?.name);
-      const g = norm(it.game?.name);
-      if (c) composer.set(c, (composer.get(c) || 0) + 1);
-      if (s) series.set(s, (series.get(s) || 0) + 1);
-      if (g) game.set(g, (game.get(g) || 0) + 1);
-    }
+  for (const d of entries) {
+    const it = d.entry;
+    const c = norm(it?.track?.composer || it?.composer);
+    const s = norm(it?.game?.series || it?.game?.name || it?.game);
+    const g = norm(it?.game?.name || it?.game);
+    if (c) composer.set(c, (composer.get(c) || 0) + 1);
+    if (s) series.set(s, (series.get(s) || 0) + 1);
+    if (g) game.set(g, (game.get(g) || 0) + 1);
   }
   return { composer, series, game };
 }
@@ -111,22 +110,26 @@ async function run() {
   const args = parseArgs(process.argv);
   const raw = await fs.readFile(args.in, 'utf8');
   const json = JSON.parse(raw);
-  const by = normalizeByDate(json.by_date);
+  const entries = getEntries(json.by_date);
 
-  const freqs = buildFrequencies(by);
+  const freqs = buildFrequencies(entries);
 
-  const target = by.find(d => String(d.date) === String(args.date));
+  const target = entries.find(d => String(d.date) === String(args.date));
   if (!target) {
     console.warn(`[warn] by_date has no ${args.date}; nothing to do.`);
   } else {
-    let touched = 0;
-    for (const item of target.items || []) {
-      const hasNumeric = typeof item.difficulty === 'number' && isFinite(item.difficulty);
-      if (hasNumeric && !args.force) continue;
+    const item = target.entry || {};
+    const hasNumeric = typeof item.difficulty === 'number' && isFinite(item.difficulty);
+    if (!hasNumeric || args.force){
       item.difficulty = scoreDifficulty(item, freqs);
-      touched++;
+      console.log(`[difficulty] date=${args.date} difficulty=${item.difficulty.toFixed(2)}`);
     }
-    console.log(`[difficulty] date=${args.date} items=${target.items?.length ?? 0} updated=${touched}`);
+    // write back flat
+    if (json.by_date && typeof json.by_date === 'object' && !Array.isArray(json.by_date)){
+      json.by_date[String(args.date)] = item;
+    } else {
+      json.by_date = { [String(args.date)]: item };
+    }
   }
 
   const outPath = args.out || args.in;

--- a/scripts/distractors_v1_post.mjs
+++ b/scripts/distractors_v1_post.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * distractors_v1_post.mjs
- * daily_auto.json 生成後に、当日分の items[*].choices を補完/強化する軽量ポストプロセッサ。
+ * daily_auto.json 生成後に、当日分の choices を補完/強化する軽量ポストプロセッサ。
  *
  * 入力:  --in  public/app/daily_auto.json
  *        --date YYYY-MM-DD (JST基準。未指定なら今日)
@@ -9,12 +9,11 @@
  *
  * 方針（MVP）:
  *  - 正解: item.answers.canonical を採用
- *  - 候補プール: daily_auto.by_date[*].items の answers.canonical を横断収集
+ *  - 候補プール: daily_auto.by_date の answers.canonical を横断収集
  *  - スコアリング（高い順に採用）:
  *      +2: 同作曲者（track.composer が一致）
  *      +1: 同シリーズ/同ゲーム（game.series または game.name が部分一致）
  *     +0.5: 年が近い（|year - year'| <= 2）
- *  - 3件に満たない場合はランダム補完（重複・同値・正解は除外）
  *  - 既に choices が十分揃っている場合は変更しない（--force で再生成）
  *
  * 制約・守ること:
@@ -52,81 +51,46 @@ function norm(s) {
   return String(s || '').trim().toLowerCase();
 }
 
-function uniq(arr) {
-  return [...new Set(arr)];
-}
-
-function sample(arr, k, rng=Math.random) {
-  const a = arr.slice();
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1));
-    [a[i], a[j]] = [a[j], a[i]];
-  }
-  return a.slice(0, k);
-}
+function uniq(arr){ return Array.from(new Set(arr)); }
 
 function pickDistractors(target, pool, k = 3) {
-  const correct = norm(target.answers?.canonical);
-  const series = norm(target.game?.series || target.game?.name);
-  const composer = norm(target.track?.composer);
-  const year = Number(target.game?.year) || null;
-
-  const scored = [];
-  for (const cand of pool) {
-    const ans = norm(cand.answers?.canonical);
-    if (!ans || ans === correct) continue;
-
+  const canonical = target?.answers?.canonical || target?.answers;
+  if (!canonical) return [];
+  const base = [];
+  const c = norm(target?.track?.composer || target?.composer);
+  const s = norm(target?.game?.series || target?.game?.name || target?.game);
+  const y = Number(target?.game?.year);
+  for (const it of pool) {
+    const ci = norm(it?.track?.composer || it?.composer);
+    const si = norm(it?.game?.series || it?.game?.name || it?.game);
+    const yi = Number(it?.game?.year);
     let score = 0;
-    const c_series = norm(cand.game?.series || cand.game?.name);
-    const c_composer = norm(cand.track?.composer);
-    const c_year = Number(cand.game?.year) || null;
-
-    if (composer && c_composer && composer === c_composer) score += 2;
-    if (series && c_series && (series === c_series || c_series.includes(series) || series.includes(c_series))) score += 1;
-    if (year != null && c_year != null && Math.abs(year - c_year) <= 2) score += 0.5;
-
-    scored.push({ cand, score, ans });
+    if (ci && c && ci === c) score += 2;
+    if (si && s && si === s) score += 1;
+    if (Number.isFinite(yi) && Number.isFinite(y) && Math.abs(yi - y) <= 2) score += 0.5;
+    base.push([score, it?.answers?.canonical, it]);
   }
-
-  // スコア降順 → 同点はランダム
-  scored.sort((a, b) => b.score - a.score || (Math.random() - 0.5));
-
-  const picked = [];
-  const seen = new Set([correct]);
-  for (const s of scored) {
-    if (picked.length >= k) break;
-    if (seen.has(s.ans)) continue;
-    seen.add(s.ans);
-    picked.push(s.cand.answers.canonical);
-  }
-
-  // 不足分はランダムに補完
-  if (picked.length < k) {
-    const remain = uniq(pool.map(c => c.answers?.canonical).filter(Boolean))
-      .filter(a => !seen.has(norm(a)));
-    picked.push(...sample(remain, k - picked.length));
-  }
-
+  base.sort((a,b)=>b[0]-a[0]);
+  const picked = base.map(e=>e[1]).filter(x=>x && x!==canonical);
   return uniq(picked).slice(0, k);
 }
 
-function normalizeByDate(by_date) {
-  // 受け取り形に幅があるため、配列[{date, items}] に正規化する
-  if (Array.isArray(by_date)) {
-    // 既に [{date, items}] 形式想定
-    return by_date
-      .map((d) => {
-        if (d && typeof d === 'object' && 'date' in d) return d;
-        if (typeof d === 'string') return { date: d, items: [] };
-        return d;
-      })
-      .filter(Boolean);
+function getEntries(by_date){
+  // Normalize by_date into array of {date, entry}
+  if (Array.isArray(by_date)){
+    // Accept [{date, items:[...] }] or [{date, ...flat...}]
+    return by_date.map(d => {
+      if (d && typeof d === 'object' && 'date' in d){
+        const entry = Array.isArray(d.items) ? d.items[0] : d;
+        return { date: d.date, entry };
+      }
+      return null;
+    }).filter(Boolean);
   }
-  if (by_date && typeof by_date === 'object') {
-    // { "YYYY-MM-DD": {items:[...]}, ... } あるいは { "YYYY-MM-DD": [...] }
+  if (by_date && typeof by_date === 'object'){
     return Object.entries(by_date).map(([date, v]) => {
-      const items = Array.isArray(v?.items) ? v.items : Array.isArray(v) ? v : [];
-      return { date, items };
+      const entry = Array.isArray(v?.items) ? v.items[0] : v;
+      return { date, entry };
     });
   }
   return [];
@@ -135,43 +99,37 @@ async function run() {
   const args = parseArgs(process.argv);
   const raw = await fs.readFile(args.in, 'utf8');
   const json = JSON.parse(raw);
-  const by = normalizeByDate(json.by_date);
+  const entries = getEntries(json.by_date);
 
   // プール作成（全期間から抽出）
   const pool = [];
-  for (const d of by) {
-    for (const it of d.items || []) {
-      if (it?.answers?.canonical) pool.push(it);
-    }
+  for (const d of entries) {
+    const it = d.entry;
+    if (it?.answers?.canonical || it?.answers) pool.push(it);
   }
 
-  const target = by.find(d => String(d.date) === String(args.date));
+  const target = entries.find(d => String(d.date) === String(args.date));
   if (!target) {
     console.warn(`[warn] by_date has no ${args.date}; nothing to do.`);
   } else {
-    let touched = 0;
-    for (const item of target.items || []) {
-      const correct = item?.answers?.canonical;
-      if (!correct) continue;
-
-      const hasChoices = Array.isArray(item.choices) && item.choices.includes(correct) && item.choices.length >= 4;
-      if (hasChoices && !args.force) continue;
-
-      const ds = pickDistractors(item, pool, 3);
-      const choices = [correct, ...ds];
-      // シャッフル（安易に決め打ち順にならないよう）
-      for (let i = choices.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [choices[i], choices[j]] = [choices[j], choices[i]];
-      }
-      item.choices = uniq(choices).slice(0, 4);
-      // 念のため正解が含まれているか再確認
-      if (!item.choices.includes(correct)) {
-        item.choices[0] = correct;
-      }
-      touched++;
+    const item = target.entry || {};
+    const correct = item?.answers?.canonical || item?.answers;
+    const ch = Array.isArray(item?.choices) ? item.choices : [];
+    const haveCorrect = correct && ch.includes(correct);
+    if (!haveCorrect || ch.length < 4) {
+      const need = Math.max(0, 4 - ch.length - (haveCorrect ? 0 : 1));
+      const picks = pickDistractors(item, pool, need + (haveCorrect ? 0 : 1));
+      const merged = haveCorrect ? ch.concat(picks).slice(0,4) : [correct, ...picks].slice(0,4);
+      item.choices = uniq(merged);
+      console.log(`[distractors] date=${args.date} updated choices -> ${JSON.stringify(item.choices)}`);
     }
-    console.log(`[distractors] date=${args.date} items=${target.items?.length ?? 0} updated=${touched}`);
+    // write back in flat shape under by_date
+    if (json.by_date && typeof json.by_date === 'object' && !Array.isArray(json.by_date)){
+      json.by_date[String(args.date)] = item;
+    } else {
+      // convert to object
+      json.by_date = { [String(args.date)]: item };
+    }
   }
 
   const outPath = args.out || args.in;

--- a/scripts/ensure_min_items_v1_post.mjs
+++ b/scripts/ensure_min_items_v1_post.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * ensure_min_items_v1_post.mjs
- * daily_auto.json の当日（または --date 指定日）の items が 0 件なら、
+ * daily_auto.json の当日（または --date 指定日）が空なら、
  * 候補 JSONL から最良の1件を構築して最低1件に補うポストプロセス。
  *
  * 目的: 収集が薄い日でも UI/PR が空にならないようにするための最後の砦（MVP）。
@@ -44,20 +44,25 @@ function hasRequiredFields(it) {
 }
 
 function pruneInvalidDates(list, keepDate) {
-  return list.filter(d => String(d.date) === String(keepDate) || (Array.isArray(d.items) && d.items.length > 0 && hasRequiredFields(d.items[0])));
+  return list.filter(d => String(d.date) === String(keepDate) || hasRequiredFields(d.entry));
 }
 
-function normalizeByDate(by_date) {
+function getEntries(by_date) {
   if (Array.isArray(by_date)) {
     return by_date
-      .map((d) => (d && typeof d === 'object' && 'date' in d) ? d
-        : (typeof d === 'string' ? { date: d, items: [] } : null))
+      .map((d) => {
+        if (d && typeof d === 'object' && 'date' in d) {
+          const entry = Array.isArray(d.items) ? d.items[0] : d;
+          return { date: d.date, entry };
+        }
+        return null;
+      })
       .filter(Boolean);
   }
   if (by_date && typeof by_date === 'object') {
     return Object.entries(by_date).map(([date, v]) => {
-      const items = Array.isArray(v?.items) ? v.items : Array.isArray(v) ? v : [];
-      return { date, items };
+      const entry = Array.isArray(v?.items) ? v.items[0] : v;
+      return { date, entry };
     });
   }
   return [];
@@ -157,7 +162,7 @@ async function run() {
   const raw = await fs.readFile(args.daily, 'utf8');
   const json = JSON.parse(raw);
   const originalByDate = json.by_date;
-  const by = normalizeByDate(originalByDate);
+  const by = getEntries(originalByDate);
   if (!by.length) {
     console.warn('[ensure_min_items] by_date is empty; nothing to do.');
     return;
@@ -166,11 +171,11 @@ async function run() {
   const targetDate = args.date || dates[dates.length - 1];
   let target = by.find(d => String(d.date) === String(targetDate));
   if (!target) {
-    target = { date: targetDate, items: [] };
+    target = { date: targetDate, entry: null };
     by.push(target);
   }
-  if ((target.items?.length || 0) >= 1) {
-    console.log(`[ensure_min_items] date=${targetDate} already has items=${target.items.length}, skip.`);
+  if (target.entry) {
+    console.log(`[ensure_min_items] date=${targetDate} already has entry, skip.`);
   } else {
     const candPath = pickCandidatesFile(args.candidates);
     const cands = readJsonl(candPath)
@@ -181,24 +186,18 @@ async function run() {
       console.warn(`[ensure_min_items] no suitable candidates found (checked: ${args.candidates.join(', ')})`);
     } else {
       const item = buildItem(best);
-      target.items = [item];
+      target.entry = item;
       console.log(`[ensure_min_items] date=${targetDate} injected 1 item from ${candPath}`);
     }
   }
 
-  // 不正エントリを prune（今回対象日以外で items が空 or 必須欠落のものは落とす）
-  const pruned = pruneInvalidDates(by, targetDate);
-  // 書き戻し（by_date の形状は元に合わせる: 配列で保存している前提）
-  // validator 互換のため、原則 `{ "YYYY-MM-DD": { items:[...] } }` 形に整えて保存する
-  function toObjectItems(arr) {
-    const obj = {};
-    for (const d of pruned) {
-      obj[d.date] = { items: d.items || [] };
-    }
-    return obj;
-  }
-  // 既存がオブジェクトだった場合はそれに合わせる。配列だった場合もオブジェクトに昇格させる（検証安定性のため）
-  json.by_date = toObjectItems(pruned);
+  // 不正エントリを prune（今回対象日以外で空/必須欠落のものは落とす）
+  const pruned = pruneInvalidDates(by, targetDate).reduce((acc, d) => {
+    if (d.entry) acc[d.date] = d.entry;
+    return acc;
+  }, {});
+  // validator 互換のため、**フラット形**で保存: { "YYYY-MM-DD": { title, game, composer, norm, ... } }
+  json.by_date = pruned;
   await fs.writeFile(args.daily, JSON.stringify(json, null, 2), 'utf8');
 }
 

--- a/scripts/validate_nonempty_today.mjs
+++ b/scripts/validate_nonempty_today.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * validate_nonempty_today.mjs
- * daily_auto.json の最新日（または --date 指定日）に items が 1 件以上あることを検証する。
+ * daily_auto.json の最新日（または --date 指定日）に **フラットな1件**が存在することを検証する。
  * 0 件の場合は exit 1。
  */
 
@@ -17,40 +17,29 @@ function parseArgs(argv) {
   return a;
 }
 
-function normalizeByDate(by_date) {
-  if (Array.isArray(by_date)) {
-    return by_date
-      .map((d) => (d && typeof d === 'object' && 'date' in d) ? d
-        : (typeof d === 'string' ? { date: d, items: [] } : null))
-      .filter(Boolean);
-  }
-  if (by_date && typeof by_date === 'object') {
-    return Object.entries(by_date).map(([date, v]) => {
-      const items = Array.isArray(v?.items) ? v.items : Array.isArray(v) ? v : [];
-      return { date, items };
-    });
-  }
-  return [];
+function hasRequiredFlat(v){
+  return v && typeof v==='object' && v.title && (v.game?.name || typeof v.game==='string') && (v.track?.composer || v.composer);
 }
 
 async function run() {
   const args = parseArgs(process.argv);
   const raw = await fs.readFile(args.in, 'utf8');
   const json = JSON.parse(raw);
-  const by = normalizeByDate(json.by_date);
-  if (!by.length) {
+  const entries = (json.by_date && typeof json.by_date==='object' && !Array.isArray(json.by_date))
+    ? Object.entries(json.by_date).map(([date,v])=>({date, v}))
+    : [];
+  if (!entries.length) {
     console.error('[validate_nonempty_today] by_date is empty');
     process.exit(1);
   }
-  const dates = by.map(d => d.date).sort();
+  const dates = entries.map(d => d.date).sort();
   const targetDate = args.date || dates[dates.length - 1];
-  const target = by.find(d => String(d.date) === String(targetDate));
-  const n = target?.items?.length || 0;
-  if (n < 1) {
-    console.error(`[validate_nonempty_today] date=${targetDate} has no items`);
+  const target = entries.find(d => String(d.date) === String(targetDate));
+  if (!hasRequiredFlat(target?.v)) {
+    console.error(`[validate_nonempty_today] date=${targetDate} missing required flat entry`);
     process.exit(1);
   }
-  console.log(`[validate_nonempty_today] date=${targetDate} items=${n} OK`);
+  console.log(`[validate_nonempty_today] date=${targetDate} flat entry OK`);
 }
 
 run().catch((e) => {


### PR DESCRIPTION
## Summary
- update distractor generation to operate on single flat daily entries
- compute difficulty scores for flat entries and persist results
- ensure daily files store minimum single entries and validate flat shape

## Testing
- `npm test` *(fails: clojure: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba71d0697883249a9bab0e76f4a292