### PR TITLE
feat: add daily OGP and feed generators

### DIFF
--- a/.github/workflows/ogp-and-feeds.yml
+++ b/.github/workflows/ogp-and-feeds.yml
@@ -1,0 +1,29 @@
+name: daily (ogp+feeds)
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "25 18 * * *" # UTC 18:25 ≒ JST 03:25
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Generate OGP (SVG + optional PNG)
+        run: node scripts/generate_ogp.mjs
+
+      - name: Generate Feeds (single-item)
+        run: node scripts/generate_feeds_min.mjs
+
+      - name: Summary
+        run: |
+          echo "### daily (ogp+feeds)" >> $GITHUB_STEP_SUMMARY
+          echo "- OGP SVG required; PNG if @resvg/resvg-js is present" >> $GITHUB_STEP_SUMMARY
+          echo "- Feeds: public/daily/feed.(xml|json)" >> $GITHUB_STEP_SUMMARY

--- a/assets/og/template.svg
+++ b/assets/og/template.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="1200" height="630" fill="url(#bg)"/>
+  <text x="60" y="140" fill="#94a3b8" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="28">vgm-quiz • <tspan id="date">YYYY-MM-DD</tspan></text>
+  <text x="60" y="230" fill="#e2e8f0" font-weight="700" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="64" id="title">Track Title</text>
+  <text x="60" y="300" fill="#cbd5e1" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="36" id="game">Game Title</text>
+  <text x="60" y="360" fill="#a3bffa" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="28" id="composer">Composer</text>
+  <rect x="60" y="410" width="800" height="24" rx="12" fill="#334155"/>
+  <rect x="60" y="410" width="0" height="24" rx="12" fill="#60a5fa" id="difficultyBar"/>
+  <text x="875" y="430" fill="#93c5fd" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="22" id="difficulty">difficulty 0.00</text>
+  <text x="60" y="580" fill="#64748b" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="20">auto-generated • v1.8</text>
+</svg>

