### PR TITLE
chore(aliases): add backfill script and workflow

### DIFF
--- a/.github/workflows/aliases-backfill.yml
+++ b/.github/workflows/aliases-backfill.yml
@@ -1,0 +1,34 @@
+name: aliases backfill
+on:
+  workflow_dispatch: {}
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run backfill
+        run: |
+          node scripts/backfill_aliases_v1.mjs
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: aliases_backfill
+          path: |
+            data/aliases/*.json
+            build/logs/*.txt
+          if-no-files-found: error
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "chore(aliases): backfill aliases"
+          branch: "chore/aliases-backfill"
+          commit-message: "chore(aliases): backfill aliases"
+          add-paths: |
+            data/aliases/*.json
+            build/logs/*.txt

--- a/docs/BACKFILL_ALIASES.md
+++ b/docs/BACKFILL_ALIASES.md
@@ -1,0 +1,8 @@
+# BACKFILL_ALIASES (v1)
+
+`public/app/daily_auto.json` の `by_date` を走査して、`data/aliases/{game,composer,track}.json` に
+不足している正規化キー（小文字化＋空白圧縮）→ 正式表記を追加します。
+
+- 既存値は上書きしません（衝突はスキップ）
+- ログ: `build/logs/backfill_YYYYMMDD.txt`
+- **注意:** 自動で意味解釈はしません。名称統一は軽微な補完（lower/space）までです。

--- a/scripts/backfill_aliases_v1.mjs
+++ b/scripts/backfill_aliases_v1.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * scripts/backfill_aliases_v1.mjs
+ * - `public/app/daily_auto.json` の by_date から 2025-09-07 までの項目を走査し、
+ *   data/aliases/{game,composer,track}.json を拡充する簡易バックフィル。
+ * - 出力ログ: build/logs/backfill_YYYYMMDD.txt
+ * - 既存エントリは保持し、新規キーのみ追加します（衝突時はスキップ）。
+ */
+import fs from 'node:fs/promises';
+import fss from 'node:fs';
+import path from 'node:path';
+
+function normLower(s){ return String(s||'').toLowerCase().trim().replace(/\s+/g,' '); }
+function toName(x){ return typeof x==='object' && x ? (x.name||'') : (x||''); }
+
+async function readJson(p, fallback){ try{ return JSON.parse(await fs.readFile(p,'utf-8')); }catch{ return fallback; } }
+async function writeJson(p, obj){ await fs.mkdir(path.dirname(p),{recursive:true}); await fs.writeFile(p, JSON.stringify(obj,null,2)+'\n','utf-8'); }
+
+async function main(){
+  const autoPath = 'public/app/daily_auto.json';
+  const logDir = 'build/logs';
+  const logPath = path.join(logDir, 'backfill_20250907.txt');
+  await fs.mkdir(logDir, {recursive:true});
+
+  const auto = await readJson(autoPath, null);
+  if (!auto || !auto.by_date || typeof auto.by_date!=='object'){
+    await fs.writeFile(logPath, '[backfill] no by_date found; skip\n');
+    console.log('[backfill] no by_date; skip');
+    return;
+  }
+
+  const aliasPaths = {
+    game: 'data/aliases/game.json',
+    composer: 'data/aliases/composer.json',
+    track: 'data/aliases/track.json',
+  };
+  const aliases = {
+    game: await readJson(aliasPaths.game, {}),
+    composer: await readJson(aliasPaths.composer, {}),
+    track: await readJson(aliasPaths.track, {}),
+  };
+
+  let added = {game:0, composer:0, track:0};
+  let lines = [];
+
+  for (const [d, item] of Object.entries(auto.by_date)){
+    const title = item?.title || item?.track?.name || '';
+    const game  = toName(item?.game || item?.track?.game);
+    const comp  = item?.composer || item?.track?.composer || '';
+    if (game){
+      const k = normLower(game);
+      if (!(k in aliases.game)){ aliases.game[k] = game; added.game++; lines.push(`game\t${d}\t${k}\t${game}`); }
+    }
+    if (comp){
+      const k = normLower(comp);
+      if (!(k in aliases.composer)){ aliases.composer[k] = comp; added.composer++; lines.push(`composer\t${d}\t${k}\t${comp}`); }
+    }
+    if (title){
+      const k = normLower(title);
+      if (!(k in aliases.track)){ aliases.track[k] = title; added.track++; lines.push(`track\t${d}\t${k}\t${title}`); }
+    }
+  }
+
+  // write back
+  await writeJson(aliasPaths.game, aliases.game);
+  await writeJson(aliasPaths.composer, aliases.composer);
+  await writeJson(aliasPaths.track, aliases.track);
+
+  const summary = `[backfill] added game=${added.game} composer=${added.composer} track=${added.track}\n`;
+  await fs.writeFile(logPath, summary + lines.join('\n') + (lines.length?'\n':''), 'utf-8');
+  console.log(summary.trim());
+}
+
+main().catch(e=>{ console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add script and docs to backfill game/composer/track aliases
- add a workflow to run the backfill and open a pull request

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd29eed0e88324884fdc3829d2c1ee