### PR TITLE
feat: schedule candidate scoring & picking

### DIFF
--- a/.github/workflows/candidates-score-pick-cron.yml
+++ b/.github/workflows/candidates-score-pick-cron.yml
@@ -1,0 +1,95 @@
+name: candidates (score+pick PR - cron)
+
+on:
+  schedule:
+    # 00:05 JST 毎日 = 15:05 UTC
+    - cron: "5 15 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  pipeline:
+    runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Tokyo
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Ingest candidates v0
+        run: |
+          node scripts/ingest_candidates_v0.mjs --allow "on"
+
+      - name: heuristic-media-guard v0
+        run: |
+          node scripts/heuristic_media_guard_v0.mjs \
+            --in public/app/daily_candidates.jsonl \
+            --out public/app/daily_candidates_guarded.jsonl
+
+      - name: Score candidates
+        run: |
+          node scripts/score_candidates.js \
+            --in public/app/daily_candidates_guarded.jsonl \
+            --out public/app/daily_candidates_scored.jsonl
+
+      - name: Pick for today (JST)
+        run: |
+          node scripts/generate_daily_from_candidates.js \
+            --in public/app/daily_candidates_scored.jsonl \
+            --out public/app/daily_auto.json
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: candidates-pick-cron
+          path: |
+            public/app/daily_candidates.jsonl
+            public/app/daily_candidates_guarded.jsonl
+            public/app/daily_candidates_scored.jsonl
+            public/app/daily_auto.json
+
+      - name: Detect changes
+        id: diff
+        run: |
+          git add -N public/app/daily_auto.json || true
+          if git diff --quiet -- public/app/daily_auto.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "[candidates-cron] no changes detected; skipping PR"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create PR
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: "${{ secrets.CPR_PAT }}"
+          title: "feat(daily): pick from candidates (cron)"
+          branch: "feat/daily-from-candidates-cron-${{ github.run_id }}"
+          commit-message: "feat(daily): pick from candidates (cron)"
+          add-paths: |
+            public/app/daily_auto.json
+          labels: "automerge, daily, candidates"
+          draft: false
+
+      - name: Summary
+        run: |
+          echo "### candidates (score+pick - cron) done" >> "$GITHUB_STEP_SUMMARY"
+          echo "- date: \`today(JST)\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- allow: \`on\`" >> "$GITHUB_STEP_SUMMARY"
+

--- a/docs/OPERATIONS_CANDIDATES.md
+++ b/docs/OPERATIONS_CANDIDATES.md
@@ -33,6 +33,20 @@
 2. **candidates (score+pick PR)** を実行（`date` 未指定なら当日、`with_choices` 任意）
 3. PR が自動作成される（差分が無ければスキップ）。保護ルールを満たせば自動マージ。
 
+## 自動運用（cron）
+- Workflow: **candidates (score+pick PR - cron)** を追加（毎日 00:05 JST 実行）
+- 処理内容: ingest → guard → score → pick → PR作成（差分なしならスキップ）
+- 備考:
+  - `daily (ogp+feeds)` は既存スケジュールのまま運用。PR が自動マージされた後に実行されるよう JST 時刻を調整する。
+  - もし重複してしまう場合は、`daily (auto extended)` のスケジュールを後ろにずらすか、手動運用に統一する。
+
+### スケジュール（UTCベース）
+- 00:05 JST = **15:05 UTC**（Actions の `cron: "5 15 * * *"`）
+
+### よくある質問
+- Q. 同日に PR が無い日がある？  
+  A. 候補から既に近傍日で採用済みで選出できない場合などは、**差分無しスキップ**になります（正常動作）。
+
 ## 注意
 - allowlist は最小から開始し、必要に応じて `sources/allowlist.json` を育てる運用。
 - 非公式／埋め込み不可の検知は今後 **heuristic-media-guard** を導入予定（v1.9タスク）。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -301,5 +301,11 @@
 ### 進捗（2025-09-07 JST）
 - ✅ ingest（候補JSONL生成）導入済み
 - ✅ score+pick PR ワークフロー追加（Actionsのみで daily_auto.json を更新）
+- ✅ cron 化：毎日 00:05 JST に pick & PR（差分なければスキップ）
+
+**ToDo（v1.9 の残件）**
+- allowlist/seed の拡充（運用で育てる）
+- 埋め込み不可の推定強化（guard v1: pattern 追加）
+- choices 付与の自動化パラメータの調整（`choices_mode=auto` 前提）
 
 ## v1.10 — Difficulty 2.0 & De-dup v1（近似重複抑制）


### PR DESCRIPTION
## Summary
- schedule daily candidates pipeline to ingest, score and pick via cron
- document new candidates cron workflow and its UTC schedule
- update roadmap with cron progress and remaining v1.9 tasks

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5b69fb388324b2ec2a4636b0dc43