### PR TITLE
ci: guard for missing DAILY_PR_PAT

### DIFF
--- a/.github/workflows/ogp-and-feeds.yml
+++ b/.github/workflows/ogp-and-feeds.yml
@@ -21,6 +21,13 @@ jobs:
         with:
           node-version: 20
 
+      - name: Guard: DAILY_PR_PAT must exist
+        run: |
+          if [ -z "${{ secrets.DAILY_PR_PAT }}" ]; then
+            echo "::error::DAILY_PR_PAT is missing. Add a PAT with 'repo' scope in Settings > Secrets > Actions."
+            exit 1
+          fi
+
       # Ensure today's slim artifact exists (v1.7 export). If missing, this generates it.
       - name: Ensure build/daily_today.json (export slim)
         run: |


### PR DESCRIPTION
## Summary
- fail early if DAILY_PR_PAT GitHub secret is not set for daily OGP/feeds workflow

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68babf19cc748324ae6e0b86217c1666