### PR TITLE
feat: add authoring schema validation and aliases

### DIFF
--- a/.github/workflows/authoring-schema-check.yml
+++ b/.github/workflows/authoring-schema-check.yml
@@ -1,0 +1,29 @@
+name: authoring (schema soft-check)
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Soft schema validation
+        run: |
+          node --version
+          node scripts/validate_authoring_schema.mjs || true
+        # NOTE: soft-check for v1.8 phase 1. Flip to strict by removing '|| true'
+
+      - name: Summary
+        run: |
+          echo "### Authoring schema soft-check completed" >> $GITHUB_STEP_SUMMARY
+          echo "- Uses scripts/validate_authoring_schema.mjs" >> $GITHUB_STEP_SUMMARY
+          echo "- Set SCHEMA_CHECK_STRICT=true to enforce exit 1 on violations" >> $GITHUB_STEP_SUMMARY

--- a/config/authoring.json
+++ b/config/authoring.json
@@ -1,0 +1,7 @@
+{
+  "//": "v1.8 introduces a configurable choices mode. Keep default 'auto' to try 4-choice when quality gate passes, otherwise fallback to 1-choice. Switch to 'always4' when data quality is high.",
+  "choices_mode": "auto",
+  "choices_quality_gate": {
+    "max_same_composer_distractors": 1
+  }
+}

--- a/data/aliases/composer.json
+++ b/data/aliases/composer.json
@@ -1,0 +1,5 @@
+{
+  "//": "Composer alias map (normalized -> array of aliases). Fill incrementally.",
+  "Yasunori Mitsuda": ["光田 康典"],
+  "Nobuo Uematsu": ["植松 伸夫"]
+}

--- a/data/aliases/game.json
+++ b/data/aliases/game.json
@@ -1,0 +1,6 @@
+{
+  "//": "Game alias map (normalized -> array of aliases). Examples only.",
+  "Chrono Trigger": ["クロノ・トリガー", "クロノトリガー"],
+  "Undertale": ["UNDERTALE"],
+  "The Legend of Zelda: Ocarina of Time": ["ゼルダの伝説 時のオカリナ"]
+}

--- a/data/aliases/track.json
+++ b/data/aliases/track.json
@@ -1,0 +1,5 @@
+{
+  "//": "Track alias map (normalized -> array of aliases). Examples only.",
+  "Corridors of Time": ["時の回廊"],
+  "Megalovania": ["メガロバニア"]
+}

--- a/schema/daily_item.schema.json
+++ b/schema/daily_item.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "vgm-quiz daily item (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["title", "game", "track", "media", "answers"],
+  "properties": {
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "title": { "type": "string", "minLength": 1 },
+    "game": { "type": "string", "minLength": 1 },
+    "track": {
+      "type": "object",
+      "required": ["composer"],
+      "properties": {
+        "composer": { "type": "string", "minLength": 1 }
+      }
+    },
+    "media": {
+      "type": "object",
+      "required": ["provider", "id"],
+      "properties": {
+        "provider": { "type": "string", "enum": ["apple", "youtube", "auto"] },
+        "id": { "type": "string", "minLength": 1 }
+      }
+    },
+    "answers": {
+      "type": "object",
+      "required": ["canonical"],
+      "properties": {
+        "canonical": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
+        },
+        "aliases": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "choices": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "difficulty": { "type": "number", "minimum": 0.0, "maximum": 1.0 }
+  }
+}

