### PR TITLE
chore: improve aliases backfill and smoke override

### DIFF
--- a/.github/workflows/aliases-backfill.yml
+++ b/.github/workflows/aliases-backfill.yml
@@ -29,11 +29,30 @@ jobs:
             data/aliases/*.json
             build/logs/*.txt
           if-no-files-found: error
+      - name: Diff
+        id: diff
+        run: |
+          if [ -z "$(git status --porcelain data/aliases build/logs 2>/dev/null)" ]; then
+            echo "[aliases-backfill] no changes detected; skipping PR"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Configure Git user
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Stage changes
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          # 明示的にステージング（create-pull-requestのadd-pathsでも拾われますが、念のため）
+          git add data/aliases/*.json || true
+          # build/logs は .gitignore の対象の可能性があるためステージングは best-effort
+          if [ -f build/logs/backfill_*.txt ]; then
+            git add -f build/logs/*.txt || true
+          fi
       - name: Create PR
+        if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           token: "${{ secrets.CPR_PAT }}"

--- a/.github/workflows/smoke-apple-override.yml
+++ b/.github/workflows/smoke-apple-override.yml
@@ -30,9 +30,24 @@ jobs:
         with:
           node-version: 20
 
+      - name: Resolve default key (empty input)
+        id: resolve
+        run: |
+          KEY_IN="${{ github.event.inputs.key }}"
+          TITLE_IN="${{ github.event.inputs.title }}"
+          GAME_IN="${{ github.event.inputs.game }}"
+          if [ -z "$KEY_IN" ] && [ -z "$TITLE_IN" ] && [ -z "$GAME_IN" ]; then
+            # Pick the first key in data/apple_overrides.jsonc as a sensible default smoke target
+            KEY=$(node -e 'const fs=require("fs");let r="";try{const raw=fs.readFileSync("data/apple_overrides.jsonc","utf8").replace(/\/\\*(?:.|\n|\r)*?\\*\\//g,"").replace(/(^|\s+)//.*$/gm,"");const o=JSON.parse(raw);r=Object.keys(o)[0]||"";}catch{};console.log(r)')
+            echo "key=$KEY" >> "$GITHUB_OUTPUT"
+            echo "[smoke] default key -> $KEY"
+          else
+            echo "key=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run smoke script
         run: |
-          KEY="${{ github.event.inputs.key }}"
+          KEY="${{ steps.resolve.outputs.key != '' && steps.resolve.outputs.key || github.event.inputs.key }}"
           TITLE="${{ github.event.inputs.title }}"
           GAME="${{ github.event.inputs.game }}"
           COMP="${{ github.event.inputs.composer }}"

--- a/docs/BACKFILL_ALIASES.md
+++ b/docs/BACKFILL_ALIASES.md
@@ -20,3 +20,9 @@
 ### メモ
 - ブランチは `chore/aliases-backfill-<run_id>`（ユニーク）で作成します。
 - `CPR_PAT` が未設定の場合は PR 作成で失敗します（`required secret not found`）。設定後に再実行してください。
+
+### 変更なしの場合の挙動
+バックフィル後に差分が無い場合は、ワークフロー側で **PR 作成をスキップ** します。  
+（ログに `[aliases-backfill] no changes detected; skipping PR` と表示）  
+差分があるはずなのにスキップされた場合は、`data/aliases/*.json` の内容・`build/logs/backfill_*.txt` を確認してください。
+`.gitignore` により `build/logs` が除外される場合でも、`data/aliases` の差分があれば PR が作成されます。

--- a/docs/OPERATIONS_AUTHORING.md
+++ b/docs/OPERATIONS_AUTHORING.md
@@ -154,6 +154,16 @@ cp build/apple_override_candidates.jsonc data/apple_overrides.jsonc
   ```
   - クライアント側の再生は `public/app/media_player.mjs` により **Apple優先** でレンダリングされます（`media.apple.embedUrl | previewUrl | url` が存在すれば Apple を選択）。
 
+#### Tips: smoke apple override を無入力で実行する
+`smoke apple override` の inputs（key/title/game）が **空のまま**でも、`data/apple_overrides.jsonc` の **先頭キー** を自動選択して実行するようにしました。  
+（任意で個別に検証したい場合は、これまで通り `key="game__title"` もしくは `title+game` を指定してください。）
+
+例:
+- そのまま Run → 先頭キーが自動選択され、`build/daily_today.json/.md` が生成されます
+- 明示的に試す場合: `key="chrono trigger__corridors of time"` などを指定
+
+> 注意: 先頭キーはオーバーライド定義の順序に依存します。別の楽曲で検証したい場合は inputs を明示してください。
+
 ### スタブ運用の終了（stub-on-empty → OFF）
 - `scripts/export_today_slim.mjs` の **stub-on-empty は運用終了**しました。通常は **厳格モード（見つからなければ fail）** で動作します。
 - どうしても暫定的にスタブを出したい場合のみ、手動実行で


### PR DESCRIPTION
## Summary
- detect alias backfill changes and skip PR when none
- default to first apple override key when smoke inputs are empty
- document new behaviors for alias backfill and smoke override

## Testing
- `npm test` *(fails: clojure not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd34cd7e7883248bc667e66f898bae