### PR TITLE
ci: disable slim stub and document stub-off policy

### DIFF
--- a/.github/workflows/authoring-schema-check.yml
+++ b/.github/workflows/authoring-schema-check.yml
@@ -20,8 +20,6 @@ jobs:
       - name: Prepare today's artifact (Finalize → Validate → Export slim)
         env:
           EXPORT_SLIM_SCAN_DAYS: "7"
-          # Temporary: write a minimal stub when today's by_date is empty
-          EXPORT_SLIM_STUB_ON_EMPTY: "true"
         run: |
           set -euxo pipefail
           # Ensure build dir exists
@@ -33,8 +31,8 @@ jobs:
           node scripts/validate_nonempty_today.mjs --in public/app/daily_auto.json || true
           node scripts/difficulty_v1_post.mjs --in public/app/daily_auto.json || true
           node scripts/distractors_v1_post.mjs --in public/app/daily_auto.json || true
-          # Export (strict unless stub-on-empty is enabled)
-          node scripts/export_today_slim.mjs --in public/app/daily_auto.json
+          # Export (strict; stub-on-empty disabled)
+          EXPORT_SLIM_STUB_ON_EMPTY=false node scripts/export_today_slim.mjs --in public/app/daily_auto.json
           # Assert artifact exists AND has a non-empty item with minimal fields
           node -e "const fs=require('fs'); const p='build/daily_today.json'; const j=JSON.parse(fs.readFileSync(p,'utf-8')); if(!j.item||!j.item.title||!j.item.game||!(j.item.media&&j.item.media.provider&&j.item.media.id)&&!(j.item.answers&&j.item.answers.canonical)){ console.error('::error:: build/daily_today.json.item is invalid'); process.exit(1); }"
           echo "[authoring] OK: build/daily_today.json and .md are ready"

--- a/.github/workflows/daily-auto-extended.yml
+++ b/.github/workflows/daily-auto-extended.yml
@@ -127,6 +127,8 @@ jobs:
           node scripts/validate_nonempty_today.mjs --in public/app/daily_auto.json $([ -n "$DATE" ] && echo "--date $DATE")
 
       - name: Export today's slim artifact
+        env:
+          EXPORT_SLIM_STUB_ON_EMPTY: 'false'
         run: |
           if [ -z "${{ inputs.date }}" ]; then DATE=""; else DATE="${{ inputs.date }}"; fi
           node scripts/export_today_slim.mjs --in public/app/daily_auto.json $([ -n "$DATE" ] && echo "--date $DATE") --out-json build/daily_today.json --out-md build/daily_today.md

--- a/docs/OPERATIONS_AUTHORING.md
+++ b/docs/OPERATIONS_AUTHORING.md
@@ -152,4 +152,12 @@ cp build/apple_override_candidates.jsonc data/apple_overrides.jsonc
     }
   }
   ```
-- クライアント側の再生は `public/app/media_player.mjs` により **Apple優先** でレンダリングされます（`media.apple.embedUrl | previewUrl | url` が存在すれば Apple を選択）。
+  - クライアント側の再生は `public/app/media_player.mjs` により **Apple優先** でレンダリングされます（`media.apple.embedUrl | previewUrl | url` が存在すれば Apple を選択）。
+
+### スタブ運用の終了（stub-on-empty → OFF）
+- `scripts/export_today_slim.mjs` の **stub-on-empty は運用終了**しました。通常は **厳格モード（見つからなければ fail）** で動作します。
+- どうしても暫定的にスタブを出したい場合のみ、手動実行で
+  ```bash
+  EXPORT_SLIM_STUB_ON_EMPTY=true node scripts/export_today_slim.mjs --in public/app/daily_auto.json
+  ```
+  を使用してください（CIでは常にOFF）。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -267,4 +267,9 @@
 - `docs/V1_8_PLAN.md` — v1.8 の目的/スコープ/DoD/タスク/リスク/成果物
 - `docs/DESIGN_OGP.md` — OGP 静的生成（SVG→PNG）設計
 - `docs/SPEC_CHOICES_MODE.md` — 出題の選択肢制御仕様（auto/always4/one + 品質ゲート）
+ 
+## v1.8 進捗メモ（2025-09-07 JST）
+- **Stub卒業**: `EXPORT_SLIM_STUB_ON_EMPTY` を CI で常時OFF。日次のスリム出力は「実データのみ」を許容。
+- Apple優先のメディア添付: `data/apple_overrides.jsonc` を運用に組み込み（Chrono Trigger / Final Fantasy / Sonic）
+- Smokeワークフロー追加: 任意キーで Apple 埋め込みの成果物をアーティファクト検証（リポ差分なし）
 


### PR DESCRIPTION
## Summary
- disable stub-on-empty for slim exports in daily workflows
- document the end of stub-on-empty and note Apple media priority

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1224aec08324a13c83e3f25c5f2a