### PR TITLE
feat: add by-date passthrough to normalizer

### DIFF
--- a/docs/NORMALIZATION_RULES.md
+++ b/docs/NORMALIZATION_RULES.md
@@ -4,3 +4,5 @@
 - `answers.canonical` は string / string[] 両対応（内部判定は正規化後の同値比較）。
 - `item.norm.*` に小文字化＋空白圧縮を格納。
 
+> **Note:** `normalize_core.mjs` は「単一アイテム容器」向けです。`by_date` マップを含む `daily_auto.json` に対して実行した場合は、**破壊しない（パススルー）**動作になります。
+

--- a/scripts/normalize_core.mjs
+++ b/scripts/normalize_core.mjs
@@ -9,6 +9,16 @@ import path from 'path';
 import url from 'url';
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
+function hasByDateMap(obj) {
+  if (!obj || typeof obj !== 'object') return false;
+  const m = obj.by_date;
+  if (!m || typeof m !== 'object') return false;
+  const keys = Object.keys(m);
+  if (!keys.length) return true; // empty map, still a map
+  // ISO8601 date YYYY-MM-DD
+  return keys.every(k => /^\d{4}-\d{2}-\d{2}$/.test(k));
+}
+
 // Wave dash variants to full-width tilde U+301C or ASCII hyphen?
 // Here, normalize to ASCII hyphen-minus and collapse repeats.
 export function normalizeDashes(s) {
@@ -145,7 +155,7 @@ async function main() {
   const raw = await readFile(opts.in, 'utf-8').catch(() => null);
   if (!raw) throw new Error('input not found: ' + opts.in);
   const json = JSON.parse(raw);
-  const outObj = normalizeContainer(json);
+  const outObj = hasByDateMap(json) ? json : normalizeContainer(json);
   const outPath = opts.out || opts.in;
   await mkdir(path.dirname(outPath), { recursive: true });
   await writeFile(outPath, JSON.stringify(outObj, null, 2) + '\n', 'utf-8');


### PR DESCRIPTION
## Summary
- add `hasByDateMap` helper and bypass normalization when a by_date map exists
- document that running the normalizer on daily_auto.json is a no-op

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd27f82c7c83249f5987a45afcb6c1