### PR TITLE
docs: record v1.7 authoring automation

### DIFF
--- a/docs/FEATURES.yml
+++ b/docs/FEATURES.yml
@@ -84,13 +84,13 @@
 - id: i18n-core
   title: Internationalization baseline (JP/EN)
   area: i18n
-  status: planned
+  status: implemented
+  since: v1.6
   milestone: v1.6
   description: |
     Key-based UI messages, locale negotiation (?lang, localStorage, navigator.language),
     Start view language toggle, localized html lang/title/meta, a11y labels, and a light E2E.
   labels: [i18n, ui, a11y]
-
 
 - id: auto-on-toast
   area: ui
@@ -126,8 +126,8 @@
 - id: auto-authoring-v1
   area: pipeline
   title: End-to-end nightly authoring (candidates→publish)
-  status: planned
-  since: null
+  status: implemented
+  since: 2025-09-05
   milestone: v1.7
 - id: daily-rss-feed
   area: ops

--- a/docs/OPERATIONS_AUTHORING.md
+++ b/docs/OPERATIONS_AUTHORING.md
@@ -37,3 +37,10 @@
 - `sources/allowlist.json`：チャンネル/パブリッシャの拡充（任意）
 - `sources/seed_candidates.jsonl`：安全な候補（`provider:auto` も可）を数件ずつ追加
 
+## 7. 日次チェックリスト（軽監視）
+- `build/daily_today.json/.md` の当日 1 件を確認（**choices** が 1 or 4、欠損がない）
+- **difficulty** が `0.00–1.00` の範囲に収まっている
+- **media.provider / media.id** が存在（`?provider=auto&test=1&mock=1&autostart=1` で埋め込み可）
+- **answers.canonical** が正規化済み
+- Actions ログに `[difficulty] date=… values=[…]` の数値出力がある
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,6 +19,7 @@
 | v1.4 | **Done (2025-09-04)** | A11y最小セット（live region/roles/labels/`aria-describedby`）＋ダイアログのフォーカストラップ/復帰＋背景 inert + scroll lock＋a11y static checker（static smoke） | — |
 | v1.5 | **Done (2025-09-04)** | UI/Responsive polish（トークン/44px/2→3→4列/微トランジション/ライト調整/E2E緑） | — |
 | v1.6 | **Done (2025-09-05)** | i18nベースライン（UI文言辞書/言語選択/`<html lang>` 等） | — |
+| v1.7 | **Done (2025-09-05)** | Authoring Automation（MVP：Finalize→Validate→Export(slim)、Auto-merge 到達） | — |
 
 ## 現状 (v1.0.x Stabilization) — 完了/運用中
 - キーボード操作（Tab/Enter/Space の基本操作）: **実装済み（Baseline）**

--- a/docs/V1_7_STATUS.md
+++ b/docs/V1_7_STATUS.md
@@ -11,8 +11,9 @@
   - `export_today_slim.mjs`（検収用アーティファクト）
 - **Artifacts**: `build/daily_today.json`, `build/daily_today.md`
 
-## Known follow-ups (v1.7.1)
-- 選択肢の多様性（シリーズ/作曲者の過密回避）
-- 出現頻度に基づく緩やかな難易度スケーリング
-- seed/allowlist の少量拡充
+## v1.7.1 — Applied (2025-09-05)
+- 選択肢の多様性：同シリーズ/同作曲者への過密を**軽く抑制**（不足時は緩和して充足）
+- 難易度の緩スケーリング：**出現頻度**に基づく微調整＋**端貼り防止マージン**
+- ログ可観測性：`[difficulty] date=… values=[0.xx,...]` の**数値出力**
+- allowlist/seed の少量拡充：`sources/allowlist.json` / `sources/seed_candidates.jsonl` を微増
 


### PR DESCRIPTION
## Summary
- document v1.7 authoring automation in roadmap and status docs
- add daily authoring checklist and applied follow-ups
- mark i18n baseline and auto authoring as implemented in feature inventory

## Testing
- `npm test` *(fails: clojure not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba97ef46648324aed72f95b9f47a1d