### PR TITLE
Add forced date support to authoring schema validator

### DIFF
--- a/.github/workflows/authoring-schema-check.yml
+++ b/.github/workflows/authoring-schema-check.yml
@@ -46,6 +46,8 @@ jobs:
           fi
 
       - name: Schema validation (strict)
+        env:
+          SCHEMA_CHECK_DEBUG: "true"
         run: |
           node --version
           SCHEMA_CHECK_STRICT=true node scripts/validate_authoring_schema.mjs

--- a/scripts/validate_authoring_schema.mjs
+++ b/scripts/validate_authoring_schema.mjs
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const strict = (process.env.SCHEMA_CHECK_STRICT || '').toLowerCase() === 'true';
 const debug  = (process.env.SCHEMA_CHECK_DEBUG  || '').toLowerCase() === 'true';
+const forceDate = (process.env.SCHEMA_CHECK_FORCE_DATE || '').trim();
 
 function annotate(msg, level='error'){
   const tag = level === 'warning' ? '::warning::' : '::error::';
@@ -113,7 +114,15 @@ async function main(){
 
   if (!src) {
     src = pAuto;
-    const u = latestFromDailyAuto(await readJson(pAuto));
+    const auto = await readJson(pAuto);
+    let u;
+    if (forceDate && auto.by_date && auto.by_date[forceDate]) {
+      let item = auto.by_date[forceDate];
+      if (item && typeof item === 'object' && 'item' in item) item = item.item;
+      u = { date: forceDate, item };
+    } else {
+      u = latestFromDailyAuto(auto);
+    }
     ({date,item} = u);
     dbg = u._debug;
   }


### PR DESCRIPTION
## Summary
- enable debug output in authoring schema check workflow
- allow forcing a specific date when validating authoring schema

## Testing
- `SCHEMA_CHECK_STRICT=true SCHEMA_CHECK_DEBUG=true node scripts/validate_authoring_schema.mjs`
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bba2d395308324a81cfa99e5b57bc7