### PR TITLE
docs: add roadmap issues for v1.9–v1.11

### DIFF
--- a/docs/issues/v1_10.json
+++ b/docs/issues/v1_10.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "v110-dedup-v15",
+    "title": "v1.10: De-dup v1.5（N-gram 類似 + 正規化）",
+    "labels": [
+      "roadmap:v1.10",
+      "area:quality"
+    ],
+    "body": "### Scope\n- 3-gram 類似の導入（θ_main=0.80 / strict=0.82）\n- suspicious-title 減点 0.02\n- Step Summary: examined/dup-exact/dup-similar\n\n### DoD\n- ゴールデン10件の回帰緑\n- Summary に dup 率\n- SPEC_DEDUP_v1.md を最終反映"
+  },
+  {
+    "id": "v110-notability-v1",
+    "title": "v1.10: Notability v1（High/Med/Low=75/20/5）",
+    "labels": [
+      "roadmap:v1.10",
+      "area:quality"
+    ],
+    "body": "### Scope\n- 特徴量: Apple Popularity / aliases頻度 / 公式フラグ\n- 帯域閾値: 0.67 / 0.33（初期）\n- pick ミックスに適用\n\n### DoD\n- Summary に帯域比\n- SPEC_NOTABILITY.md 反映\n- 直近7日の正答率が 60–85% 帯に入る（観測）"
+  },
+  {
+    "id": "v110-provenance-wire",
+    "title": "v1.10: provenance 配線（ingest→pick）",
+    "labels": [
+      "roadmap:v1.10",
+      "area:quality",
+      "area:pipeline"
+    ],
+    "body": "### Scope\n- source/provider/id/collected_at/hash/license_hint の継承\n- JSONL/JSON のスキーマ差分棚卸し\n\n### DoD\n- 欠落なしで通過\n- POLICY_PROVENANCE.md に実装例追記"
+  },
+  {
+    "id": "v110-kpi-summary",
+    "title": "v1.10: Step Summary にKPI最小セットを出す",
+    "labels": [
+      "roadmap:v1.10",
+      "area:ops"
+    ],
+    "body": "### Scope\n- guard/dedup/notability/pick の最小必須セット\n\n### DoD\n- 全主要WFで表示\n- QUALITY_KPIS.md と突合可能"
+  },
+  {
+    "id": "v110-backfill-by-year-if",
+    "title": "v1.10: backfill の by_year I/F 設計",
+    "labels": [
+      "roadmap:v1.10",
+      "area:ops"
+    ],
+    "body": "### Scope\n- public/app/by_year/YYYY.json のI/F確定\n- 未来地平線90日・PR粒度30–90日\n\n### DoD\n- OPERATIONS_BACKFILL.md にI/F例を追記\n- 小規模試験が可能"
+  },
+  {
+    "id": "v110-rate-cost-doc",
+    "title": "v1.10: Rate/Cost 制御の方針を明文化（任意）",
+    "labels": [
+      "roadmap:v1.10",
+      "area:ops",
+      "type:docs"
+    ],
+    "body": "### Scope\n- レートリミット/バックオフ/キャッシュの指針\n\n### DoD\n- ROADMAP.md および関連 docs に反映"
+  }
+]

--- a/docs/issues/v1_11.json
+++ b/docs/issues/v1_11.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "v111-discovery-dryrun",
+    "title": "v1.11: Discovery 設計 & dry-run（iTunes Search 起点）",
+    "labels": [
+      "roadmap:v1.11",
+      "area:collector"
+    ],
+    "body": "### Scope\n- game/album 語 → 正規化 → 提案 seed（dry-run）\n- 公式性判定の最小ルール\n\n### DoD\n- 提案seedをアーティファクト出力\n- 簡易レビューが可能"
+  },
+  {
+    "id": "v111-gate-threshold",
+    "title": "v1.11: Gate 閾値 θ の定義（自動採用 vs PR送り）",
+    "labels": [
+      "roadmap:v1.11",
+      "area:collector",
+      "area:ops"
+    ],
+    "body": "### Scope\n- 信頼度スコア θ（Notability/Guard/Provider信頼度の合成）\n- 切替（Repo Variables or workflow input）\n\n### DoD\n- θ を docs に明記\n- 切替動作を確認"
+  }
+]

--- a/docs/issues/v1_9.json
+++ b/docs/issues/v1_9.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "v19-daily-auto-stable",
+    "title": "v1.9: 日次自動作問の安定化（cron & pick PR）",
+    "labels": [
+      "roadmap:v1.9",
+      "area:ops",
+      "status:done"
+    ],
+    "state": "closed",
+    "body": "### Scope\n- candidates (ingest→score→pick PR) の日次運用\n- 差分なければPRなしの挙動確認\n\n### Done\n- cron運用で緑が継続\n- daily_auto.json が日次で更新（候補枯渇時はスキップ）\n"
+  },
+  {
+    "id": "v19-smoke-apple-override",
+    "title": "v1.9: smoke apple override（即時検証フロー）",
+    "labels": [
+      "roadmap:v1.9",
+      "area:pipeline",
+      "status:done"
+    ],
+    "state": "closed",
+    "body": "### Scope\n- smoke ワークフローで Apple Overrides の適用可否を即時検証\n\n### Done\n- 成果物 daily_today.md に music.apple.com / embed.music.apple.com を確認\n"
+  },
+  {
+    "id": "v19-aliases-backfill-base",
+    "title": "v1.9: aliases backfill ベース運用",
+    "labels": [
+      "roadmap:v1.9",
+      "area:data",
+      "status:done"
+    ],
+    "state": "closed",
+    "body": "### Scope\n- scripts/backfill_aliases_v1.mjs の実行とアーティファクト確認\n\n### Done\n- data/aliases/*.json を拡充（artifact で差分検知）\n"
+  }
+]


### PR DESCRIPTION
## Summary
- add v1.9 issue definitions for daily auto generation, Apple override smoke, and aliases backfill
- document v1.10 roadmap items including dedup v1.5, notability v1, provenance wiring, KPI summary, backfill interface, and rate/cost docs
- outline v1.11 discovery dry-run and gate threshold topics

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9e59b11c83249e5a09efe05c3d9c