### PR TITLE
feat: log numeric difficulty values

### DIFF
--- a/scripts/difficulty_v1_post.mjs
+++ b/scripts/difficulty_v1_post.mjs
@@ -136,7 +136,15 @@ async function run() {
       item.difficulty = scoreDifficulty(item, freqs);
       touched++;
     }
-    console.log(`[difficulty] date=${args.date} items=${target.items?.length ?? 0} updated=${touched}`);
+    // Log numeric values (array or flat shape)
+    try {
+      const vals = Array.isArray(target.items)
+        ? target.items.map(it => (typeof it.difficulty === 'number' ? it.difficulty : NaN)).filter(Number.isFinite).map(v => v.toFixed(2))
+        : (typeof target.entry?.difficulty === 'number' ? [target.entry.difficulty.toFixed(2)] : []);
+      console.log(`[difficulty] date=${args.date} values=[${vals.join(', ')}] updated=${touched}`);
+    } catch {
+      console.log(`[difficulty] date=${args.date} updated=${touched}`);
+    }
   }
 
   const outPath = args.out || args.in;


### PR DESCRIPTION
## Summary
- log numeric difficulty values in difficulty_v1_post.mjs

## Testing
- `npm test` (fails: clojure: not found)
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ba86fb594083249fa0f5f73ac55ded