### PR TITLE
feat: add heuristic media guard

### DIFF
--- a/.github/workflows/candidates-score-pick-pr.yml
+++ b/.github/workflows/candidates-score-pick-pr.yml
@@ -40,10 +40,16 @@ jobs:
         run: |
           node scripts/ingest_candidates_v0.mjs --allow "${{ github.event.inputs.allow || 'on' }}"
 
+      - name: heuristic-media-guard v0
+        run: |
+          node scripts/heuristic_media_guard_v0.mjs \
+            --in public/app/daily_candidates.jsonl \
+            --out public/app/daily_candidates_guarded.jsonl
+
       - name: Score candidates
         run: |
           node scripts/score_candidates.js \
-            --in public/app/daily_candidates.jsonl \
+            --in public/app/daily_candidates_guarded.jsonl \
             --out public/app/daily_candidates_scored.jsonl
 
       - name: Pick for date (merge into daily_auto.json)

--- a/docs/COLLECTOR_V0.md
+++ b/docs/COLLECTOR_V0.md
@@ -14,6 +14,10 @@
 - **整形**：`norm`（title/answer/composer/series/game）を補う。media が無くても可。
 - **サマリ**：Step Summary に件数/除外理由を出力。
 
+### 追加ガード（推奨）
+- `scripts/heuristic_media_guard_v0.mjs`：provider/id 形式・title/answer 欠落など**明らかな不正**を除外（外部ネット無し）
+- ワークフロー `candidates (score+pick PR)` に組み込み済み（ingest → **guard** → score → pick）
+
 ## 使い方
 ```bash
 # 1) seed/allow を確認・編集

--- a/scripts/heuristic_media_guard_v0.mjs
+++ b/scripts/heuristic_media_guard_v0.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * heuristic_media_guard_v0.mjs
+ * - 候補JSONLを受け取り、明らかに不正/非公式/壊れの可能性が高い行を除外する。
+ * - v0の簡易ヒューリスティック（外部ネットワークは使わない）。
+ *
+ * 仕様
+ * - 入力: --in <jsonl>（既定: public/app/daily_candidates.jsonl）
+ * - 出力: --out <jsonl>（既定: public/app/daily_candidates_guarded.jsonl）
+ * - 基本基準:
+ *   - provider は apple / youtube のみ許可
+ *   - id 形式検査: apple は数値, youtube は長さ11かつ [A-Za-z0-9_-]
+ *   - title / answers.canonical の空は除外
+ * - 統計は Step Summary に出力
+ */
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+
+function parseArgs(argv){
+  const args = { in: 'public/app/daily_candidates.jsonl', out: 'public/app/daily_candidates_guarded.jsonl' };
+  for (let i=0;i<argv.length;i++){
+    const a = argv[i];
+    if (a === '--in' && i+1 < argv.length) args.in = argv[++i];
+    else if (a === '--out' && i+1 < argv.length) args.out = argv[++i];
+  }
+  return args;
+}
+function* readJSONL(p){
+  const text = fs.readFileSync(p,'utf-8');
+  for (const line of text.split(/\r?\n/)){
+    const s = line.trim(); if (!s) continue;
+    try{ yield JSON.parse(s); }catch{}
+  }
+}
+function isYoutubeId(id){
+  return typeof id === 'string' && id.length === 11 && /^[A-Za-z0-9_-]+$/.test(id);
+}
+function isAppleId(id){
+  return typeof id === 'string' && /^[0-9]+$/.test(id);
+}
+function guard(entry){
+  const prov = (entry?.clip?.provider || entry?.provider || '').toLowerCase();
+  const id = entry?.clip?.id || entry?.id || '';
+  if (!(prov === 'youtube' || prov === 'apple')) return { keep:false, reason:'provider-unsupported' };
+  if (prov === 'youtube' && !isYoutubeId(id)) return { keep:false, reason:'youtube-id-format' };
+  if (prov === 'apple' && !isAppleId(id)) return { keep:false, reason:'apple-id-format' };
+  const title = entry?.title || entry?.track?.name || '';
+  const ans = entry?.answers?.canonical || '';
+  if (!String(title).trim()) return { keep:false, reason:'missing-title' };
+  if (!String(ans).trim()) return { keep:false, reason:'missing-answer' };
+  return { keep:true, reason:'' };
+}
+async function main(){
+  const args = parseArgs(process.argv.slice(2));
+  const kept = [];
+  const stats = { in:0, kept:0, drop:0 };
+  const reasons = {};
+  for (const c of readJSONL(args.in)){
+    stats.in++;
+    const g = guard(c);
+    if (g.keep){ kept.push(c); stats.kept++; }
+    else { stats.drop++; reasons[g.reason] = (reasons[g.reason]||0)+1; }
+  }
+  await fsp.mkdir(path.dirname(args.out), { recursive:true });
+  await fsp.writeFile(args.out, kept.map(o=>JSON.stringify(o)).join('\n')+'\n', 'utf-8');
+  const lines = [
+    '### heuristic-media-guard v0',
+    `- in: **${stats.in}**`,
+    `- kept: **${stats.kept}**`,
+    `- drop: ${stats.drop}`,
+    `- reasons: ${Object.entries(reasons).map(([k,v])=>`${k}:${v}`).join(', ') || '(none)'}`,
+  ];
+  if (process.env.GITHUB_STEP_SUMMARY){
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n')+'\n');
+  } else {
+    console.log(lines.join('\n'));
+  }
+}
+main().catch(e=>{ console.error(e); process.exit(1); });
+
+
+


### PR DESCRIPTION
## Summary
- add heuristic-media-guard script to filter bad candidate entries
- run guard step before scoring candidates
- document optional guard in Collector v0 guide

## Testing
- `node scripts/heuristic_media_guard_v0.mjs --in /tmp/sample.jsonl --out /tmp/out.jsonl`
- `npm test` *(fails: clojure not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5847d5548324b9f8df1ef3500c12