### PR TITLE
ci: upload authoring artifacts in schema check workflow

### DIFF
--- a/.github/workflows/authoring-schema-check.yml
+++ b/.github/workflows/authoring-schema-check.yml
@@ -35,11 +35,17 @@ jobs:
           fi
           echo "[authoring] OK: build/daily_today.json and .md are ready"
 
+      - name: Upload authoring artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: authoring-daily-today
+          path: |
+            build/daily_today.json
+            build/daily_today.md
+
       - name: Schema validation (strict)
         env:
           SCHEMA_CHECK_DEBUG: "true"
-          # Allow CI to pass even when today's by_date is empty (annotates a warning).
-          SCHEMA_CHECK_ALLOW_EMPTY: "true"
         run: |
           node --version
           SCHEMA_CHECK_STRICT=true node scripts/validate_authoring_schema.mjs


### PR DESCRIPTION
## Summary
- upload daily authoring artifacts in schema check workflow
- enable strict schema validation without allow-empty override

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2085b4f88324bdba50b8809040df