--- a/scripts/generate_feeds_min.mjs
+++ b/scripts/generate_feeds_min.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Minimal feeds generator
+ * - Generates single-item RSS/JSON feed for the latest daily item.
+ * - Safe starter; can be extended to multi-item when an index becomes available.
+ */
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import path from 'path';
+import url from 'url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+function siteBase() {
+  // Best effort. Adjust if repository slug changes.
+  return 'https://nantes-rfli.github.io/vgm-quiz';
+}
+
+function pad(n){ return String(n).padStart(2, '0'); }
+function todayStr() {
+  const d = new Date();
+  return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
+}
+
+async function main() {
+  const src = path.resolve(__dirname, '../build/daily_today.json');
+  const outDir = path.resolve(__dirname, '../public/daily');
+  if (!existsSync(src)) {
+    console.warn(`[feeds] missing ${src} — skip`);
+    return;
+  }
+  await mkdir(outDir, { recursive: true });
+
+  let item = JSON.parse(await readFile(src, 'utf-8'));
+  if (item && item.by_date && typeof item.by_date === 'object') {
+    const keys = Object.keys(item.by_date);
+    if (keys.length === 1) {
+      item = { date: keys[0], ...item.by_date[keys[0]] };
+    }
+  }
+  const date = item.date || todayStr();
+  const urlBase = siteBase();
+  const pageUrl = `${urlBase}/daily/${date}.html`;
+  const ogUrlPng = `${urlBase}/og/${date}.png`;
+
+  const title = `[vgm-quiz] ${item.title || ''} — ${item.game || ''}`.trim();
+  const description = `Daily VGM quiz for ${date}. Composer: ${item.track?.composer || 'N/A'}`;
+
+  const rss = `<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+  <channel>
+    <title>vgm-quiz daily</title>
+    <link>${urlBase}/daily/latest.html</link>
+    <description>One VGM question per day</description>
+    <item>
+      <title>${escapeXml(title)}</title>
+      <link>${pageUrl}</link>
+      <guid>${pageUrl}</guid>
+      <description>${escapeXml(description)}</description>
+      <enclosure url="${ogUrlPng}" type="image/png"/>
+      <pubDate>${new Date().toUTCString()}</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+  const jsonFeed = {
+    version: "https://jsonfeed.org/version/1.1",
+    title: "vgm-quiz daily",
+    home_page_url: `${urlBase}/daily/latest.html`, 
+    items: [{
+      id: pageUrl,
+      url: pageUrl,
+      title,
+      content_text: description,
+      date_published: new Date().toISOString(),
+      attachments: [{
+        url: ogUrlPng,
+        mime_type: "image/png"
+      }]
+    }]
+  };
+
+  await writeFile(path.join(outDir, 'feed.xml'), rss, 'utf-8');
+  await writeFile(path.join(outDir, 'feed.json'), JSON.stringify(jsonFeed, null, 2), 'utf-8');
+  console.log('[feeds] generated: public/daily/feed.(xml|json)');
+}
+
+function escapeXml(s){
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+main();

--- a/scripts/generate_ogp.mjs
+++ b/scripts/generate_ogp.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * OGP static generator (SVG required, PNG optional)
+ * - Reads build/daily_today.json
+ * - Fills assets/og/template.svg and writes public/og/YYYY-MM-DD.svg and latest.svg
+ * - If @resvg/resvg-js is available, also renders PNGs.
+ */
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import path from 'path';
+import url from 'url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+function pad(n){ return String(n).padStart(2, '0'); }
+function todayStr() {
+  const d = new Date();
+  return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
+}
+
+async function ensureDir(p) {
+  if (!existsSync(p)) await mkdir(p, { recursive: true });
+}
+
+function inject(svg, fields) {
+  let out = svg;
+  out = out.replace('id="date">YYYY-MM-DD', `id="date">${fields.date}`);
+  out = out.replace('id="title">Track Title', `id="title">${escapeXml(fields.title)}`);
+  out = out.replace('id="game">Game Title', `id="game">${escapeXml(fields.game)}`);
+  out = out.replace('id="composer">Composer', `id="composer">${escapeXml(fields.composer)}`);
+  out = out.replace('width="0" height="24" rx="12" fill="#60a5fa" id="difficultyBar"', `width="${Math.round((fields.difficulty||0)*800)}" height="24" rx="12" fill="#60a5fa" id="difficultyBar"`);
+  out = out.replace('id="difficulty">difficulty 0.00', `id="difficulty">difficulty ${(fields.difficulty||0).toFixed(2)}`);
+  return out;
+}
+
+function escapeXml(s){
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+async function maybePng(svgBuf, outPng) {
+  try {
+    const { Resvg } = await import('@resvg/resvg-js'); // optional dependency
+    const resvg = new Resvg(svgBuf, { fitTo: { mode: 'width', value: 1200 } });
+    const png = resvg.render().asPng();
+    await writeFile(outPng, png);
+    return true;
+  } catch (e) {
+    console.warn('[ogp] PNG render skipped (resvg not installed):', e.message || e);
+    return false;
+  }
+}
+
+async function main() {
+  const src = path.resolve(__dirname, '../build/daily_today.json');
+  const tpl = path.resolve(__dirname, '../assets/og/template.svg');
+  const outDir = path.resolve(__dirname, '../public/og');
+  await ensureDir(outDir);
+
+  const raw = await readFile(src, 'utf-8').catch(()=>null);
+  if (!raw) {
+    console.warn(`[ogp] missing ${src} — skip`);
+    return;
+  }
+  let item = JSON.parse(raw);
+  if (item && item.by_date && typeof item.by_date === 'object') {
+    const keys = Object.keys(item.by_date);
+    if (keys.length === 1) {
+      item = { date: keys[0], ...item.by_date[keys[0]] };
+    }
+  }
+  const date = item.date || todayStr();
+  const fields = {
+    date,
+    title: item.title || '',
+    game: item.game || '',
+    composer: item.track?.composer || '',
+    difficulty: typeof item.difficulty === 'number' ? item.difficulty : 0
+  };
+  const svg = await readFile(tpl, 'utf-8');
+  const filled = inject(svg, fields);
+
+  const outSvg = path.join(outDir, `${date}.svg`);
+  const outSvgLatest = path.join(outDir, `latest.svg`);
+  await writeFile(outSvg, filled, 'utf-8');
+  await writeFile(outSvgLatest, filled, 'utf-8');
+
+  // Try PNG (optional)
+  const outPng = path.join(outDir, `${date}.png`);
+  const outPngLatest = path.join(outDir, `latest.png`);
+  const pngOk = await maybePng(Buffer.from(filled), outPng);
+  if (pngOk) await writeFile(outPngLatest, await readFile(outPng));
+
+  console.log(`[ogp] generated: ${path.relative(process.cwd(), outSvg)} (+png:${pngOk})`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add template SVG and Node scripts to generate daily OGP assets and feeds
- schedule workflow to build OGP and feeds daily

## Testing
- `npm test` *(fails: clojure: not found)*
- `node scripts/generate_ogp.mjs`
- `node scripts/generate_feeds_min.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68baa675297083249245c957c990e8e4