### PR TITLE
chore: add normalization guard CLI and backfill workflow PAT

### DIFF
--- a/.github/workflows/aliases-backfill.yml
+++ b/.github/workflows/aliases-backfill.yml
@@ -2,12 +2,18 @@ name: aliases backfill
 on:
   workflow_dispatch: {}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   backfill:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -23,12 +29,19 @@ jobs:
             data/aliases/*.json
             build/logs/*.txt
           if-no-files-found: error
+      - name: Configure Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Create PR
         uses: peter-evans/create-pull-request@v6
         with:
+          token: "${{ secrets.CPR_PAT }}"
           title: "chore(aliases): backfill aliases"
-          branch: "chore/aliases-backfill"
+          branch: "chore/aliases-backfill-${{ github.run_id }}"
           commit-message: "chore(aliases): backfill aliases"
           add-paths: |
             data/aliases/*.json
             build/logs/*.txt
+          labels: "automerge, chore, aliases"
+          draft: false

--- a/docs/BACKFILL_ALIASES.md
+++ b/docs/BACKFILL_ALIASES.md
@@ -6,3 +6,17 @@
 - 既存値は上書きしません（衝突はスキップ）
 - ログ: `build/logs/backfill_YYYYMMDD.txt`
 - **注意:** 自動で意味解釈はしません。名称統一は軽微な補完（lower/space）までです。
+
+## 運用手順（PR 自動作成 / PAT 版）
+
+1. GitHub リポジトリに **Secrets → `CPR_PAT`** を追加  
+   - Fine-grained PAT / Repository permissions: **Contents: Read & Write**, **Pull requests: Read & Write**
+2. Actions の **Workflow permissions** を *Read and write permissions* に設定
+3. `aliases backfill` を手動実行  
+   - 成果物: `data/aliases/*.json`, `build/logs/backfill_YYYYMMDD.txt`
+   - 変更があれば **PR が自動作成**され、`automerge` ラベルにより **自動マージ**（保護ルールを満たす場合）
+4. トラブル時は `build/logs/backfill_*.txt` を確認
+
+### メモ
+- ブランチは `chore/aliases-backfill-<run_id>`（ユニーク）で作成します。
+- `CPR_PAT` が未設定の場合は PR 作成で失敗します（`required secret not found`）。設定後に再実行してください。

--- a/docs/OPERATIONS_AUTHORING.md
+++ b/docs/OPERATIONS_AUTHORING.md
@@ -171,3 +171,9 @@ cp build/apple_override_candidates.jsonc data/apple_overrides.jsonc
 node scripts/normalize_core.mjs --in public/app/daily_auto.json
 ```
 
+### 補遺：normalize_core の安全弁（任意）
+`by_date` を含むコンテナに対して誤って単体正規化を適用しないために、**`scripts/normalize_core_guard_cli.mjs`** を用意しました。    
+- 使い方:  
+  `node scripts/normalize_core_guard_cli.mjs --in build/daily_today.json --out build/daily_today.json`  
+- `by_date` を検出した場合は **NO-OP** として終了します。
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,8 +49,12 @@
   - roadmap-guard: `FEATURES.yml` の planned が ROADMAP に無いと **警告**。  
   - docs-legacy-guard: 旧ファイルの再導入は **警告**。
 
-- **PRチェック（最小）**  
-  1) 正本の更新有無（`urls-and-params.md` 等）  
-  2) ROADMAP/FEATURES の drift 無し  
-  3) 古い docs の再導入無し（ARCHIVE に追記済み）  
+- **PRチェック（最小）**
+  1) 正本の更新有無（`urls-and-params.md` 等）
+  2) ROADMAP/FEATURES の drift 無し
+  3) 古い docs の再導入無し（ARCHIVE に追記済み）
   4) 変更に応じて E2E / Budgets の説明を必要最小限で更新
+
+## ドキュメント言語ポリシー
+本リポジトリのドキュメントは **日本語に統一** します（固有名詞・API名・エラー文などは英語表記可）。  
+新規追加・更新時は日本語で記述し、英語ドキュメントを追加する場合は別ファイルにせず原則日本語へ統合します。

--- a/scripts/normalize_core_guard_cli.mjs
+++ b/scripts/normalize_core_guard_cli.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * scripts/normalize_core_guard_cli.mjs
+ * - 入力JSONを読み込み、`by_date` マップが検出された場合は **ノーオペ** で終了（安全弁）。
+ * - 単一アイテム形の場合のみ `normalize_core.mjs` を用いて正規化して上書き保存。
+ *
+ * 使い方:
+ *   node scripts/normalize_core_guard_cli.mjs --in build/daily_today.json --out build/daily_today.json
+ */
+import { readFile, writeFile } from 'node:fs/promises';
+import { normalizeContainer } from './normalize_core.mjs';
+
+function hasByDateMap(obj) {
+  if (!obj || typeof obj !== 'object') return false;
+  const m = obj.by_date;
+  if (!m || typeof m !== 'object') return false;
+  return Object.keys(m).length > 0;
+}
+
+function parseArgs(argv) {
+  const args = { in: '', out: '' };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--in') args.in = argv[++i];
+    else if (a === '--out') args.out = argv[++i];
+  }
+  if (!args.in) throw new Error('--in is required');
+  if (!args.out) args.out = args.in;
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const input = JSON.parse(await readFile(args.in, 'utf-8'));
+  if (hasByDateMap(input)) {
+    console.error('[normalize_core_guard] detected by_date container; NO-OP:', args.in);
+    return;
+  }
+  const outObj = normalizeContainer(input);
+  await writeFile(args.out, JSON.stringify(outObj, null, 2) + '\n', 'utf-8');
+  console.error('[normalize_core_guard] normalized ->', args.out);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- allow alias backfill workflow to create PRs using PAT and configure git user
- document PAT-based backfill process and repository language policy
- add normalize_core_guard_cli script and mention it in authoring ops

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd31935b0c8324b9ef0e6539a0ea22