### PR TITLE
chore: update schema validation and OGP feeds workflow

### DIFF
--- a/.github/workflows/ogp-and-feeds.yml
+++ b/.github/workflows/ogp-and-feeds.yml
@@ -20,50 +20,53 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+
+      - name: Guard: DAILY_PR_PAT must exist
+        run: |
+          if [ -z "${{ secrets.DAILY_PR_PAT }}" ]; then
+            echo "::error::DAILY_PR_PAT is missing. Add a PAT with 'repo' scope in Settings > Secrets > Actions."
+            exit 1
+          fi
+
       - name: Prepare workspace
         run: |
-          mkdir -p build public/og public/daily
-
-      - name: Export today's slim (fallback)
-        run: |
-          if [ ! -f build/daily_today.json ]; then
-            node scripts/export_today_slim.mjs --out-json build/daily_today.json --out-md build/daily_today.md || true
-          fi
+          mkdir -p public/og public/daily build
 
       - name: Optional PNG renderer
         run: |
-          npm --version
-          npm i --no-save @resvg/resvg-js || true
+          npm i --no-save @resvg/resvg-js || echo "resvg not installed; PNG will be skipped"
 
-      - name: Generate OGP (SVG/PNG)
+      - name: Ensure slim artifact (best-effort)
+        run: |
+          node scripts/export_today_slim.mjs || echo "export_today_slim.mjs failed; will fallback to public/app/daily_auto.json"
+
+      - name: Generate OGP (SVG + optional PNG)
         run: node scripts/generate_ogp.mjs
 
-      - name: Generate Feeds (RSS/JSON)
+      - name: Generate Feeds (single-item)
         run: node scripts/generate_feeds_min.mjs
 
-      - name: Create PR
+      - name: Read date for PR title (JST)
+        id: meta
+        shell: bash
+        run: |
+          echo "date=$(TZ=Asia/Tokyo date +%F)" >> "$GITHUB_OUTPUT"
+
+      - name: Create PR (OGP & Feeds)
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.DAILY_PR_PAT }}
-          branch: "bot/ogp-and-feeds/${{ github.run_id }}"
+          branch: bot/ogp-and-feeds/${{ steps.meta.outputs.date }}
+          title: "Daily OGP & Feeds for ${{ steps.meta.outputs.date }}"
           commit-message: |
-            chore(ogp+feeds): update OGP and feeds for daily
-          title: "chore(ogp+feeds): update OGP and feeds for daily"
-          body: |
-            This PR adds/updates:
-            - OGP assets: `public/og/YYYY-MM-DD.(svg|png)` and `public/og/latest.(svg|png)`
+            chore(ogp,feeds): generate static OGP and feeds for ${{ steps.meta.outputs.date }}
+            
+            - OGP: `public/og/${{ steps.meta.outputs.date }}.(svg|png)` and `latest.*`
             - Feeds: `public/daily/feed.xml` and `public/daily/feed.json`
