### PR TITLE
feat: handle by_date map in normalize_core

### DIFF
--- a/docs/NORMALIZATION_RULES.md
+++ b/docs/NORMALIZATION_RULES.md
@@ -1,5 +1,7 @@
 # NORMALIZATION_RULES (v1.8 Phase 2)
 
+> **Note:** `normalize_core.mjs` は「単一アイテム容器」向けです。`by_date` マップを含む `daily_auto.json` に対して実行した場合は、**破壊しない（パススルー）**動作になります。
+
 - 入力の揺れ（`{ date,item }` / `{ date,...item }` / `{ date,items:[...] }` / 深い入れ子）を 1系統に正規化。
 - `answers.canonical` は string / string[] 両対応（内部判定は正規化後の同値比較）。
 - `item.norm.*` に小文字化＋空白圧縮を格納。

--- a/scripts/normalize_core.mjs
+++ b/scripts/normalize_core.mjs
@@ -1,4 +1,13 @@
-#!/usr/bin/env node
+function hasByDateMap(obj){
+  if (!obj || typeof obj !== 'object') return false;
+  const m = obj.by_date;
+  if (!m || typeof m !== 'object') return false;
+  const keys = Object.keys(m);
+  if (!keys.length) return true; // empty map, still a map
+  // ISO8601 date YYYY-MM-DD
+  return keys.every(k => /^\d{4}-\d{2}-\d{2}$/.test(k));
+}
+
 /**
  * normalize_core.mjs — v1.8 unified normalization helpers
  * NOTE: Not yet wired; safe to import incrementally.
@@ -145,7 +154,7 @@ async function main() {
   const raw = await readFile(opts.in, 'utf-8').catch(() => null);
   if (!raw) throw new Error('input not found: ' + opts.in);
   const json = JSON.parse(raw);
-  const outObj = normalizeContainer(json);
+  const outObj = hasByDateMap(json) ? json : normalizeContainer(json);
   const outPath = opts.out || opts.in;
   await mkdir(path.dirname(outPath), { recursive: true });
   await writeFile(outPath, JSON.stringify(outObj, null, 2) + '\n', 'utf-8');


### PR DESCRIPTION
## Summary
- treat `by_date` collections as pass-through when normalizing
- document behavior of `normalize_core.mjs` for daily_auto.json

## Testing
- `node scripts/test_normalize_parity.js`
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd27f82c7c83249f5987a45afcb6c1