### PR TITLE
refactor: use path module for output dir

### DIFF
--- a/scripts/generate_apple_override_candidates.mjs
+++ b/scripts/generate_apple_override_candidates.mjs
@@ -18,6 +18,7 @@
  */
 import fs from 'node:fs/promises';
 import fss from 'node:fs';
+import path from 'node:path';
 
 function normLower(s){ return String(s||'').toLowerCase().trim().replace(/\s+/g,' '); }
 function keyFrom(item){
@@ -90,7 +91,7 @@ async function main(){
       }}
     };
   }
-  await fs.mkdir(require('node:path').dirname(opts.out), { recursive: true });
+  await fs.mkdir(path.dirname(opts.out), { recursive: true });
   const jsonc = JSON.stringify(out, null, 2);
   const header = '// Auto-generated template; fill Apple URLs as needed.\n';
   await fs.writeFile(opts.out, header + jsonc + '\n', 'utf-8');


### PR DESCRIPTION
## Summary
- import `path` module and use it to create output directory for Apple override candidate generator

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0099b3548324b6ea5d2433ff50bb