### PR TITLE
chore: update daily asset scripts and workflow

### DIFF
--- a/.github/workflows/ogp-and-feeds.yml
+++ b/.github/workflows/ogp-and-feeds.yml
@@ -20,57 +20,38 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Guard: DAILY_PR_PAT must exist
-        env:
-          DAILY_PR_PAT: ${{ secrets.DAILY_PR_PAT }}
+      - name: Prepare workspace
         run: |
-          if [ -z "$DAILY_PR_PAT" ]; then
-            echo "::error::DAILY_PR_PAT is missing. Add a PAT with 'repo' scope in Settings > Secrets > Actions."
-            exit 1
-          fi
+          mkdir -p build public/og public/daily
 
-      - name: Ensure build/daily_today.json (export slim)
+      - name: Export today's slim (fallback)
         run: |
           if [ ! -f build/daily_today.json ]; then
-            echo "[ogp+feeds] build/daily_today.json not found; trying export_today_slim.mjs ..."
-            node scripts/export_today_slim.mjs || true
+            node scripts/export_today_slim.mjs --out-json build/daily_today.json --out-md build/daily_today.md || true
           fi
 
-      - name: Install PNG renderer (@resvg/resvg-js)
+      - name: Optional PNG renderer
         run: |
-          if [ ! -f package.json ]; then
-            npm init -y >/dev/null 2>&1 || true
-          fi
-          npm i @resvg/resvg-js --no-audit --no-fund
-          echo "Installed @resvg/resvg-js for PNG rendering"
+          npm --version
+          npm i --no-save @resvg/resvg-js || true
 
-      - name: Generate OGP (SVG + optional PNG)
+      - name: Generate OGP (SVG/PNG)
         run: node scripts/generate_ogp.mjs
 
-      - name: Generate Feeds (single-item)
+      - name: Generate Feeds (RSS/JSON)
         run: node scripts/generate_feeds_min.mjs
 
-      - name: Read date for PR title
-        id: meta
-        shell: bash
-        run: |
-          DATE="$(node -e "try{const fs=require('fs');const p1='build/daily_today.json', p2='public/app/daily_auto.json';let o=null;if(fs.existsSync(p1))o=JSON.parse(fs.readFileSync(p1,'utf8'));else if(fs.existsSync(p2))o=JSON.parse(fs.readFileSync(p2,'utf8'));let d=o?.date; if(!d && o?.item) d=o.date; if(!d && o?.by_date) d=Object.keys(o.by_date)[0]; process.stdout.write(d||new Date().toISOString().slice(0,10));}catch(e){process.stdout.write(new Date().toISOString().slice(0,10));}")"
-          echo "date=$DATE" >> "$GITHUB_OUTPUT"
-
-      - name: Create PR with changes
+      - name: Create PR
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.DAILY_PR_PAT }}
-          branch: bot/ogp-feeds-${{ steps.meta.outputs.date }}
-          title: "chore(ogp+feeds): assets for ${{ steps.meta.outputs.date }}"
-          commit-message: "chore(ogp+feeds): add OGP/feeds for ${{ steps.meta.outputs.date }}"
-          draft: false
-          base: main
+          branch: "bot/ogp-and-feeds/${{ github.run_id }}"
+          commit-message: |
+            chore(ogp+feeds): update OGP and feeds for daily
+          title: "chore(ogp+feeds): update OGP and feeds for daily"
           body: |
-            This PR adds OGP/feeds generated for ${{ steps.meta.outputs.date }}.
-
-            - OGP: `public/og/${{ steps.meta.outputs.date }}.svg` (+PNG if available) and `public/og/latest.*`
+            This PR adds/updates:
+            - OGP assets: `public/og/YYYY-MM-DD.(svg|png)` and `public/og/latest.(svg|png)`
             - Feeds: `public/daily/feed.xml` and `public/daily/feed.json`
 
             Auto-created by `daily (ogp+feeds)`.

--- a/scripts/generate_feeds_min.mjs
+++ b/scripts/generate_feeds_min.mjs
@@ -2,7 +2,7 @@
 /**
  * Minimal feeds generator
  * - Generates single-item RSS/JSON feed for the latest daily item.
- * - Safe starter; can be extended to multi-item when an index becomes available.
+ * - Accepts wrapper {date,item} and by_date maps.
  */
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
@@ -16,83 +16,78 @@ function siteBase() {
   return 'https://nantes-rfli.github.io/vgm-quiz';
 }
 
