### PR TITLE
feat: fallback to daily_auto for ogp and feeds

### DIFF
--- a/.github/workflows/ogp-and-feeds.yml
+++ b/.github/workflows/ogp-and-feeds.yml
@@ -16,14 +16,50 @@ jobs:
         with:
           node-version: 20
 
+      # Ensure today's slim artifact exists (v1.7 export). If missing, this generates it.
+      - name: Ensure build/daily_today.json (export slim)
+        run: |
+          if [ ! -f build/daily_today.json ]; then
+            echo "[ogp+feeds] build/daily_today.json not found; trying export_today_slim.mjs ..."
+            node scripts/export_today_slim.mjs || true
+          fi
+
       - name: Generate OGP (SVG + optional PNG)
         run: node scripts/generate_ogp.mjs
 
       - name: Generate Feeds (single-item)
         run: node scripts/generate_feeds_min.mjs
 
+      - name: Read date for PR title
+        id: meta
+        run: |
+          DATE="$(node -e "try{const fs=require('fs');const p1='build/daily_today.json', p2='public/app/daily_auto.json';let o=null;if(fs.existsSync(p1))o=JSON.parse(fs.readFileSync(p1,'utf8'));else if(fs.existsSync(p2))o=JSON.parse(fs.readFileSync(p2,'utf8'));let d=o?.date; if(!d && o?.by_date) d=Object.keys(o.by_date)[0]; process.stdout.write(d||'$(date -u +%Y-%m-%d)');}catch(e){process.stdout.write('$(date -u +%Y-%m-%d)');}")"
+          echo "date=$DATE" >> $GITHUB_OUTPUT
+
+      - name: Create PR with changes
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: bot/ogp-feeds-${{ steps.meta.outputs.date }}
+          title: "chore(ogp+feeds): ${
+            format('assets for {0}', steps.meta.outputs.date)
+          }}"
+          commit-message: "chore(ogp+feeds): add OGP/feeds for ${{ steps.meta.outputs.date }}"
+          body: |
+            This PR adds OGP/feeds generated for ${{ steps.meta.outputs.date }}.
+            - OGP: `public/og/${{ steps.meta.outputs.date }}.svg` (+PNG if available) and `public/og/latest.*`
+            - Feeds: `public/daily/feed.xml` and `public/daily/feed.json`
+            Auto-created by `daily (ogp+feeds)`.
+          add-paths: |
+            public/og/**
+            public/daily/feed.xml
+            public/daily/feed.json
+          delete-branch: true
+          labels: automation, ogp, feeds
+
       - name: Summary
         run: |
           echo "### daily (ogp+feeds)" >> $GITHUB_STEP_SUMMARY
           echo "- OGP SVG required; PNG if @resvg/resvg-js is present" >> $GITHUB_STEP_SUMMARY
           echo "- Feeds: public/daily/feed.(xml|json)" >> $GITHUB_STEP_SUMMARY
+          echo "- PR branch: bot/ogp-feeds-${{ steps.meta.outputs.date }}" >> $GITHUB_STEP_SUMMARY

--- a/scripts/generate_feeds_min.mjs
+++ b/scripts/generate_feeds_min.mjs
@@ -7,9 +7,9 @@
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
-import url from 'url';
+import { fileURLToPath } from 'url';
 
-const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function siteBase() {
   // Best effort. Adjust if repository slug changes.
@@ -22,16 +22,28 @@ function todayStr() {
   return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
 }
 
+async function readDaily() {
+  const buildPath = path.resolve(__dirname, '../build/daily_today.json');
+  if (existsSync(buildPath)) {
+    return JSON.parse(await readFile(buildPath, 'utf-8'));
+  }
+  const autoPath = path.resolve(__dirname, '../public/app/daily_auto.json');
+  if (existsSync(autoPath)) {
+    return JSON.parse(await readFile(autoPath, 'utf-8'));
+  }
+  return null;
+}
+
 async function main() {
-  const src = path.resolve(__dirname, '../build/daily_today.json');
   const outDir = path.resolve(__dirname, '../public/daily');
-  if (!existsSync(src)) {
-    console.warn(`[feeds] missing ${src} — skip`);
+  const rawObj = await readDaily();
+  if (!rawObj) {
+    console.warn('[feeds] no source JSON found (build/daily_today.json nor public/app/daily_auto.json) — skip');
     return;
   }
   await mkdir(outDir, { recursive: true });
 
-  let item = JSON.parse(await readFile(src, 'utf-8'));
+  let item = rawObj;
   if (item && item.by_date && typeof item.by_date === 'object') {
     const keys = Object.keys(item.by_date);
     if (keys.length === 1) {

--- a/scripts/generate_ogp.mjs
+++ b/scripts/generate_ogp.mjs
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
 /**
  * OGP static generator (SVG required, PNG optional)
- * - Reads build/daily_today.json
+ * - Prefers build/daily_today.json; falls back to public/app/daily_auto.json (by_date)
  * - Fills assets/og/template.svg and writes public/og/YYYY-MM-DD.svg and latest.svg
  * - If @resvg/resvg-js is available, also renders PNGs.
  */
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
-import url from 'url';
+import { fileURLToPath } from 'url';
 
-const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function pad(n){ return String(n).padStart(2, '0'); }
 function todayStr() {
@@ -50,18 +50,30 @@ async function maybePng(svgBuf, outPng) {
   }
 }
 
+async function readDaily() {
+  // prefer build/daily_today.json, else public/app/daily_auto.json
+  const buildPath = path.resolve(__dirname, '../build/daily_today.json');
+  if (existsSync(buildPath)) {
+    return JSON.parse(await readFile(buildPath, 'utf-8'));
+  }
+  const autoPath = path.resolve(__dirname, '../public/app/daily_auto.json');
+  if (existsSync(autoPath)) {
+    return JSON.parse(await readFile(autoPath, 'utf-8'));
+  }
+  return null;
+}
+
 async function main() {
-  const src = path.resolve(__dirname, '../build/daily_today.json');
   const tpl = path.resolve(__dirname, '../assets/og/template.svg');
   const outDir = path.resolve(__dirname, '../public/og');
   await ensureDir(outDir);
 
-  const raw = await readFile(src, 'utf-8').catch(()=>null);
-  if (!raw) {
-    console.warn(`[ogp] missing ${src} — skip`);
+  const rawObj = await readDaily();
+  if (!rawObj) {
+    console.warn('[ogp] no source JSON found (build/daily_today.json nor public/app/daily_auto.json) — skip');
     return;
   }
-  let item = JSON.parse(raw);
+  let item = rawObj;
   if (item && item.by_date && typeof item.by_date === 'object') {
     const keys = Object.keys(item.by_date);
     if (keys.length === 1) {


### PR DESCRIPTION
## Summary
- make OGP and feed generators fall back to `public/app/daily_auto.json`
- ensure GitHub workflow creates slim export, generates assets, and opens PR automatically

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baacdfaab08324b04f1e6e8f2a922c