### PR TITLE
Allow stub daily export when no item found

### DIFF
--- a/.github/workflows/authoring-schema-check.yml
+++ b/.github/workflows/authoring-schema-check.yml
@@ -18,6 +18,10 @@ jobs:
           node-version: 20
 
       - name: Prepare today's artifact (Finalize → Validate → Export slim)
+        env:
+          EXPORT_SLIM_SCAN_DAYS: "7"
+          # Temporary: write a minimal stub when today's by_date is empty
+          EXPORT_SLIM_STUB_ON_EMPTY: "true"
         run: |
           set -euxo pipefail
           # Ensure build dir exists
@@ -29,15 +33,11 @@ jobs:
           node scripts/validate_nonempty_today.mjs --in public/app/daily_auto.json || true
           node scripts/difficulty_v1_post.mjs --in public/app/daily_auto.json || true
           node scripts/distractors_v1_post.mjs --in public/app/daily_auto.json || true
-          # Export (strict): will exit non-zero if it cannot produce a valid item
+          # Export (strict unless stub-on-empty is enabled)
           node scripts/export_today_slim.mjs --in public/app/daily_auto.json
           # Assert artifact exists AND has a non-empty item with minimal fields
           node -e "const fs=require('fs'); const p='build/daily_today.json'; const j=JSON.parse(fs.readFileSync(p,'utf-8')); if(!j.item||!j.item.title||!j.item.game||!(j.item.media&&j.item.media.provider&&j.item.media.id)&&!(j.item.answers&&j.item.answers.canonical)){ console.error('::error:: build/daily_today.json.item is invalid'); process.exit(1); }"
           echo "[authoring] OK: build/daily_today.json and .md are ready"
-
-        env:
-          # Optional: allow exporter to scan back up to 7 days for a valid item
-          EXPORT_SLIM_SCAN_DAYS: "7"
 
       - name: Upload authoring artifacts
         uses: actions/upload-artifact@v4

--- a/scripts/export_today_slim.mjs
+++ b/scripts/export_today_slim.mjs
@@ -112,8 +112,19 @@ async function main(){
     }
   }
   if (!pickedItem){
-    console.error(`[export_today_slim] no valid item found from ${start} backward; abort`);
-    process.exit(1);
+    const allowStub = (process.env.EXPORT_SLIM_STUB_ON_EMPTY || '').toLowerCase() === 'true';
+    if (!allowStub){
+      console.error(`[export_today_slim] no valid item found from ${start} backward; abort`);
+      process.exit(1);
+    }
+    console.log(`::warning::[export_today_slim] no valid item found from ${start}; writing stub item (stub-on-empty enabled)`);
+    pickedDate = start;
+    pickedItem = {
+      title: "(stub) pending fill",
+      game: "(stub)",
+      answers: { canonical: "(stub)" },
+      difficulty: 0
+    };
   }
   await mkdir('build', { recursive: true });
   await writeFile('build/daily_today.json', JSON.stringify({ date: pickedDate, item: pickedItem }, null, 2));


### PR DESCRIPTION
## Summary
- allow `export_today_slim.mjs` to emit a stub item when no valid daily is available
- expose `EXPORT_SLIM_STUB_ON_EMPTY` and set scan env in authoring workflow

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc265aceb08324824e96f7338b7cf7