### PR TITLE
Refactor schema validation script

### DIFF
--- a/scripts/validate_authoring_schema.mjs
+++ b/scripts/validate_authoring_schema.mjs
@@ -1,141 +1,119 @@
 #!/usr/bin/env node
 /**
- * validate_authoring_schema.mjs (v1.8+)
- * - Validates the "today" daily item shape.
- * - Sources (in order):
- *    1) build/daily_today.json  ({ date, item })
- *    2) public/app/daily_auto.json (by_date)
- * - Behavior:
- *    * Required fields -> error
- *    * difficulty in [0,1] -> ok; missing/out-of-range -> warning (does not fail)
- * - Exit:
- *    * default: strict (fail on errors); env SCHEMA_CHECK_STRICT=false to soften
-
+ * v1.8 schema check (soft by default)
+ * - Validates shape of ONE daily item.
+ * - Sources (priority):
+ *   1) build/daily_today.json (accepts {date,item}, {date,...item}, or plain item)
+ *   2) public/app/daily_auto.json (by_date -> latest)
+ * - Exit 0 by default; set SCHEMA_CHECK_STRICT=true to fail on violations.
  */
-import fs from 'node:fs/promises';
-import fss from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { readFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const strict = (process.env.SCHEMA_CHECK_STRICT || '').toLowerCase() === 'true';
 
-function annotate(kind, msg){
-  const k = kind.toLowerCase();
-  const tag = k === 'error' ? '::error::' : '::warning::';
-  console.log(tag + msg);
+function annotate(msg, level='error'){
+  const tag = level === 'warning' ? '::warning::' : '::error::';
+  console.log(`${tag}${msg}`);
 }
 
-function isStr(x){ return typeof x === 'string' && x.trim().length > 0; }
-function isNum(x){ return typeof x === 'number' && Number.isFinite(x); }
+async function readJson(p){
+  return JSON.parse(await readFile(p, 'utf-8'));
+}
 
-function pickLatest(by_date){
-  const entries = Object.entries(by_date || {})
-    .filter(([d,v]) => v && typeof v === 'object' && isStr(d))
-    .sort((a,b) => a[0].localeCompare(b[0]));
-  if (!entries.length) return null;
-  const [date, item] = entries[entries.length-1];
+function unwrapDaily(obj){
+  // {date,item} or {date,...item} or plain item
+  if (!obj || typeof obj !== 'object') return { date: null, item: null };
+  if ('item' in obj) {
+    const { date = null, item } = obj;
+    return { date, item };
+  }
+  const keys = Object.keys(obj);
+  const looksLikeItem = ['title','game','composer','media','answers','track'].some(k => keys.includes(k));
+  if (looksLikeItem) {
+    const { date = null, ...rest } = obj;
+    return { date, item: rest };
+  }
+  return { date: null, item: null };
+}
+
+function latestFromDailyAuto(obj){
+  if (!obj || typeof obj !== 'object' || !obj.by_date) return { date: null, item: null };
+  const dates = Object.keys(obj.by_date).sort();
+  const date = dates[dates.length - 1] || null;
+  const item = date ? obj.by_date[date] : null;
   return { date, item };
 }
 
-async function readJsonIfExists(p){
-  try {
-    if (!fss.existsSync(p)) return null;
-    const s = await fs.readFile(p, 'utf-8');
-    return JSON.parse(s);
-  } catch (e) {
-    annotate('error', `failed to read JSON ${p}: ${e?.message || e}`);
-    return null;
-  }
+function isNonEmptyString(v){ return typeof v === 'string' && v.trim().length > 0; }
+function getComposer(item){
+  const t = item.track && item.track.composer;
+  const c = item.composer;
+  if (Array.isArray(t) && t.length) return t.join(', ');
+  if (isNonEmptyString(t)) return t;
+  if (Array.isArray(c) && c.length) return c.join(', ');
+  if (isNonEmptyString(c)) return c;
+  return null;
 }
 
-async function loadToday(){
-  const build = path.resolve(__dirname, '../build/daily_today.json');
-  const auto  = path.resolve(__dirname, '../public/app/daily_auto.json');
-
-  // 1) build/daily_today.json
-  const slim = await readJsonIfExists(build);
-  if (slim) {
-    // { date, item } shape
-    if (slim.item && typeof slim.item === 'object') {
-      return { src: build, date: slim.date, item: slim.item };
-    }
-    // Some older shapes might already be unwrapped
-    if (slim.by_date && typeof slim.by_date === 'object') {
-      const p = pickLatest(slim.by_date);
-      if (p) return { src: build, date: p.date, item: p.item };
-    }
-    // If it already looks like an item, accept
-    if (slim.title || slim.game || slim.media) {
-      return { src: build, date: null, item: slim };
-    }
-    // If present but unusable, continue to fallback
-    annotate('warning', `build/daily_today.json present but could not find an item; falling back to public/app/daily_auto.json`);
-  }
-
-  // 2) public/app/daily_auto.json
-  const autoObj = await readJsonIfExists(auto);
-  if (autoObj && autoObj.by_date && typeof autoObj.by_date === 'object') {
-    const p = pickLatest(autoObj.by_date);
-    if (p) return { src: auto, date: p.date, item: p.item };
-  }
-
-  return { src: build, date: null, item: null };
-}
-
-function validate(item){
+function validate(date, item){
   const errors = [];
   const warnings = [];
-
   if (!item || typeof item !== 'object') {
-    errors.push('no item');
+    errors.push('schema: no item in source');
     return { errors, warnings };
   }
-
-  // accept composer as either item.composer or item.track.composer
-  const composer = isStr(item.composer) ? item.composer
-                   : (item.track && isStr(item.track.composer) ? item.track.composer : null);
-
-  // required string fields
-  if (!isStr(item.title)) errors.push('schema title missing/non-string');
-  if (!isStr(item.game)) errors.push('schema game missing/non-string');
-  if (!composer) errors.push('schema track.composer missing/non-string');
-
-  // media
-  const m = item.media || {};
-  if (!isStr(m.provider)) errors.push('schema media.provider missing/non-string');
-  if (!isStr(m.id))       errors.push('schema media.id missing/non-string');
-
-  // answers.canonical
+  if (!isNonEmptyString(item.title)) errors.push('schema title missing/non-string');
+  if (!isNonEmptyString(item.game)) errors.push('schema game missing/non-string');
+  const comp = getComposer(item);
+  if (!isNonEmptyString(comp)) errors.push('schema track.composer missing/non-string');
+  const media = item.media || {};
+  if (!isNonEmptyString(media.provider)) errors.push('schema media.provider missing/non-string');
+  if (!isNonEmptyString(media.id)) errors.push('schema media.id missing/non-string');
   const ans = item.answers || {};
-  if (!isStr(ans.canonical)) errors.push('schema answers.canonical missing/empty');
-
-  // difficulty -> warning only
-  if (!(isNum(item.difficulty) && item.difficulty >= 0 && item.difficulty <= 1)){
+  if (!isNonEmptyString(ans.canonical)) errors.push('schema answers.canonical missing/empty');
+  const d = item.difficulty;
+  if (!(typeof d === 'number' && d >= 0 && d <= 1)) {
     warnings.push('schema difficulty missing or out of range [0,1]');
   }
-
   return { errors, warnings };
 }
 
 async function main(){
-  const strict = String(process.env.SCHEMA_CHECK_STRICT || 'true').toLowerCase() !== 'false';
-  const { src, date, item } = await loadToday();
+  const pToday = path.resolve(__dirname, '../build/daily_today.json');
+  const pAuto  = path.resolve(__dirname, '../public/app/daily_auto.json');
 
-  const { errors, warnings } = validate(item);
-  warnings.forEach(w => annotate('warning', w));
+  let src = null, date = null, item = null;
 
-  if (errors.length){
-    errors.forEach(e => annotate('error', e));
-    console.log(`schema: violations=${errors.length} file=${src}`);
-    process.exit(strict ? 1 : 0);
+  if (existsSync(pToday)) {
+    const u = unwrapDaily(await readJson(pToday));
+    if (u.item) { src = pToday; ({date,item} = u); }
+    else console.log('Warning: build/daily_today.json present but could not find an item; falling back to public/app/daily_auto.json');
   }
 
-  console.log(`schema: OK file=${src}${date ? ` date=${date}` : ''}`);
-  process.exit(0);
+  if (!src) {
+    src = pAuto;
+    const u = latestFromDailyAuto(await readJson(pAuto));
+    ({date,item} = u);
+  }
+
+  const { errors, warnings } = validate(date, item);
+  warnings.forEach(w => annotate(w, 'warning'));
+  errors.forEach(e => annotate(e, 'error'));
+
+  if (errors.length) {
+    console.log(`schema: violations=${errors.length} file=${src}`);
+    process.exit(strict ? 1 : 0);
+  } else {
+    console.log(`schema: OK file=${src} date=${date||'unknown'}`);
+    process.exit(0);
+  }
 }
 
-main().catch(e=>{
-  annotate('error', `unhandled error: ${e?.stack || e}`);
+main().catch(e => {
+  annotate(`unhandled error: ${e?.stack || e}`, 'error');
   process.exit(1);
 });
-


### PR DESCRIPTION
## Summary
- rewrite validate_authoring_schema to handle multiple daily item formats and composer extraction
- add soft schema check with optional SCHEMA_CHECK_STRICT

## Testing
- `npm test` *(fails: clojure not found)*
- `node scripts/validate_authoring_schema.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68bae95cdc4083248e91899804673e7b