-
+            
             Auto-created by `daily (ogp+feeds)`.
           add-paths: |
             public/og/**
             public/daily/feed.xml
             public/daily/feed.json
-          delete-branch: true
-          labels: automation, ogp, feeds
 
-      - name: Summary
-        run: |
-          echo "### daily (ogp+feeds)" >> $GITHUB_STEP_SUMMARY
-          echo "- OGP SVG required; PNG if @resvg/resvg-js is present" >> $GITHUB_STEP_SUMMARY
-          echo "- Feeds: public/daily/feed.(xml|json)" >> $GITHUB_STEP_SUMMARY

--- a/docs/DESIGN_OGP.md
+++ b/docs/DESIGN_OGP.md
@@ -43,8 +43,15 @@
 - クリップ時間の可視化（将来の Collector v1 で開始秒が決まったら描画）
 
 ## 運用メモ（PRの必須チェックが走らない場合）
-`daily (ogp+feeds)` が作る PR では、**GITHUB_TOKEN ではなく PAT（例: 
+`daily (ogp+feeds)` が作る PR では、**GITHUB_TOKEN ではなく PAT（例:
 `${{ secrets.DAILY_PR_PAT }}`）**を使ってください。
 GitHub の仕様で、GITHUB_TOKEN による PR/commit では `pull_request` トリガの Workflow が起動しない場合があり、
 ブランチ保護の Required（`ci-fast-pr-build` / `pages-pr-build` / `required-check`）が永続 Pending になることがあります。
 本プロジェクトでは PAT の使用を前提にしています。
+
+
+## v1.8 追補 — データ参照とワークフロー
+- **データ参照**：`build/daily_today.json` があれば優先。無ければ `public/app/daily_auto.json` の `by_date` 最新を使用。
+- **YAML 再構成**：`.github/workflows/ogp-and-feeds.yml` は `env:` 埋め込みを避け、`Read date` は `TZ=Asia/Tokyo date +%F` を用いて安全化。
+- **PNG 任意化**：`@resvg/resvg-js` は `npm i --no-save` を試行し、失敗時は **SVGのみ**生成（ジョブは成功）。
+- **PR 作成**：`peter-evans/create-pull-request@v6` を使用し、**`token: ${{ secrets.DAILY_PR_PAT }}`** を必須とする。

--- a/docs/OPERATIONS_AUTHORING.md
+++ b/docs/OPERATIONS_AUTHORING.md
@@ -55,3 +55,15 @@ PR作成に **GITHUB_TOKEN** を使っていることが原因です。**必ず 
 - **answers.canonical** が正規化済み
 - Actions ログに `[difficulty] date=… values=[…]` の数値出力がある
 
+
+
+## v1.8 追補 — スキーマ検証の仕様更新
+- **入力の自動アンラップ**：`build/daily_today.json` の `{ date, item }` 形を自動で `{ date, ...item }` に展開して検証します。
+- **フォールバック**：`build/daily_today.json` が無い/壊れている場合は `public/app/daily_auto.json` の `by_date` から最新日付を選びます（JST想定）。
+- **composer の互換**：`item.composer` と `item.track.composer` の **どちらでも可**（過去データの互換保持）。
+- **difficulty は警告**：`0..1` の範囲外や欠落は `::warning::` として注記し、**ジョブは失敗させません**。
+
+### 手動確認メモ
+- Actions の `authoring (schema check)` を実行し、`schema: OK file=... date=YYYY-MM-DD` を確認。
+- 必須欠落（title/game/composer/media.provider/id/answers.canonical）がある場合は `::error::` が出て **失敗**します。
+

--- a/scripts/generate_feeds_min.mjs
+++ b/scripts/generate_feeds_min.mjs
@@ -16,79 +16,83 @@ function siteBase() {
   return 'https://nantes-rfli.github.io/vgm-quiz';
 }
 
-function unwrapEnvelope(x){
-  if (x && typeof x === 'object') {
-    if (x.item && (x.date || x.item.date)) return { date: x.date || x.item.date, item: x.item };
-    if (x.date && (x.title || x.game || x.media)) { const { date, ...rest } = x; return { date, item: rest }; }
-    if (x.by_date && typeof x.by_date === 'object') {
-      const dates = Object.keys(x.by_date).sort();
-      const date = dates[dates.length - 1];
-      return { date, item: x.by_date[date] };
+function escapeXml(s){ return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+function pad(n){ return String(n).padStart(2,'0'); }
+function todayStrJST() {
+  const fmt = new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Tokyo', year:'numeric', month:'2-digit', day:'2-digit' });
+  const p = fmt.formatToParts(new Date()).reduce((o,v)=> (o[v.type]=v.value, o), {});
+  return `${p.year}-${p.month}-${p.day}`;
+}
+
+function pickLatest(by_date){
+  const entries = Object.entries(by_date || {}).filter(([d,v])=>v && typeof v==='object');
+  if (!entries.length) return null;
+  entries.sort((a,b)=>a[0].localeCompare(b[0]));
+  const [date, item] = entries[entries.length-1];
+  return { date, item };
+}
+
+async function readDaily() {
+  const buildPath = path.resolve(__dirname, '../build/daily_today.json');
+  if (existsSync(buildPath)) {
+    const o = JSON.parse(await readFile(buildPath, 'utf-8'));
+    if (o && o.item && typeof o.item === 'object') {
+      return { date: o.date, item: o.item };
     }
-    if (x.title || x.game || x.media) return { date: null, item: x };
-    if (Array.isArray(x) && x.length) return { date: null, item: x[x.length-1] };
+    if (o && o.by_date && typeof o.by_date==='object'){
+      const p = pickLatest(o.by_date);
+      if (p) return p;
+    }
+    if (o && (o.title || o.game || o.media)){
+      return { date: todayStrJST(), item: o };
+    }
   }
-  return { date: null, item: null };
+  const autoPath = path.resolve(__dirname, '../public/app/daily_auto.json');
+  if (existsSync(autoPath)) {
+    const obj = JSON.parse(await readFile(autoPath, 'utf-8'));
+    const p = pickLatest(obj.by_date);
+    if (p) return p;
+  }
+  return null;
 }
 
-async function loadLatest(){
-  const prefer = path.resolve(__dirname, '../build/daily_today.json');
-  const fallback = path.resolve(__dirname, '../public/app/daily_auto.json');
-  let data, src;
-  if (existsSync(prefer)) { data = JSON.parse(await readFile(prefer, 'utf-8')); src = prefer; }
-  else if (existsSync(fallback)) { data = JSON.parse(await readFile(fallback, 'utf-8')); src = fallback; }
-  else throw new Error('no source found');
-  const { date, item } = unwrapEnvelope(data);
-  return { date: date || new Date().toISOString().slice(0,10), item, src };
-}
-
-function escapeXml(s){
-  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-}
-
-async function main(){
-  const { date, item } = await loadLatest();
-  if (!item) throw new Error('no item for feeds');
-
+async function main() {
   const outDir = path.resolve(__dirname, '../public/daily');
-  if (!existsSync(outDir)) await mkdir(outDir, { recursive: true });
+  const daily = await readDaily();
+  if (!daily) {
+    console.warn('[feeds] no source JSON found (build/daily_today.json nor public/app/daily_auto.json) — skip');
+    return;
+  }
+  await mkdir(outDir, { recursive: true });
 
-  const title = item.title || 'Untitled';
-  const game = item.game || '';
-  const composer = (item?.track?.composer) ? ` — ${item.track.composer}` : '';
-  const ogUrl = `${siteBase()}/og/${date}.png`;
-  const pageUrl = `${siteBase()}/daily/${date}.html`;
+  const { date, item } = daily;
+  const urlBase = siteBase();
+  const pageUrl = `${urlBase}/daily/${date}.html`;
+  const ogUrlPng = `${urlBase}/og/${date}.png`;
 
-  const rss = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
-  <channel>
-    <title>VGM Quiz — Daily</title>
-    <link>${siteBase()}</link>
-    <description>Daily game music quiz</description>
-    <item>
-      <title>${escapeXml(`${title} — ${game}${composer}`)}</title>
-      <link>${pageUrl}</link>
-      <guid>${pageUrl}</guid>
-      <pubDate>${new Date(date+'T00:00:00Z').toUTCString()}</pubDate>
-      <description>${escapeXml('Play today\'s quiz')}</description>
-      <enclosure url="${ogUrl}" type="image/png"/>
-    </item>
-  </channel>
-</rss>
-`;
+  const composer = item.track?.composer || item.composer || 'N/A';
+  const title = `[vgm-quiz] ${item.title || ''} — ${item.game || ''}`.trim();
+  const description = `Daily VGM quiz for ${date}. Composer: ${composer}`;
+
+  const rss = `<?xml version="1.0" encoding="UTF-8" ?>\n<rss version="2.0">\n  <channel>\n    <title>${escapeXml(title)}</title>\n    <link>${urlBase}</link>\n    <description>${escapeXml(description)}</description>\n    <item>\n      <title>${escapeXml(title)}</title>\n      <link>${pageUrl}</link>\n      <guid>${pageUrl}</guid>\n      <pubDate>${new Date().toUTCString()}</pubDate>\n      <description>${escapeXml(description)}</description>\n      <enclosure url="${ogUrlPng}" type="image/png" />\n    </item>\n  </channel>\n</rss>\n`;
 
   const jsonFeed = {
-    version: 'https://jsonfeed.org/version/1.1',
-    title: 'VGM Quiz — Daily',
-    home_page_url: siteBase(),
-    feed_url: `${siteBase()}/daily/feed.json`,
+    version: "https://jsonfeed.org/version/1.1",
+    title: "vgm-quiz daily",
+    home_page_url: `${urlBase}/daily/latest.html`,
     items: [{
       id: pageUrl,
       url: pageUrl,
-      title: `${title} — ${game}${composer}`,
-      date_published: new Date(date+'T00:00:00Z').toISOString(),
-      attachments: [{ url: ogUrl, mime_type: 'image/png' }]
-    }]
+      title,
+      content_text: description,
+      image: ogUrlPng,
+      date_published: new Date().toISOString(),
+      attachments: [{
+        url: ogUrlPng,
+        mime_type: "image/png",
+      }],
+    }],
   };
 
   await writeFile(path.join(outDir, 'feed.xml'), rss, 'utf-8');
@@ -96,5 +100,5 @@ async function main(){
   console.log('[feeds] generated: public/daily/feed.(xml|json)');
 }
 
-main().catch(e=>{ console.error(e); process.exit(1); });
+main();
 

--- a/scripts/generate_ogp.mjs
+++ b/scripts/generate_ogp.mjs
@@ -15,79 +15,101 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function pad(n){ return String(n).padStart(2, '0'); }
 function todayStrJST() {
-  const now = new Date();
-  const jst = new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }));
-  const y = jst.getFullYear();
-  const m = pad(jst.getMonth()+1);
-  const d = pad(jst.getDate());
-  return `${y}-${m}-${d}`;
+  const fmt = new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Tokyo', year:'numeric', month:'2-digit', day:'2-digit' });
+  const p = fmt.formatToParts(new Date()).reduce((o,v)=> (o[v.type]=v.value, o), {});
+  return `${p.year}-${p.month}-${p.day}`;
 }
 
-function unwrapEnvelope(x){
-  if (x && typeof x === 'object') {
-    if (x.item && (x.date || x.item.date)) return { date: x.date || x.item.date, item: x.item };
-    if (x.date && (x.title || x.game || x.media)) { const { date, ...rest } = x; return { date, item: rest }; }
-    if (x.by_date && typeof x.by_date === 'object') {
-      const dates = Object.keys(x.by_date).sort();
-      const date = dates[dates.length - 1];
-      return { date, item: x.by_date[date] };
-    }
-    if (x.title || x.game || x.media) return { date: null, item: x };
-    if (Array.isArray(x) && x.length) return { date: null, item: x[x.length-1] };
-  }
-  return { date: null, item: null };
+async function ensureDir(p) {
+  if (!existsSync(p)) await mkdir(p, { recursive: true });
 }
 
-async function loadLatest(){
-  const prefer = path.resolve(__dirname, '../build/daily_today.json');
-  const fallback = path.resolve(__dirname, '../public/app/daily_auto.json');
-  let data, src;
-  if (existsSync(prefer)) { data = JSON.parse(await readFile(prefer, 'utf-8')); src = prefer; }
-  else if (existsSync(fallback)) { data = JSON.parse(await readFile(fallback, 'utf-8')); src = fallback; }
-  else throw new Error('no source found');
-  const { date, item } = unwrapEnvelope(data);
-  return { date: date || todayStrJST(), item, src };
+function escapeXml(s){
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 }
 
-function inject(svg, fields){
-  return svg
-    .replace(/{{\s*title\s*}}/g, fields.title)
-    .replace(/{{\s*game\s*}}/g, fields.game)
-    .replace(/{{\s*composer\s*}}/g, fields.composer)
-    .replace(/{{\s*date\s*}}/g, fields.date)
-    .replace(/{{\s*difficulty\s*}}/g, String(fields.difficulty ?? 0));
+function inject(svg, fields) {
+  let out = svg;
+  out = out.replace('id="title">Track Title', `id="title">${escapeXml(fields.title)}`);
+  out = out.replace('id="game">Game Title', `id="game">${escapeXml(fields.game)}`);
+  out = out.replace('id="composer">Composer', `id="composer">${escapeXml(fields.composer)}`);
+  // naive difficulty bar 0..1 -> 0..800 width
+  const w = Math.max(0, Math.min(1, Number(fields.difficulty || 0))) * 800;
+  out = out.replace('width="0" height="24" rx="12" fill="#60a5fa" id="difficultyBar"', `width="${Math.round(w)}" height="24" rx="12" fill="#60a5fa" id="difficultyBar"`);
+  out = out.replace('id="difficulty">difficulty 0.00', `id="difficulty">difficulty ${(Number(fields.difficulty)||0).toFixed(2)}`);
+  return out;
 }
 
-async function maybePng(svgBuf, outFile){
+async function maybePng(svgBuf, outPng) {
   try {
     const { Resvg } = await import('@resvg/resvg-js');
     const r = new Resvg(svgBuf);
     const png = r.render().asPng();
-    await writeFile(outFile, png);
+    await writeFile(outPng, png);
     return true;
   } catch (e) {
-    console.log('[ogp] PNG skipped (no @resvg/resvg-js)');
+    console.warn('[ogp] PNG skipped:', e?.message || e);
     return false;
   }
 }
 
-async function main(){
-  const { date, item, src } = await loadLatest();
-  if (!item) throw new Error(`no item to render (src=${src})`);
+function isStr(x){ return typeof x === 'string' && x.trim().length>0; }
 
+function pickLatest(by_date){
+  const entries = Object.entries(by_date || {}).filter(([d,v])=>v && typeof v==='object');
+  if (!entries.length) return null;
+  entries.sort((a,b)=>a[0].localeCompare(b[0]));
+  const [date, item] = entries[entries.length-1];
+  return { date, item };
+}
+
+async function readDaily() {
+  // prefer build/daily_today.json, else public/app/daily_auto.json
+  const buildPath = path.resolve(__dirname, '../build/daily_today.json');
+  if (existsSync(buildPath)) {
+    const o = JSON.parse(await readFile(buildPath, 'utf-8'));
+    // unwrap slim shape
+    if (o && o.item && typeof o.item === 'object') {
+      return { date: o.date, item: o.item };
+    }
+    if (o && o.by_date && typeof o.by_date==='object'){
+      const p = pickLatest(o.by_date);
+      if (p) return p;
+    }
+    if (o && (o.title || o.game || o.media)){
+      return { date: todayStrJST(), item: o };
+    }
+  }
+  const autoPath = path.resolve(__dirname, '../public/app/daily_auto.json');
+  if (existsSync(autoPath)) {
+    const obj = JSON.parse(await readFile(autoPath, 'utf-8'));
+    const p = pickLatest(obj.by_date);
+    if (p) return p;
+  }
+  return null;
+}
+
+async function main() {
   const tpl = path.resolve(__dirname, '../assets/og/template.svg');
   const outDir = path.resolve(__dirname, '../public/og');
-  if (!existsSync(outDir)) await mkdir(outDir, { recursive: true });
+  await ensureDir(outDir);
 
-  const fields = {
-    title: String(item.title || '').slice(0, 140),
-    game: String(item.game || '').slice(0, 140),
-    composer: String(item?.track?.composer || '').slice(0, 140),
-    date,
-    difficulty: typeof item.difficulty === 'number' ? item.difficulty : 0
-  };
+  const daily = await readDaily();
+  if (!daily){
+    console.warn('[ogp] no daily data found; skip');
+    return;
+  }
+  const { date, item } = daily;
+
+  const composer = item.composer || (item.track && item.track.composer) || '';
   const svg = await readFile(tpl, 'utf-8');
-  const filled = inject(svg, fields);
+  const filled = inject(svg, {
+    date,
+    title: item.title || '',
+    game: item.game || '',
+    composer,
+    difficulty: Number(item.difficulty||0)
+  });
 
   const outSvg = path.join(outDir, `${date}.svg`);
   const outSvgLatest = path.join(outDir, `latest.svg`);
@@ -96,10 +118,12 @@ async function main(){
 
   const outPng = path.join(outDir, `${date}.png`);
   const outPngLatest = path.join(outDir, `latest.png`);
-  const pngOk = await maybePng(Buffer.from(filled), outPng);
-  if (pngOk) await writeFile(outPngLatest, await readFile(outPng));
+  if (await maybePng(Buffer.from(filled), outPng)) {
+    await writeFile(outPngLatest, await readFile(outPng));
+  }
 
   console.log(`[ogp] wrote ${path.relative(process.cwd(), outSvg)} (+latest)`);
 }
 
-main().catch(e=>{ console.error(e); process.exit(1); });
+main().catch(e => { console.error(e); process.exit(1); });
+

--- a/scripts/validate_authoring_schema.mjs
+++ b/scripts/validate_authoring_schema.mjs
@@ -1,121 +1,141 @@
 #!/usr/bin/env node
 /**
- * v1.8 schema check (strict core, soft difficulty)
- * - Validates shape of a single daily item (today) using lightweight checks.
- * - Sources: prefer build/daily_today.json ({date,item}); fallback to public/app/daily_auto.json (by_date or array)
- * - Exit 1 on CORE violations (title/game/track.composer/media.provider/id/answers.canonical).
- * - 'difficulty' is **warning-only** (missing or out-of-range does not fail the job).
+ * validate_authoring_schema.mjs (v1.8+)
+ * - Validates the "today" daily item shape.
+ * - Sources (in order):
+ *    1) build/daily_today.json  ({ date, item })
+ *    2) public/app/daily_auto.json (by_date)
+ * - Behavior:
+ *    * Required fields -> error
+ *    * difficulty in [0,1] -> ok; missing/out-of-range -> warning (does not fail)
+ * - Exit:
+ *    * default: strict (fail on errors); env SCHEMA_CHECK_STRICT=false to soften
+
  */