--- a/scripts/normalize_core.mjs
+++ b/scripts/normalize_core.mjs
@@ -1,0 +1,64 @@
+/**
+ * normalize_core.mjs — v1.8 unified normalization helpers
+ * NOTE: Not yet wired; safe to import incrementally.
+ */
+
+// Wave dash variants to full-width tilde U+301C or ASCII hyphen?
+// Here, normalize to ASCII hyphen-minus and collapse repeats.
+export function normalizeDashes(s) {
+  if (!s) return s;
+  return String(s)
+    // common tilde/dash variants
+    .replace(/[\u301C\u3030\u30FC\uFF5E\u2212\u2010-\u2015]/g, '-')
+    // collapse multiple dashes
+    .replace(/-+/g, '-');
+}
+
+// Remove CJK-internal spaces but keep ASCII word boundaries
+export function normalizeCjkSpaces(s) {
+  if (!s) return s;
+  // Remove spaces between two CJK chars
+  return String(s).replace(/([\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}])\s+([\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}])/gu, '$1$2');
+}
+
+// Roman numerals: unify I,V,X,L,C,D,M blocks; add thin space before them when trailing a word
+export function normalizeRomanNumerals(s) {
+  if (!s) return s;
+  // uppercase roman
+  const ROMAN = '(?=[IVXLCDM])(I|II|III|IV|V|VI|VII|VIII|IX|X|XI|XII|XIII|XIV|XV|XVI|XVII|XVIII|XIX|XX)';
+  return String(s)
+    .replace(/Ｉ/g, 'I')
+    .replace(new RegExp(`([^\\s])(${ROMAN})`, 'g'), '$1 $2')
+    .replace(/\s{2,}/g, ' ');
+}
+
+// Long vowel normalization around 'ン' (Japanese)
+export function normalizeLongVowelAroundN(s) {
+  if (!s) return s;
+  return String(s).replace(/ンー/g, 'ン');
+}
+
+export function normalizeAll(s) {
+  let x = s;
+  x = normalizeDashes(x);
+  x = normalizeCjkSpaces(x);
+  x = normalizeRomanNumerals(x);
+  x = normalizeLongVowelAroundN(x);
+  return x;
+}
+
+// Simple aliases loader (future use)
+import { readFile } from 'fs/promises';
+import path from 'path';
+import url from 'url';
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+export async function loadAliases(kind /* 'game' | 'composer' | 'track' */) {
+  const p = path.resolve(__dirname, `../data/aliases/${kind}.json`);
+  try {
+    const raw = await readFile(p, 'utf-8');
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}

--- a/scripts/validate_authoring_schema.mjs
+++ b/scripts/validate_authoring_schema.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * v1.8 soft schema check (no external deps)
+ * - Validates shape of a single daily item (today) using lightweight checks.
+ * - Sources: prefer build/daily_today.json; fallback to public/app/daily_auto.json
+ * - Exit 0 by default (soft). Set SCHEMA_CHECK_STRICT=true to exit 1 on violations.
+ */
+import { readFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import path from 'path';
+import url from 'url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const candidates = [
+  path.resolve(__dirname, '../build/daily_today.json'),
+  path.resolve(__dirname, '../public/app/daily_auto.json')
+];
+
+function pickSource() {
+  for (const p of candidates) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+function isNonEmptyString(x) {
+  return typeof x === 'string' && x.trim().length > 0;
+}
+
+function isStringArray(arr) {
+  return Array.isArray(arr) && arr.every(isNonEmptyString);
+}
+
+function annotate(msg) {
+  // GitHub Actions annotation compatible line
+  console.log(`::warning::schema ${msg}`);
+}
+
+async function main() {
+  const strict = (process.env.SCHEMA_CHECK_STRICT || 'false').toLowerCase() === 'true';
+  const src = pickSource();
+  if (!src) {
+    annotate('no source found (build/daily_today.json nor public/app/daily_auto.json)');
+    process.exit(strict ? 1 : 0);
+  }
+  const raw = await readFile(src, 'utf-8');
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (e) {
+    annotate(`invalid JSON: ${e.message}`);
+    process.exit(strict ? 1 : 0);
+  }
+
+  // Some builds may wrap the item (e.g., { by_date: { "YYYY-MM-DD": {...} } })
+  if (data && data.by_date && typeof data.by_date === 'object') {
+    const keys = Object.keys(data.by_date);
+    if (keys.length === 1) {
+      data = { date: keys[0], ...data.by_date[keys[0]] };
+    }
+  }
+
+  const errors = [];
+  // Required top-level
+  if (!isNonEmptyString(data.title)) errors.push('title missing/non-string');
+  if (!isNonEmptyString(data.game)) errors.push('game missing/non-string');
+  if (!(data.track && isNonEmptyString(data.track.composer))) errors.push('track.composer missing/non-string');
+  if (!(data.media && isNonEmptyString(data.media.provider) && isNonEmptyString(data.media.id))) errors.push('media.provider/id missing/non-string');
+  if (!(data.answers && isStringArray(data.answers.canonical) && data.answers.canonical.length > 0)) errors.push('answers.canonical missing/empty');
+
+  // Optional but recommended
+  if (typeof data.difficulty !== 'number' || data.difficulty < 0 || data.difficulty > 1) {
+    errors.push('difficulty missing or out of range [0,1]');
+  }
+
+  // choices integrity (if present)
+  if (Array.isArray(data.choices)) {
+    const uniq = new Set(data.choices.map(String));
+    if (uniq.size !== data.choices.length) errors.push('choices contain duplicates');
+  }
+
+  if (errors.length) {
+    errors.forEach(e => annotate(e));
+    console.log(`schema: violations=${errors.length} file=${src}`);
+    process.exit(strict ? 1 : 0);
+  } else {
+    console.log(`schema: OK file=${src}`);
+    process.exit(0);
+  }
+}
+
+main().catch(e => {
+  annotate(`unhandled error: ${e?.stack || e}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add config for authoring choices
- define JSON schema and normalization helpers with alias data
- add soft schema validation script and CI workflow

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `node scripts/validate_authoring_schema.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68baa54a1ce88324ac87a789183b5c15