-function pad(n){ return String(n).padStart(2, '0'); }
-function todayStr() {
-  const d = new Date();
-  return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
-}
-
-async function readDaily() {
-  const buildPath = path.resolve(__dirname, '../build/daily_today.json');
-  if (existsSync(buildPath)) {
-    const o = JSON.parse(await readFile(buildPath, 'utf-8'));
-    if (o && o.item && typeof o.item === 'object') {
-      return { date: o.date, ...o.item };
+function unwrapEnvelope(x){
+  if (x && typeof x === 'object') {
+    if (x.item && (x.date || x.item.date)) return { date: x.date || x.item.date, item: x.item };
+    if (x.date && (x.title || x.game || x.media)) { const { date, ...rest } = x; return { date, item: rest }; }
+    if (x.by_date && typeof x.by_date === 'object') {
+      const dates = Object.keys(x.by_date).sort();
+      const date = dates[dates.length - 1];
+      return { date, item: x.by_date[date] };
     }
-    return o;
+    if (x.title || x.game || x.media) return { date: null, item: x };
+    if (Array.isArray(x) && x.length) return { date: null, item: x[x.length-1] };
   }
-  const autoPath = path.resolve(__dirname, '../public/app/daily_auto.json');
-  if (existsSync(autoPath)) {
-    return JSON.parse(await readFile(autoPath, 'utf-8'));
-  }
-  return null;
+  return { date: null, item: null };
 }
 
-async function main() {
+async function loadLatest(){
+  const prefer = path.resolve(__dirname, '../build/daily_today.json');
+  const fallback = path.resolve(__dirname, '../public/app/daily_auto.json');
+  let data, src;
+  if (existsSync(prefer)) { data = JSON.parse(await readFile(prefer, 'utf-8')); src = prefer; }
+  else if (existsSync(fallback)) { data = JSON.parse(await readFile(fallback, 'utf-8')); src = fallback; }
+  else throw new Error('no source found');
+  const { date, item } = unwrapEnvelope(data);
+  return { date: date || new Date().toISOString().slice(0,10), item, src };
+}
+
+function escapeXml(s){
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+async function main(){
+  const { date, item } = await loadLatest();
+  if (!item) throw new Error('no item for feeds');
+
   const outDir = path.resolve(__dirname, '../public/daily');
-  const rawObj = await readDaily();
-  if (!rawObj) {
-    console.warn('[feeds] no source JSON found (build/daily_today.json nor public/app/daily_auto.json) — skip');
-    return;
-  }
-  await mkdir(outDir, { recursive: true });
+  if (!existsSync(outDir)) await mkdir(outDir, { recursive: true });
 
-  let item = rawObj;
-  if (item && item.by_date && typeof item.by_date === 'object') {
-    const keys = Object.keys(item.by_date);
-    if (keys.length === 1) {
-      item = { date: keys[0], ...item.by_date[keys[0]] };
-    }
-  }
-  const date = item.date || todayStr();
-  const urlBase = siteBase();
-  const pageUrl = `${urlBase}/daily/${date}.html`;
-  const ogUrlPng = `${urlBase}/og/${date}.png`;
+  const title = item.title || 'Untitled';
+  const game = item.game || '';
+  const composer = (item?.track?.composer) ? ` — ${item.track.composer}` : '';
+  const ogUrl = `${siteBase()}/og/${date}.png`;
+  const pageUrl = `${siteBase()}/daily/${date}.html`;
 
-  const title = `[vgm-quiz] ${item.title || ''} — ${item.game || ''}`.trim();
-  const description = `Daily VGM quiz for ${date}. Composer: ${item.track?.composer || 'N/A'}`;
-
-  const rss = `<?xml version="1.0" encoding="UTF-8" ?>
+  const rss = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
   <channel>
-    <title>vgm-quiz daily</title>
-    <link>${urlBase}/daily/latest.html</link>
-    <description>One VGM question per day</description>
+    <title>VGM Quiz — Daily</title>
+    <link>${siteBase()}</link>
+    <description>Daily game music quiz</description>
     <item>
-      <title>${escapeXml(title)}</title>
+      <title>${escapeXml(`${title} — ${game}${composer}`)}</title>
       <link>${pageUrl}</link>
       <guid>${pageUrl}</guid>
-      <description>${escapeXml(description)}</description>
-      <enclosure url="${ogUrlPng}" type="image/png"/>
-      <pubDate>${new Date().toUTCString()}</pubDate>
+      <pubDate>${new Date(date+'T00:00:00Z').toUTCString()}</pubDate>
+      <description>${escapeXml('Play today\'s quiz')}</description>
+      <enclosure url="${ogUrl}" type="image/png"/>
     </item>
   </channel>
-</rss>`;
+</rss>
+`;
 
   const jsonFeed = {
-    version: "https://jsonfeed.org/version/1.1",
-    title: "vgm-quiz daily",
-    home_page_url: `${urlBase}/daily/latest.html`, 
+    version: 'https://jsonfeed.org/version/1.1',
+    title: 'VGM Quiz — Daily',
+    home_page_url: siteBase(),
+    feed_url: `${siteBase()}/daily/feed.json`,
     items: [{
       id: pageUrl,
       url: pageUrl,
-      title,
-      content_text: description,
-      date_published: new Date().toISOString(),
-      attachments: [{
-        url: ogUrlPng,
-        mime_type: "image/png"
-      }]
+      title: `${title} — ${game}${composer}`,
+      date_published: new Date(date+'T00:00:00Z').toISOString(),
+      attachments: [{ url: ogUrl, mime_type: 'image/png' }]
     }]
   };
 
@@ -101,8 +96,5 @@ async function main() {
   console.log('[feeds] generated: public/daily/feed.(xml|json)');
 }
 
-function escapeXml(s){
-  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-}
+main().catch(e=>{ console.error(e); process.exit(1); });
 
-main();

--- a/scripts/generate_ogp.mjs
+++ b/scripts/generate_ogp.mjs
@@ -2,6 +2,7 @@
 /**
  * OGP static generator (SVG required, PNG optional)
  * - Prefers build/daily_today.json; falls back to public/app/daily_auto.json (by_date)
+ * - Accepts wrapper {date,item} and flattens.
  * - Fills assets/og/template.svg and writes public/og/YYYY-MM-DD.svg and latest.svg
  * - If @resvg/resvg-js is available, also renders PNGs.
  */
@@ -13,84 +14,76 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function pad(n){ return String(n).padStart(2, '0'); }
-function todayStr() {
-  const d = new Date();
-  return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
+function todayStrJST() {
+  const now = new Date();
+  const jst = new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }));
+  const y = jst.getFullYear();
+  const m = pad(jst.getMonth()+1);
+  const d = pad(jst.getDate());
+  return `${y}-${m}-${d}`;
 }
 
-async function ensureDir(p) {
-  if (!existsSync(p)) await mkdir(p, { recursive: true });
+function unwrapEnvelope(x){
+  if (x && typeof x === 'object') {
+    if (x.item && (x.date || x.item.date)) return { date: x.date || x.item.date, item: x.item };
+    if (x.date && (x.title || x.game || x.media)) { const { date, ...rest } = x; return { date, item: rest }; }
+    if (x.by_date && typeof x.by_date === 'object') {
+      const dates = Object.keys(x.by_date).sort();
+      const date = dates[dates.length - 1];
+      return { date, item: x.by_date[date] };
+    }
+    if (x.title || x.game || x.media) return { date: null, item: x };
+    if (Array.isArray(x) && x.length) return { date: null, item: x[x.length-1] };
+  }
+  return { date: null, item: null };
 }
 
-function inject(svg, fields) {
-  let out = svg;
-  out = out.replace('id="date">YYYY-MM-DD', `id="date">${fields.date}`);
-  out = out.replace('id="title">Track Title', `id="title">${escapeXml(fields.title)}`);
-  out = out.replace('id="game">Game Title', `id="game">${escapeXml(fields.game)}`);
-  out = out.replace('id="composer">Composer', `id="composer">${escapeXml(fields.composer)}`);
-  out = out.replace('width="0" height="24" rx="12" fill="#60a5fa" id="difficultyBar"', `width="${Math.round((fields.difficulty||0)*800)}" height="24" rx="12" fill="#60a5fa" id="difficultyBar"`);
-  out = out.replace('id="difficulty">difficulty 0.00', `id="difficulty">difficulty ${(fields.difficulty||0).toFixed(2)}`);
-  return out;
+async function loadLatest(){
+  const prefer = path.resolve(__dirname, '../build/daily_today.json');
+  const fallback = path.resolve(__dirname, '../public/app/daily_auto.json');
+  let data, src;
+  if (existsSync(prefer)) { data = JSON.parse(await readFile(prefer, 'utf-8')); src = prefer; }
+  else if (existsSync(fallback)) { data = JSON.parse(await readFile(fallback, 'utf-8')); src = fallback; }
+  else throw new Error('no source found');
+  const { date, item } = unwrapEnvelope(data);
+  return { date: date || todayStrJST(), item, src };
 }
 
-function escapeXml(s){
-  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+function inject(svg, fields){
+  return svg
+    .replace(/{{\s*title\s*}}/g, fields.title)
+    .replace(/{{\s*game\s*}}/g, fields.game)
+    .replace(/{{\s*composer\s*}}/g, fields.composer)
+    .replace(/{{\s*date\s*}}/g, fields.date)
+    .replace(/{{\s*difficulty\s*}}/g, String(fields.difficulty ?? 0));
 }
 
-async function maybePng(svgBuf, outPng) {
+async function maybePng(svgBuf, outFile){
   try {
-    const { Resvg } = await import('@resvg/resvg-js'); // optional dependency
-    const resvg = new Resvg(svgBuf, { fitTo: { mode: 'width', value: 1200 } });
-    const png = resvg.render().asPng();
-    await writeFile(outPng, png);
+    const { Resvg } = await import('@resvg/resvg-js');
+    const r = new Resvg(svgBuf);
+    const png = r.render().asPng();
+    await writeFile(outFile, png);
     return true;
   } catch (e) {
-    console.warn('[ogp] PNG render skipped (resvg not installed):', e.message || e);
+    console.log('[ogp] PNG skipped (no @resvg/resvg-js)');
     return false;
   }
 }
 
-async function readDaily() {
-  // prefer build/daily_today.json, else public/app/daily_auto.json
-  const buildPath = path.resolve(__dirname, '../build/daily_today.json');
-  if (existsSync(buildPath)) {
-    const o = JSON.parse(await readFile(buildPath, 'utf-8'));
-    // unwrap slim shape
-    if (o && o.item && typeof o.item === 'object') {
-      return { date: o.date, ...o.item };
-    }
-    return o;
-  }
-  const autoPath = path.resolve(__dirname, '../public/app/daily_auto.json');
-  if (existsSync(autoPath)) {
-    return JSON.parse(await readFile(autoPath, 'utf-8'));
-  }
-  return null;
-}
+async function main(){
+  const { date, item, src } = await loadLatest();
+  if (!item) throw new Error(`no item to render (src=${src})`);
 
-async function main() {
   const tpl = path.resolve(__dirname, '../assets/og/template.svg');
   const outDir = path.resolve(__dirname, '../public/og');
-  await ensureDir(outDir);
+  if (!existsSync(outDir)) await mkdir(outDir, { recursive: true });
 
-  const rawObj = await readDaily();
-  if (!rawObj) {
-    console.warn('[ogp] no source JSON found (build/daily_today.json nor public/app/daily_auto.json) — skip');
-    return;
-  }
-  let item = rawObj;
-  if (item && item.by_date && typeof item.by_date === 'object') {
-    const keys = Object.keys(item.by_date);
-    if (keys.length === 1) {
-      item = { date: keys[0], ...item.by_date[keys[0]] };
-    }
-  }
-  const date = item.date || todayStr();
   const fields = {
+    title: String(item.title || '').slice(0, 140),
+    game: String(item.game || '').slice(0, 140),
+    composer: String(item?.track?.composer || '').slice(0, 140),
     date,
-    title: item.title || '',
-    game: item.game || '',
-    composer: item.track?.composer || '',
     difficulty: typeof item.difficulty === 'number' ? item.difficulty : 0
   };
   const svg = await readFile(tpl, 'utf-8');
@@ -101,13 +94,12 @@ async function main() {
   await writeFile(outSvg, filled, 'utf-8');
   await writeFile(outSvgLatest, filled, 'utf-8');
 
-  // Try PNG (optional)
   const outPng = path.join(outDir, `${date}.png`);
   const outPngLatest = path.join(outDir, `latest.png`);
   const pngOk = await maybePng(Buffer.from(filled), outPng);
   if (pngOk) await writeFile(outPngLatest, await readFile(outPng));
 
-  console.log(`[ogp] generated: ${path.relative(process.cwd(), outSvg)} (+png:${pngOk})`);
+  console.log(`[ogp] wrote ${path.relative(process.cwd(), outSvg)} (+latest)`);
 }
 
-main();
+main().catch(e=>{ console.error(e); process.exit(1); });

--- a/scripts/validate_authoring_schema.mjs
+++ b/scripts/validate_authoring_schema.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 /**
- * v1.8 soft schema check (no external deps)
+ * v1.8 schema check (strict core, soft difficulty)
  * - Validates shape of a single daily item (today) using lightweight checks.
- * - Sources: prefer build/daily_today.json; fallback to public/app/daily_auto.json
- * - Exit 0 by default (soft). Set SCHEMA_CHECK_STRICT=true to exit 1 on violations.
+ * - Sources: prefer build/daily_today.json ({date,item}); fallback to public/app/daily_auto.json (by_date or array)
+ * - Exit 1 on CORE violations (title/game/track.composer/media.provider/id/answers.canonical).
+ * - 'difficulty' is **warning-only** (missing or out-of-range does not fail the job).
  */
-import { readFile } from 'fs/promises';
-import { existsSync } from 'fs';
+import { readFile, access } from 'fs/promises';
+import { constants as fsconst } from 'fs';
 import path from 'path';
 import url from 'url';
 
@@ -17,78 +18,97 @@ const candidates = [
   path.resolve(__dirname, '../public/app/daily_auto.json')
 ];
 
-function pickSource() {
-  for (const p of candidates) {
-    if (existsSync(p)) return p;
-  }
-  return null;
+function annotate(msg){ console.log(`::warning::${msg}`); }
+function errornote(msg){ console.log(`::error::${msg}`); }
+
+function isNonEmptyString(x){ return typeof x === 'string' && x.trim().length > 0; }
+function isStringArray(x){ return Array.isArray(x) && x.length > 0 && x.every(isNonEmptyString); }
+
+async function exists(p){
+  try { await access(p, fsconst.R_OK); return true; } catch { return false; }
 }
 
-function isNonEmptyString(x) {
-  return typeof x === 'string' && x.trim().length > 0;
-}
-
-function isStringArray(arr) {
-  return Array.isArray(arr) && arr.every(isNonEmptyString);
-}
-
-function annotate(msg) {
-  // GitHub Actions annotation compatible line
-  console.log(`::warning::schema ${msg}`);
-}
-
-async function main() {
-  const strict = (process.env.SCHEMA_CHECK_STRICT || 'false').toLowerCase() === 'true';
-  const src = pickSource();
-  if (!src) {
-    annotate('no source found (build/daily_today.json nor public/app/daily_auto.json)');
-    process.exit(strict ? 1 : 0);
-  }
-  const raw = await readFile(src, 'utf-8');
-  let data;
-  try {
-    data = JSON.parse(raw);
-  } catch (e) {
-    annotate(`invalid JSON: ${e.message}`);
-    process.exit(strict ? 1 : 0);
-  }
-
-  // Some builds may wrap the item (e.g., { by_date: { "YYYY-MM-DD": {...} } })
-  if (data && data.by_date && typeof data.by_date === 'object') {
-    const keys = Object.keys(data.by_date);
-    if (keys.length === 1) {
-      data = { date: keys[0], ...data.by_date[keys[0]] };
+function unwrapEnvelope(x){
+  // Accept shapes: {date,item}, {date, ...flat}, flat item, by_date map, array
+  if (x && typeof x === 'object') {
+    if (x.item && (x.date || x.item.date)) {
+      return { date: x.date || x.item.date, item: x.item };
+    }
+    if (x.date && (x.title || x.game || x.media)) {
+      const { date, ...rest } = x;
+      return { date, item: rest };
+    }
+    if (x.by_date && typeof x.by_date === 'object') {
+      const dates = Object.keys(x.by_date).sort();
+      const date = dates[dates.length - 1];
+      return { date, item: x.by_date[date] };
+    }
+    // If it looks like a single flat item
+    if (x.title || x.game || x.media) {
+      return { date: null, item: x };
+    }
+    // If it's an array, pick last
+    if (Array.isArray(x) && x.length) {
+      return { date: null, item: x[x.length - 1] };
     }
   }
-  // Slim export shape: { date: "YYYY-MM-DD", item: {...} }
-  if (data && data.item && typeof data.item === 'object') {
-    const date = data.date;
-    data = { date, ...data.item };
-  }
+  return { date: null, item: null };
+}
 
+async function loadSource(){
+  for (const p of candidates){
+    if (await exists(p)){
+      const txt = await readFile(p, 'utf-8');
+      let data;
+      try { data = JSON.parse(txt); } catch (e) {
+        errornote(`schema: JSON parse error in ${p}: ${e.message}`);
+        process.exit(1);
+      }
+      return { src: p, ...unwrapEnvelope(data) };
+    }
+  }
+  errornote('schema: no source found (build/daily_today.json nor public/app/daily_auto.json)');
+  process.exit(1);
+}
+
+function validate(item){
   const errors = [];
-  // Required top-level
-  if (!isNonEmptyString(data.title)) errors.push('title missing/non-string');
-  if (!isNonEmptyString(data.game)) errors.push('game missing/non-string');
-  if (!(data.track && isNonEmptyString(data.track.composer))) errors.push('track.composer missing/non-string');
-  if (!(data.media && isNonEmptyString(data.media.provider) && isNonEmptyString(data.media.id))) errors.push('media.provider/id missing/non-string');
-  if (!(data.answers && isStringArray(data.answers.canonical) && data.answers.canonical.length > 0)) errors.push('answers.canonical missing/empty');
+  const warnings = [];
 
-  // Optional but recommended
-  if (typeof data.difficulty !== 'number' || data.difficulty < 0 || data.difficulty > 1) {
-    errors.push('difficulty missing or out of range [0,1]');
+  if (!isNonEmptyString(item?.title)) errors.push('schema title missing/non-string');
+  if (!isNonEmptyString(item?.game)) errors.push('schema game missing/non-string');
+  if (!isNonEmptyString(item?.track?.composer)) errors.push('schema track.composer missing/non-string');
+
+  const provider = item?.media?.provider;
+  const mid = item?.media?.id;
+  if (!isNonEmptyString(provider) || !isNonEmptyString(mid)) {
+    errors.push('schema media.provider/id missing/non-string');
   }
 
-  // choices integrity (if present)
-  if (Array.isArray(data.choices)) {
-    const uniq = new Set(data.choices.map(String));
-    if (uniq.size !== data.choices.length) errors.push('choices contain duplicates');
+  const ac = item?.answers?.canonical;
+  if (!(isNonEmptyString(ac) || isStringArray(ac))) {
+    errors.push('schema answers.canonical missing/empty');
   }
 
+  const diff = item?.difficulty;
+  if (!(typeof diff === 'number' && diff >= 0 && diff <= 1)) {
+    warnings.push('schema difficulty missing or out of range [0,1]');
+  }
+  return { errors, warnings };
+}
+
+async function main(){
+  const { src, date, item } = await loadSource();
+  if (!item) {
+    errornote(`schema: no item in ${src}`);
+    process.exit(1);
+  }
+  const { errors, warnings } = validate(item);
+  for (const w of warnings) annotate(w);
   if (errors.length) {
-    errors.forEach(e => annotate(e));
+    for (const e of errors) errornote(e);
     console.log(`schema: violations=${errors.length} file=${src}`);
-    process.exit(strict ? 1 : 0);
+    process.exit(1);
   } else {
     console.log(`schema: OK file=${src}`);
     process.exit(0);
@@ -96,6 +116,6 @@ async function main() {
 }
 
 main().catch(e => {
-  annotate(`unhandled error: ${e?.stack || e}`);
+  errornote(`unhandled error: ${e?.stack || e}`);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- add strict core schema validator with soft difficulty warnings
- allow OGP and feed generators to unwrap {date,item} envelopes
- streamline OGP/feed workflow and PR creation

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `node scripts/validate_authoring_schema.mjs` *(fails: schema track.composer missing/non-string)*

------
https://chatgpt.com/codex/tasks/task_e_68bad478e0bc8324a702b8fe400bfa8c