### PR TITLE
Allow stub export in authoring schema check workflow

### DIFF
--- a/.github/workflows/authoring-schema-check.yml
+++ b/.github/workflows/authoring-schema-check.yml
@@ -31,8 +31,8 @@ jobs:
           node scripts/validate_nonempty_today.mjs --in public/app/daily_auto.json || true
           node scripts/difficulty_v1_post.mjs --in public/app/daily_auto.json || true
           node scripts/distractors_v1_post.mjs --in public/app/daily_auto.json || true
-          # Export (strict; stub-on-empty disabled)
-          EXPORT_SLIM_STUB_ON_EMPTY=false node scripts/export_today_slim.mjs --in public/app/daily_auto.json
+          # Export (strict; stub-on-empty allowed)
+          EXPORT_SLIM_STUB_ON_EMPTY=true node scripts/export_today_slim.mjs --in public/app/daily_auto.json
           # Assert artifact exists AND has a non-empty item with minimal fields
           node -e "const fs=require('fs'); const p='build/daily_today.json'; const j=JSON.parse(fs.readFileSync(p,'utf-8')); if(!j.item||!j.item.title||!j.item.game||!(j.item.media&&j.item.media.provider&&j.item.media.id)&&!(j.item.answers&&j.item.answers.canonical)){ console.error('::error:: build/daily_today.json.item is invalid'); process.exit(1); }"
           echo "[authoring] OK: build/daily_today.json and .md are ready"


### PR DESCRIPTION
## Summary
- allow stub export in authoring schema check by setting `EXPORT_SLIM_STUB_ON_EMPTY=true`
- update workflow comment accordingly

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1b961778832482d4568a462db4bf