### PR TITLE
Include difficulty in daily finalizer

### DIFF
--- a/scripts/finalize_daily_v1.mjs
+++ b/scripts/finalize_daily_v1.mjs
@@ -65,6 +65,7 @@ function ensureFlatFields(v){
     media: media ? { provider: media.provider, id: media.id, start: media.start, duration: media.duration } : null,
     answers: answersCanon ? { canonical: answersCanon } : undefined,
     choices: v.choices && Array.isArray(v.choices) ? v.choices : v.choices, // keep as-is if already set (array or object)
+    difficulty: (typeof v.difficulty === 'number' && isFinite(v.difficulty)) ? v.difficulty : v.difficulty
   };
   // Norm pack
   out.norm = {


### PR DESCRIPTION
## Summary
- propagate numeric difficulty metadata in finalize_daily_v1

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8933285c832480340dbb8f3fbfdb