### PR TITLE
feat: generate apple override candidates

### DIFF
--- a/docs/OPERATIONS_AUTHORING.md
+++ b/docs/OPERATIONS_AUTHORING.md
@@ -99,6 +99,20 @@ node scripts/distractors_v1_post.mjs --in public/app/daily_auto.json
 node scripts/export_today_slim.mjs --in public/app/daily_auto.json
 ```
 
+## オーバーライド候補の自動抽出
+- 既存の候補JSONLから、Appleオーバーライドの **正規化キー** を自動生成できます。
+- 出力は JSONC。各エントリに `media.apple` の空テンプレが入るため、URLを埋めて保存すればそのまま適用可能です。
+
+### 使い方
+```bash
+node scripts/generate_apple_override_candidates.mjs --out build/apple_override_candidates.jsonc
+# 内容を確認・編集してから data/apple_overrides.jsonc へ反映
+cp build/apple_override_candidates.jsonc data/apple_overrides.jsonc
+```
+
+- キーの優先順: `norm.game__norm.title` → `norm.answer__norm.title` → `norm.answer` → `norm.title`
+- 厳密一致をしたい場合は、各エントリに `match: { title, game, answer }` を付けてください。
+
 ## Stub 運用の卒業（v1.8）
 - 原則として **stub に依存しません**。出題がゼロの日は `ensure_min_items_v1_post.mjs` により最低 1 件を補います。
 - `scripts/export_today_slim.mjs` は **厳格モード**（有効データがない場合は非ゼロ終了）を維持します。

--- a/scripts/generate_apple_override_candidates.mjs
+++ b/scripts/generate_apple_override_candidates.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * generate_apple_override_candidates.mjs
+ *
+ * 目的:
+ *  既存の候補JSONLから Apple Music のオーバーライドキーのたたき台を自動生成する。
+ *  出力は JSONC（コメント可）。各エントリは media.apple の空テンプレを含む。
+ *
+ * 入力（優先順）:
+ *  - public/app/daily_candidates_scored_enriched.jsonl
+ *  - public/app/daily_candidates_scored.jsonl
+ *  - public/app/daily_candidates.jsonl
+ *
+ * 使い方:
+ *  node scripts/generate_apple_override_candidates.mjs [--in <path.jsonl>] [--out <path.jsonc>]
+ *  例:
+ *    node scripts/generate_apple_override_candidates.mjs --out build/apple_override_candidates.jsonc
+ */
+import fs from 'node:fs/promises';
+import fss from 'node:fs';
+
+function normLower(s){ return String(s||'').toLowerCase().trim().replace(/\s+/g,' '); }
+function keyFrom(item){
+  const title = normLower(item?.title || item?.track?.name);
+  const game  = normLower(item?.game?.name || item?.game);
+  const answer= normLower(item?.answers?.canonical || item?.norm?.answer || game);
+  const keys = [];
+  if (game && title) keys.push(`${game}__${title}`);
+  if (answer && title) keys.push(`${answer}__${title}`);
+  if (answer) keys.push(answer);
+  if (title) keys.push(title);
+  return Array.from(new Set(keys));
+}
+
+function parseArgs(argv){
+  const out = { ins: [], out: 'build/apple_override_candidates.jsonc' };
+  for (let i=0;i<argv.length;i++){
+    const a = argv[i];
+    if (a === '--in' && argv[i+1]) { out.ins.push(argv[++i]); continue; }
+    if (a === '--out' && argv[i+1]) { out.out = argv[++i]; continue; }
+    }
+  return out;
+}
+
+async function pickInputs(ins){
+  if (ins && ins.length) return ins;
+  const defaults = [
+    'public/app/daily_candidates_scored_enriched.jsonl',
+    'public/app/daily_candidates_scored.jsonl',
+    'public/app/daily_candidates.jsonl'
+  ];
+  const avail = [];
+  for (const p of defaults){
+    try { await fs.access(p); avail.push(p); } catch {}
+  }
+  return avail.length ? [avail[0]] : [];
+}
+
+async function readJsonl(path){
+  const raw = await fs.readFile(path, 'utf-8');
+  const lines = raw.split(/\r?\n/).filter(Boolean);
+  return lines.map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+}
+
+async function main(){
+  const opts = parseArgs(process.argv.slice(2));
+  const inputs = await pickInputs(opts.ins);
+  if (!inputs.length){
+    console.error('[gen apple candidates] 入力が見つかりませんでした (--in で指定可)');
+    process.exit(2);
+  }
+  const arr = await readJsonl(inputs[0]);
+  const out = {};
+  for (const it of arr){
+    const keys = keyFrom(it);
+    if (!keys.length) continue;
+    const key = keys[0];
+    if (out[key]) continue; // de-dup
+    out[key] = {
+      // 任意: 厳密一致させたい場合は match を使う
+      // "match": {
+      //   "title": normLower(it?.title || it?.track?.name),
+      //   "game":  normLower(it?.game?.name || it?.game),
+      //   "answer": normLower(it?.answers?.canonical || it?.norm?.answer || (it?.game?.name || it?.game))
+      // },
+      "media": { "apple": {
+        "url": "https://music.apple.com/jp/album/xxxxx",
+        "embedUrl": "https://embed.music.apple.com/jp/album/xxxxx",
+        "previewUrl": "https://is1-ssl.mzstatic.com/.../preview.m4a"
+      }}
+    };
+  }
+  await fs.mkdir(require('node:path').dirname(opts.out), { recursive: true });
+  const jsonc = JSON.stringify(out, null, 2);
+  const header = '// Auto-generated template; fill Apple URLs as needed.\n';
+  await fs.writeFile(opts.out, header + jsonc + '\n', 'utf-8');
+  console.error(`[gen apple candidates] wrote ${Object.keys(out).length} entries → ${opts.out}`);
+}
+
+main().catch(e=>{ console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add script to derive normalized keys for Apple override entries
- document how to auto-generate Apple override templates from existing candidate lists

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bce4bcbe74832493d5e875504b29d7