### PR TITLE
chore: specify bash shell for apple override smoke

### DIFF
--- a/.github/workflows/smoke-apple-override.yml
+++ b/.github/workflows/smoke-apple-override.yml
@@ -32,27 +32,28 @@ jobs:
 
       - name: Resolve default key (empty input)
         id: resolve
+        shell: bash
         run: |
           KEY_IN="${{ github.event.inputs.key }}"
           TITLE_IN="${{ github.event.inputs.title }}"
           GAME_IN="${{ github.event.inputs.game }}"
           if [ -z "$KEY_IN" ] && [ -z "$TITLE_IN" ] && [ -z "$GAME_IN" ]; then
             # Pick the first key in data/apple_overrides.jsonc as a sensible default smoke target
-            node - <<'NODE'
-            const fs = require('fs');
-            const out = process.env.GITHUB_OUTPUT;
-            let key = '';
-            try {
-              let raw = fs.readFileSync('data/apple_overrides.jsonc','utf8');
-              raw = raw
-                .replace(/\/\*(?:.|\n|\r)*?\*\//g, '')
-                .replace(/(^|\s+)\/\/.*$/gm, '');
-              const obj = JSON.parse(raw);
-              key = Object.keys(obj)[0] || '';
-            } catch (e) {}
-            if (out) fs.appendFileSync(out, `key=${key}\n`);
-            console.log(key ? `[smoke] default key -> ${key}` : '[smoke] default key not found');
-            NODE
+          node - <<'NODE'
+          const fs = require('fs');
+          const out = process.env.GITHUB_OUTPUT;
+          let key = '';
+          try {
+            let raw = fs.readFileSync('data/apple_overrides.jsonc','utf8');
+            raw = raw
+              .replace(/\/\*(?:.|\n|\r)*?\*\//g, '')
+              .replace(/(^|\s+)\/\/.*$/gm, '');
+            const obj = JSON.parse(raw);
+            key = Object.keys(obj)[0] || '';
+          } catch (e) {}
+          if (out) fs.appendFileSync(out, `key=${key}\n`);
+          console.log(key ? `[smoke] default key -> ${key}` : '[smoke] default key not found');
+          NODE
           else
             echo "key=" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary
- specify bash shell for smoke-apple-override workflow
- clean up indentation in smoke default key resolver

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd39162bdc8324812c9c974f4ce2d2