### PR TITLE
ci: enforce strict schema check and add PNG renderer

### DIFF
--- a/.github/workflows/authoring-schema-check.yml
+++ b/.github/workflows/authoring-schema-check.yml
@@ -1,4 +1,4 @@
-name: authoring (schema soft-check)
+name: authoring (schema check)
 
 on:
   workflow_dispatch: {}
@@ -16,14 +16,14 @@ jobs:
         with:
           node-version: 20
 
-      - name: Soft schema validation
+      - name: Schema validation (strict)
         run: |
           node --version
-          node scripts/validate_authoring_schema.mjs || true
-        # NOTE: soft-check for v1.8 phase 1. Flip to strict by removing '|| true'
+          SCHEMA_CHECK_STRICT=true node scripts/validate_authoring_schema.mjs
+        # v1.8: strict mode (fail-fast)
 
       - name: Summary
         run: |
-          echo "### Authoring schema soft-check completed" >> $GITHUB_STEP_SUMMARY
-          echo "- Uses scripts/validate_authoring_schema.mjs" >> $GITHUB_STEP_SUMMARY
-          echo "- Set SCHEMA_CHECK_STRICT=true to enforce exit 1 on violations" >> $GITHUB_STEP_SUMMARY
+          echo "### Authoring schema check (strict)" >> $GITHUB_STEP_SUMMARY
+          echo "- scripts/validate_authoring_schema.mjs ran with SCHEMA_CHECK_STRICT=true" >> $GITHUB_STEP_SUMMARY
+          echo "- Violations will fail the job" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ogp-and-feeds.yml
+++ b/.github/workflows/ogp-and-feeds.yml
@@ -21,6 +21,15 @@ jobs:
         with:
           node-version: 20
 
+      - name: Install PNG renderer (@resvg/resvg-js)
+        run: |
+          # Install per-run without touching repo commits
+          if [ ! -f package.json ]; then
+            npm init -y >/dev/null 2>&1 || true
+          fi
+          npm i @resvg/resvg-js --no-audit --no-fund
+          echo "Installed @resvg/resvg-js for PNG rendering"
+
       - name: Guard: DAILY_PR_PAT must exist
         run: |
           if [ -z "${{ secrets.DAILY_PR_PAT }}" ]; then


### PR DESCRIPTION
## Summary
- run authoring schema validation in strict mode
- install PNG renderer to support OGP PNG generation

## Testing
- `npm test` *(fails: `clojure` not found)*
- `apt-get update` *(fails: 403, repository not signed)*
- `curl -L -o /tmp/linux-install.sh https://download.clojure.org/install/linux-install-1.11.1.1413.sh` *(fails: 403 CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bac31557c48324b80be4ae4c3807b3