### PR TITLE
Include composer and media in stub export_today_slim

### DIFF
--- a/scripts/export_today_slim.mjs
+++ b/scripts/export_today_slim.mjs
@@ -122,6 +122,8 @@ async function main(){
     pickedItem = {
       title: "(stub) pending fill",
       game: "(stub)",
+      composer: "(stub)",
+      media: { provider: "mock", id: "stub" },
       answers: { canonical: "(stub)" },
       difficulty: 0
     };


### PR DESCRIPTION
## Summary
- ensure export_today_slim's stub item includes composer and mock media fields when no valid item is found

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2877d0e88324a489596209f0bfcb