### PR TITLE
docs: clarify PAT usage for daily PRs

### DIFF
--- a/docs/DESIGN_OGP.md
+++ b/docs/DESIGN_OGP.md
@@ -41,3 +41,10 @@
 ## 将来拡張
 - 多言語 OGP（パス分割）／シリーズ別の配色テーマ
 - クリップ時間の可視化（将来の Collector v1 で開始秒が決まったら描画）
+
+## 運用メモ（PRの必須チェックが走らない場合）
+`daily (ogp+feeds)` が作る PR では、**GITHUB_TOKEN ではなく PAT（例: 
+`${{ secrets.DAILY_PR_PAT }}`）**を使ってください。
+GitHub の仕様で、GITHUB_TOKEN による PR/commit では `pull_request` トリガの Workflow が起動しない場合があり、
+ブランチ保護の Required（`ci-fast-pr-build` / `pages-pr-build` / `required-check`）が永続 Pending になることがあります。
+本プロジェクトでは PAT の使用を前提にしています。

--- a/docs/OPERATIONS_AUTHORING.md
+++ b/docs/OPERATIONS_AUTHORING.md
@@ -37,6 +37,17 @@
 - `sources/allowlist.json`：チャンネル/パブリッシャの拡充（任意）
 - `sources/seed_candidates.jsonl`：安全な候補（`provider:auto` も可）を数件ずつ追加
 
+### PR 自動作成でのトラブル回避（重要・再掲）
+自動生成された PR で必須チェック（`ci-fast-pr-build` / `pages-pr-build` / `required-check`）が**起動しない/待機のまま**になる場合、
+PR作成に **GITHUB_TOKEN** を使っていることが原因です。**必ず PAT を使用**してください。
+
+- ワークフロー: `daily (ogp+feeds)`（`ogp-and-feeds.yml`）
+- 対応: `peter-evans/create-pull-request` の `token` に **`${{ secrets.DAILY_PR_PAT }}`** を指定
+- 必要権限: PAT は `repo` スコープ
+- 参考: GitHub の仕様として、GITHUB_TOKEN で作成した PR/commit では他の Workflow の `pull_request` イベントが起動しない場合があります
+
+この要件は `daily (auto extended)` と同様です。両方で **PAT** を使ってください。
+
 ## 7. 日次チェックリスト（軽監視）
 - `build/daily_today.json/.md` の当日 1 件を確認（**choices** が 1 or 4、欠損がない）
 - **difficulty** が `0.00–1.00` の範囲に収まっている

--- a/docs/V1_8_PLAN.md
+++ b/docs/V1_8_PLAN.md
@@ -38,6 +38,9 @@
    - エントリ: 当日1件、`og:image` を enclosure/attachment として露出
 3. **キャッシュ戦略**
    - `YYYY-MM-DD.png` は immutable、`latest.png` は短期キャッシュ + ETag
+4. **PR 作成**
+   - `daily (ogp+feeds)` は **PAT（`${{ secrets.DAILY_PR_PAT }}`）** を使用して PR を作成（必須チェックを確実発火）
+   - Required: `ci-fast-pr-build` / `pages-pr-build` / `required-check`（ジョブ名）
 
 ## 受け入れ基準（DoD）
 - PR 時に **Schema 検証が必須** で、違反があると赤になる。


### PR DESCRIPTION
## Summary
- note to use PAT instead of GITHUB_TOKEN when creating daily (ogp+feeds) pull requests so required checks fire
- replicate the PAT requirement in operations and v1.8 planning docs

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repositories 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68babe20fb84832480a15c11dfc617be