### PR TITLE
Add Apple override generation workflow and example

### DIFF
--- a/.github/workflows/apple-overrides-generate.yml
+++ b/.github/workflows/apple-overrides-generate.yml
@@ -1,0 +1,35 @@
+name: apple overrides (generate)
+on:
+  workflow_dispatch:
+    inputs:
+      jsonl_path:
+        description: "入力JSONLのパス（省略時は自動選択）"
+        required: false
+        default: ""
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Generate candidates JSONC
+        run: |
+          mkdir -p build
+          if [ -n "${{ github.event.inputs.jsonl_path }}" ]; then
+            node scripts/generate_apple_override_candidates.mjs --in "${{ github.event.inputs.jsonl_path }}" --out build/apple_override_candidates.jsonc
+          else
+            node scripts/generate_apple_override_candidates.mjs --out build/apple_override_candidates.jsonc
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: apple_override_candidates
+          path: build/apple_override_candidates.jsonc
+          if-no-files-found: error

--- a/data/apple_overrides.jsonc
+++ b/data/apple_overrides.jsonc
@@ -1,13 +1,16 @@
+// Apple Music overrides (format: normalized key or match)
+// キー推奨: norm.game__norm.title / norm.answer__norm.title / norm.answer / norm.title
 {
-  // key は dataset の id/slug/uid 等、実データに合わせて置換してください。
-  "sample-track-id": {
+  // 例: Chrono Trigger - Corridors of Time（公式）
+  "chrono trigger__corridors of time": {
     "media": {
       "apple": {
-        "url": "https://music.apple.com/jp/album/xxxxx",
-        "embedUrl": "https://embed.music.apple.com/jp/album/xxxxx",
-        "previewUrl": "https://is1-ssl.mzstatic.com/.../preview.m4a",
-        "previewOffset": 0
+        "url": "https://music.apple.com/us/song/corridors-of-time/324081937",
+        "embedUrl": "https://embed.music.apple.com/jp/album/chrono-trigger-original-soundtrack-ds-version/324080907?i=324081937"
+        // "previewUrl": "https://is1-ssl.mzstatic.com/.../preview.m4a"
       }
     }
   }
+
+  // ほかのトラックは generator で作った雛形を追記してください
 }

--- a/docs/OPERATIONS_AUTHORING.md
+++ b/docs/OPERATIONS_AUTHORING.md
@@ -99,6 +99,15 @@ node scripts/distractors_v1_post.mjs --in public/app/daily_auto.json
 node scripts/export_today_slim.mjs --in public/app/daily_auto.json
 ```
 
+### GitHub Actionsでの候補生成
+ローカル実行しない場合は、専用ワークフローを手動実行してください。
+
+1. **Actions → "apple overrides (generate)" → Run workflow**
+   - 必要なら `jsonl_path` に `public/app/daily_candidates_scored_enriched.jsonl` 等を指定
+2. アーティファクト `apple_override_candidates` をダウンロード
+3. 中身を確認し、必要なエントリに Apple の URL / embedUrl を記入
+4. `data/apple_overrides.jsonc` に反映してコミット → 通常の `daily` ワークフローで反映を確認
+
 ## オーバーライド候補の自動抽出
 - 既存の候補JSONLから、Appleオーバーライドの **正規化キー** を自動生成できます。
 - 出力は JSONC。各エントリに `media.apple` の空テンプレが入るため、URLを埋めて保存すればそのまま適用可能です。


### PR DESCRIPTION
## Summary
- add Chrono Trigger Apple override example
- add workflow to generate Apple override candidates
- document using the workflow to create overrides

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bcef9f8ee083248525a4934316b959