### PR TITLE
feat: extend media guard and cron workflow

### DIFF
--- a/.github/workflows/candidates-score-pick-cron.yml
+++ b/.github/workflows/candidates-score-pick-cron.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TZ: Asia/Tokyo
+      WITH_CHOICES: ${{ vars.WITH_CHOICES || 'false' }}
+      STRICT_GUARD: ${{ vars.STRICT_GUARD || 'off' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,7 +36,7 @@ jobs:
         run: |
           node scripts/heuristic_media_guard_v0.mjs \
             --in public/app/daily_candidates.jsonl \
-            --out public/app/daily_candidates_guarded.jsonl
+            --out public/app/daily_candidates_guarded.jsonl --strict "${STRICT_GUARD}"
 
       - name: Score candidates
         run: |
@@ -44,8 +46,11 @@ jobs:
 
       - name: Pick for today (JST)
         run: |
+          WITH_FLAG=""
+          if [ "$WITH_CHOICES" = "true" ] || [ "$WITH_CHOICES" = "1" ]; then WITH_FLAG="--with-choices"; fi
           node scripts/generate_daily_from_candidates.js \
             --in public/app/daily_candidates_scored.jsonl \
+            $WITH_FLAG \
             --out public/app/daily_auto.json
 
       - name: Upload artifact

--- a/docs/OPERATIONS_CANDIDATES.md
+++ b/docs/OPERATIONS_CANDIDATES.md
@@ -44,8 +44,15 @@
 - 00:05 JST = **15:05 UTC**（Actions の `cron: "5 15 * * *"`）
 
 ### よくある質問
-- Q. 同日に PR が無い日がある？  
+- Q. 同日に PR が無い日がある？
   A. 候補から既に近傍日で採用済みで選出できない場合などは、**差分無しスキップ**になります（正常動作）。
+
+### リポジトリ変数による挙動変更（cron）
+- `Settings → Variables → Repository variables` で以下を設定可能です（未設定時の既定値は括弧内）。
+  - `WITH_CHOICES` … `true|false`（`false`）: `--with-choices` を付与して選択肢を生成
+  - `STRICT_GUARD` … `on|off`（`off`）: ガードを厳格化（疑似NG語一致も drop）
+
+> 注: 厳格化は誤検知の可能性があるため、当面は `off` を推奨。疑似NG語は `scripts/heuristic_media_guard_v0.mjs` の `SUSPICIOUS` を参照。
 
 ## 注意
 - allowlist は最小から開始し、必要に応じて `sources/allowlist.json` を育てる運用。

--- a/scripts/heuristic_media_guard_v0.mjs
+++ b/scripts/heuristic_media_guard_v0.mjs
@@ -1,16 +1,19 @@
 #!/usr/bin/env node
 /**
- * heuristic_media_guard_v0.mjs
- * - 候補JSONLを受け取り、明らかに不正/非公式/壊れの可能性が高い行を除外する。
- * - v0の簡易ヒューリスティック（外部ネットワークは使わない）。
+ * heuristic_media_guard_v1.mjs（v0 からの拡張）
+ * - 候補JSONLを受け取り、明らかに不正/非公式/壊れの可能性が高い行を除外 or 警告する。
+ * - v1: タイトルの疑似NG語による「警告」カウント（既定では keep、--strict=on で drop）を追加。
  *
  * 仕様
- * - 入力: --in <jsonl>（既定: public/app/daily_candidates.jsonl）
- * - 出力: --out <jsonl>（既定: public/app/daily_candidates_guarded.jsonl）
+ * - 入力:  --in <jsonl>（既定: public/app/daily_candidates.jsonl）
+ * - 出力:  --out <jsonl>（既定: public/app/daily_candidates_guarded.jsonl）
+ * - strict: --strict on/off（既定 off。on にすると「疑似NG語」一致も drop）
  * - 基本基準:
  *   - provider は apple / youtube のみ許可
  *   - id 形式検査: apple は数値, youtube は長さ11かつ [A-Za-z0-9_-]
  *   - title / answers.canonical の空は除外
+ * - 疑似NG語（suspicious terms）: cover, remix, extended, hour(s), loop, nightcore, piano, guitar, medley, mix, arrange(d), slowed, reverb など
+ *   - 既定では「警告カウントのみ」で keep。--strict=on のときは drop。
  * - 統計は Step Summary に出力
  */
 import fs from 'node:fs';
@@ -18,11 +21,12 @@ import fsp from 'node:fs/promises';
 import path from 'node:path';
 
 function parseArgs(argv){
-  const args = { in: 'public/app/daily_candidates.jsonl', out: 'public/app/daily_candidates_guarded.jsonl' };
+  const args = { in: 'public/app/daily_candidates.jsonl', out: 'public/app/daily_candidates_guarded.jsonl', strict: 'off' };
   for (let i=0;i<argv.length;i++){
     const a = argv[i];
     if (a === '--in' && i+1 < argv.length) args.in = argv[++i];
     else if (a === '--out' && i+1 < argv.length) args.out = argv[++i];
+    else if (a === '--strict' && i+1 < argv.length) args.strict = argv[++i];
   }
   return args;
 }
@@ -39,7 +43,14 @@ function isYoutubeId(id){
 function isAppleId(id){
   return typeof id === 'string' && /^[0-9]+$/.test(id);
 }
-function guard(entry){
+const SUSPICIOUS = [
+  'cover','arrange','arranged','remix','extended','hour','hours','loop','nightcore','piano','guitar','medley','mix','slowed','reverb','orchestrated'
+];
+function hasSuspiciousTitle(entry){
+  const title = String(entry?.title || entry?.track?.name || '').toLowerCase();
+  return SUSPICIOUS.some(w => title.includes(w));
+}
+function guard(entry, strict=false){
   const prov = (entry?.clip?.provider || entry?.provider || '').toLowerCase();
   const id = entry?.clip?.id || entry?.id || '';
   if (!(prov === 'youtube' || prov === 'apple')) return { keep:false, reason:'provider-unsupported' };
@@ -49,6 +60,10 @@ function guard(entry){
   const ans = entry?.answers?.canonical || '';
   if (!String(title).trim()) return { keep:false, reason:'missing-title' };
   if (!String(ans).trim()) return { keep:false, reason:'missing-answer' };
+  if (hasSuspiciousTitle(entry)) {
+    if (strict) return { keep:false, reason:'suspicious-title' };
+    return { keep:true, reason:'warn-suspicious-title' };
+  }
   return { keep:true, reason:'' };
 }
 async function main(){
@@ -58,18 +73,20 @@ async function main(){
   const reasons = {};
   for (const c of readJSONL(args.in)){
     stats.in++;
-    const g = guard(c);
+    const g = guard(c, String(args.strict||'off').toLowerCase()==='on');
     if (g.keep){ kept.push(c); stats.kept++; }
-    else { stats.drop++; reasons[g.reason] = (reasons[g.reason]||0)+1; }
+    else { stats.drop++; }
+    if (g.reason) reasons[g.reason] = (reasons[g.reason]||0)+1;
   }
   await fsp.mkdir(path.dirname(args.out), { recursive:true });
   await fsp.writeFile(args.out, kept.map(o=>JSON.stringify(o)).join('\n')+'\n', 'utf-8');
   const lines = [
-    '### heuristic-media-guard v0',
+    '### heuristic-media-guard v1',
     `- in: **${stats.in}**`,
     `- kept: **${stats.kept}**`,
     `- drop: ${stats.drop}`,
     `- reasons: ${Object.entries(reasons).map(([k,v])=>`${k}:${v}`).join(', ') || '(none)'}`,
+    `- strict: ${args.strict}`,
   ];
   if (process.env.GITHUB_STEP_SUMMARY){
     fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n')+'\n');


### PR DESCRIPTION
## Summary
- extend heuristic_media_guard to v1 with optional strict title checks
- allow cron workflow to enable strict guard and generate choices via variables
- document repository variables for candidates cron

## Testing
- `npm test` *(fails: clojure: not found)*
- `node scripts/heuristic_media_guard_v0.mjs --in /tmp/candidates.jsonl --out /tmp/guarded.jsonl --strict off`
- `node scripts/heuristic_media_guard_v0.mjs --in /tmp/candidates.jsonl --out /tmp/guarded_strict.jsonl --strict on`


------
https://chatgpt.com/codex/tasks/task_e_68bd5d5c06788324825cf0c18a77cc26