-import { readFile, access } from 'fs/promises';
-import { constants as fsconst } from 'fs';
-import path from 'path';
-import url from 'url';
+import fs from 'node:fs/promises';
+import fss from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const candidates = [
-  path.resolve(__dirname, '../build/daily_today.json'),
-  path.resolve(__dirname, '../public/app/daily_auto.json')
-];
-
-function annotate(msg){ console.log(`::warning::${msg}`); }
-function errornote(msg){ console.log(`::error::${msg}`); }
-
-function isNonEmptyString(x){ return typeof x === 'string' && x.trim().length > 0; }
-function isStringArray(x){ return Array.isArray(x) && x.length > 0 && x.every(isNonEmptyString); }
-
-async function exists(p){
-  try { await access(p, fsconst.R_OK); return true; } catch { return false; }
+function annotate(kind, msg){
+  const k = kind.toLowerCase();
+  const tag = k === 'error' ? '::error::' : '::warning::';
+  console.log(tag + msg);
 }
 
-function unwrapEnvelope(x){
-  // Accept shapes: {date,item}, {date, ...flat}, flat item, by_date map, array
-  if (x && typeof x === 'object') {
-    if (x.item && (x.date || x.item.date)) {
-      return { date: x.date || x.item.date, item: x.item };
-    }
-    if (x.date && (x.title || x.game || x.media)) {
-      const { date, ...rest } = x;
-      return { date, item: rest };
-    }
-    if (x.by_date && typeof x.by_date === 'object') {
-      const dates = Object.keys(x.by_date).sort();
-      const date = dates[dates.length - 1];
-      return { date, item: x.by_date[date] };
-    }
-    // If it looks like a single flat item
-    if (x.title || x.game || x.media) {
-      return { date: null, item: x };
-    }
-    // If it's an array, pick last
-    if (Array.isArray(x) && x.length) {
-      return { date: null, item: x[x.length - 1] };
-    }
-  }
-  return { date: null, item: null };
+function isStr(x){ return typeof x === 'string' && x.trim().length > 0; }
+function isNum(x){ return typeof x === 'number' && Number.isFinite(x); }
+
+function pickLatest(by_date){
+  const entries = Object.entries(by_date || {})
+    .filter(([d,v]) => v && typeof v === 'object' && isStr(d))
+    .sort((a,b) => a[0].localeCompare(b[0]));
+  if (!entries.length) return null;
+  const [date, item] = entries[entries.length-1];
+  return { date, item };
 }
 
-async function loadSource(){
-  for (const p of candidates){
-    if (await exists(p)){
-      const txt = await readFile(p, 'utf-8');
-      let data;
-      try { data = JSON.parse(txt); } catch (e) {
-        errornote(`schema: JSON parse error in ${p}: ${e.message}`);
-        process.exit(1);
-      }
-      return { src: p, ...unwrapEnvelope(data) };
-    }
+async function readJsonIfExists(p){
+  try {
+    if (!fss.existsSync(p)) return null;
+    const s = await fs.readFile(p, 'utf-8');
+    return JSON.parse(s);
+  } catch (e) {
+    annotate('error', `failed to read JSON ${p}: ${e?.message || e}`);
+    return null;
   }
-  errornote('schema: no source found (build/daily_today.json nor public/app/daily_auto.json)');
-  process.exit(1);
+}
+
+async function loadToday(){
+  const build = path.resolve(__dirname, '../build/daily_today.json');
+  const auto  = path.resolve(__dirname, '../public/app/daily_auto.json');
+
+  // 1) build/daily_today.json
+  const slim = await readJsonIfExists(build);
+  if (slim) {
+    // { date, item } shape
+    if (slim.item && typeof slim.item === 'object') {
+      return { src: build, date: slim.date, item: slim.item };
+    }
+    // Some older shapes might already be unwrapped
+    if (slim.by_date && typeof slim.by_date === 'object') {
+      const p = pickLatest(slim.by_date);
+      if (p) return { src: build, date: p.date, item: p.item };
+    }
+    // If it already looks like an item, accept
+    if (slim.title || slim.game || slim.media) {
+      return { src: build, date: null, item: slim };
+    }
+    // If present but unusable, continue to fallback
+    annotate('warning', `build/daily_today.json present but could not find an item; falling back to public/app/daily_auto.json`);
+  }
+
+  // 2) public/app/daily_auto.json
+  const autoObj = await readJsonIfExists(auto);
+  if (autoObj && autoObj.by_date && typeof autoObj.by_date === 'object') {
+    const p = pickLatest(autoObj.by_date);
+    if (p) return { src: auto, date: p.date, item: p.item };
+  }
+
+  return { src: build, date: null, item: null };
 }
 
 function validate(item){
   const errors = [];
   const warnings = [];
 
-  if (!isNonEmptyString(item?.title)) errors.push('schema title missing/non-string');
-  if (!isNonEmptyString(item?.game)) errors.push('schema game missing/non-string');
-  if (!isNonEmptyString(item?.track?.composer)) errors.push('schema track.composer missing/non-string');
-
-  const provider = item?.media?.provider;
-  const mid = item?.media?.id;
-  if (!isNonEmptyString(provider) || !isNonEmptyString(mid)) {
-    errors.push('schema media.provider/id missing/non-string');
+  if (!item || typeof item !== 'object') {
+    errors.push('no item');
+    return { errors, warnings };
   }
 
-  const ac = item?.answers?.canonical;
-  if (!(isNonEmptyString(ac) || isStringArray(ac))) {
-    errors.push('schema answers.canonical missing/empty');
-  }
+  // accept composer as either item.composer or item.track.composer
+  const composer = isStr(item.composer) ? item.composer
+                   : (item.track && isStr(item.track.composer) ? item.track.composer : null);
 
-  const diff = item?.difficulty;
-  if (!(typeof diff === 'number' && diff >= 0 && diff <= 1)) {
+  // required string fields
+  if (!isStr(item.title)) errors.push('schema title missing/non-string');
+  if (!isStr(item.game)) errors.push('schema game missing/non-string');
+  if (!composer) errors.push('schema track.composer missing/non-string');
+
+  // media
+  const m = item.media || {};
+  if (!isStr(m.provider)) errors.push('schema media.provider missing/non-string');
+  if (!isStr(m.id))       errors.push('schema media.id missing/non-string');
+
+  // answers.canonical
+  const ans = item.answers || {};
+  if (!isStr(ans.canonical)) errors.push('schema answers.canonical missing/empty');
+
+  // difficulty -> warning only
+  if (!(isNum(item.difficulty) && item.difficulty >= 0 && item.difficulty <= 1)){
     warnings.push('schema difficulty missing or out of range [0,1]');
   }
+
   return { errors, warnings };
 }
 
 async function main(){
-  const { src, date, item } = await loadSource();
-  if (!item) {
-    errornote(`schema: no item in ${src}`);
-    process.exit(1);
-  }
+  const strict = String(process.env.SCHEMA_CHECK_STRICT || 'true').toLowerCase() !== 'false';
+  const { src, date, item } = await loadToday();
+
   const { errors, warnings } = validate(item);
-  for (const w of warnings) annotate(w);
-  if (errors.length) {
-    for (const e of errors) errornote(e);
+  warnings.forEach(w => annotate('warning', w));
+
+  if (errors.length){
+    errors.forEach(e => annotate('error', e));
     console.log(`schema: violations=${errors.length} file=${src}`);
-    process.exit(1);
-  } else {
-    console.log(`schema: OK file=${src}`);
-    process.exit(0);
+    process.exit(strict ? 1 : 0);
   }
+
+  console.log(`schema: OK file=${src}${date ? ` date=${date}` : ''}`);
+  process.exit(0);
 }
 
-main().catch(e => {
-  errornote(`unhandled error: ${e?.stack || e}`);
+main().catch(e=>{
+  annotate('error', `unhandled error: ${e?.stack || e}`);
   process.exit(1);
 });
+


### PR DESCRIPTION
## Summary
- expand authoring schema validator with strict defaults and soft difficulty warnings
- rework OGP/feeds scripts to auto-select latest daily item and handle PNG optionally
- streamline daily (ogp+feeds) workflow and document v1.8 operational notes

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bad97061648324abd4858359680d3e