### PR TITLE
Normalize candidate fields before scoring

### DIFF
--- a/scripts/score_candidates.js
+++ b/scripts/score_candidates.js
@@ -8,12 +8,40 @@ const fs = require('fs');
 const path = require('path');
 const readline = require('readline');
 const { buildFreq, scoreCandidate } = require('./pipeline/difficulty');
+const { normalizeAnswer } = require('./pipeline/normalize');
 
 function parseArgs(){
   const args = process.argv.slice(2);
   const i = args.indexOf('--in');  const input = i>=0 ? args[i+1] : 'public/app/daily_candidates.jsonl';
   const o = args.indexOf('--out'); const output = o>=0 ? args[o+1] : 'public/app/daily_candidates_scored.jsonl';
   return { input, output };
+}
+
+function toName(x){ return typeof x === 'object' && x ? (x.name || '') : (x || ''); }
+
+function ensureNorm(c){
+  c.norm = c.norm || {};
+  try {
+    if (!c.norm.composer){
+      const comp = c?.track?.composer || c?.composer || '';
+      c.norm.composer = normalizeAnswer(comp);
+    }
+    if (!c.norm.game){
+      const g = toName(c?.game);
+      c.norm.game = normalizeAnswer(g);
+    }
+    if (!c.norm.title){
+      const t = c?.title || c?.track?.name || '';
+      c.norm.title = normalizeAnswer(t);
+    }
+    if (!c.norm.answer){
+      const ans = c?.answers?.canonical || toName(c?.game) || '';
+      c.norm.answer = normalizeAnswer(ans);
+    }
+  } catch (e) {
+    // keep going; downstream will fail fast if critical fields are missing
+  }
+  return c;
 }
 
 async function readJSONL(p){
@@ -33,11 +61,12 @@ async function main(){
   const { input, output } = parseArgs();
   if(!fs.existsSync(input)){ console.error(`[score] not found: ${input}`); process.exit(1); }
   const cands = await readJSONL(input);
-  const freq = buildFreq(cands);
+  const normed = cands.map(ensureNorm);
+  const freq = buildFreq(normed);
   const outDir = path.dirname(output); ensureDir(outDir);
   const ws = fs.createWriteStream(output, 'utf-8');
   let n=0;
-  for(const c of cands){
+  for(const c of normed){
     const diff = scoreCandidate(c, freq);
     if (c.media && typeof c.media.start !== 'number'){
       // placeholder: neutral 45s. Fine until we hook real analysis.


### PR DESCRIPTION
## Summary
- normalize candidate fields before scoring difficulty
- build frequency table from normalized candidates
- ensure scoring uses normalized data

## Testing
- ⚠️ `npm test` *(clojure: not found)*
- ⚠️ `apt-get update` *(repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bcfdbceab48324bfd1279d4ffcce8f