### PR TITLE
docs: update issue tracking status for i18n and authoring

### DIFF
--- a/docs/issues/v1_6_i18n.json
+++ b/docs/issues/v1_6_i18n.json
@@ -3,37 +3,40 @@
     "id": "i18n-core-module",
     "title": "i18n: コアモジュール導入（i18n.mjs）",
     "labels": [
-      "roadmap:v1.6",
       "area:app",
-      "type:code",
-      "i18n"
+      "i18n",
+      "roadmap:v1.6",
+      "status:done",
+      "type:code"
     ],
     "body": "### Scope\n- public/app/i18n.mjs を追加（detectLang/loadLocale/t/setLang/initI18n）\n- <html lang> を切り替え\n\n### DoD\n- import/初期化が app.js から行われる\n- ?lang=en/ja で t() が機能する\n- 既存パフォーマンスに影響なし（遅延 import 可）",
-    "state": "open"
+    "state": "closed"
   },
   {
     "id": "locales-en-ja",
     "title": "i18n: locales/en.json & ja.json（最小キー）",
     "labels": [
-      "roadmap:v1.6",
       "area:app",
-      "type:data",
-      "i18n"
+      "i18n",
+      "roadmap:v1.6",
+      "status:done",
+      "type:data"
     ],
     "body": "### Scope\n- タイトル/主要ボタン/ライブリージョンなど最小キーの辞書を作成\n\n### DoD\n- 未翻訳キーは英語フォールバック\n- 初期バンドルは en のみ同梱（ja は遅延ロード）",
-    "state": "open"
+    "state": "closed"
   },
   {
     "id": "wiring-init-in-app",
     "title": "i18n: initI18n() を app.js 起動時に配線",
     "labels": [
-      "roadmap:v1.6",
       "area:app",
-      "type:code",
-      "i18n"
+      "i18n",
+      "roadmap:v1.6",
+      "status:done",
+      "type:code"
     ],
     "body": "### Scope\n- app.js のエントリで initI18n() を呼び出し\n- html[lang] と document.title を t() で設定\n\n### DoD\n- ?lang=en/ja で動作、デフォルトは navigator.language\n- エラー時は英語にフォールバック",
-    "state": "open"
+    "state": "closed"
   },
   {
     "id": "replace-strings-step1",
@@ -63,47 +66,47 @@
     "id": "a11y-messages-to-keys",
     "title": "i18n: a11yメッセージのキー管理へ統合",
     "labels": [
-      "roadmap:v1.6",
       "area:a11y",
-      "type:code",
-      "i18n"
+      "i18n",
+      "roadmap:v1.6",
+      "status:done",
+      "type:code"
     ],
     "body": "### Scope\n- live region などの文言を辞書キーへ移管\n\n### DoD\n- a11y 静的スモークと手動検証を通過",
-    "state": "open"
+    "state": "closed"
   },
   {
     "id": "e2e-i18n-lang-param-smoke",
     "title": "E2E: ?lang=ja|en スモーク",
     "labels": [
-      "roadmap:v1.6",
       "area:test",
-      "type:test",
-      "i18n"
+      "i18n",
+      "roadmap:post-v1.6",
+      "type:test"
     ],
-    "body": "### Scope\n- <html lang> と document.title の確認\n\n### DoD\n- Actions ワークフローで緑\n- Pages/ローカルで目視確認もOK",
-    "state": "open"
+    "body": "### Scope\n- <html lang> と document.title の確認\n\n### DoD\n- Actions ワークフローで緑\n- Pages/ローカルで目視確認もOK"
   },
   {
     "id": "static-checker-missing-keys",
     "title": "Scripts: 未翻訳/未使用キーの静的チェック",
     "labels": [
-      "roadmap:v1.6",
       "area:ops",
-      "type:scripts",
-      "i18n"
+      "i18n",
+      "roadmap:post-v1.6",
+      "type:scripts"
     ],
-    "body": "### Scope\n- スクリプトで locales と使用キーを突き合わせ\n\n### DoD\n- CI で実行して緑\n- false positive を最小限に",
-    "state": "open"
+    "body": "### Scope\n- スクリプトで locales と使用キーを突き合わせ\n\n### DoD\n- CI で実行して緑\n- false positive を最小限に"
   },
   {
     "id": "docs-styleguide-i18n-roadmap",
     "title": "Docs: STYLEGUIDE_I18N/ROADMAP の整備",
     "labels": [
+      "i18n",
       "roadmap:v1.6",
-      "type:docs",
-      "i18n"
+      "status:done",
+      "type:docs"
     ],
     "body": "### Scope\n- docs/STYLEGUIDE_I18N.md の初版\n- ROADMAP v1.6 のDoD明記\n\n### DoD\n- Docs lint/リンクチェック緑\n- 既存スタイルガイドと矛盾しない",
-    "state": "open"
+    "state": "closed"
   }
 ]

--- a/docs/issues/v1_7.json
+++ b/docs/issues/v1_7.json
@@ -3,8 +3,8 @@
     "id": "authoring-harvester-min",
     "title": "Authoring: harvester-min（公式ソース収集器）",
     "labels": [
-      "roadmap:v1.7",
-      "area:pipeline"
+      "area:pipeline",
+      "roadmap:post-v1.7"
     ],
     "body": "### Scope\n- 公式YouTube/Apple API優先で収集\n- レート制御・失敗時リトライ\n\n### DoD\n- 最低1件の有効候補を日次で獲得可能\n- 失敗時の理由をログ/サマリで確認可能"
   },
@@ -22,20 +22,24 @@
     "id": "authoring-difficulty-v1",
     "title": "Authoring: difficulty-v1（簡易スコア）",
     "labels": [
-      "roadmap:v1.7",
       "area:pipeline",
+      "roadmap:v1.7",
+      "status:done",
       "type:test"
     ],
-    "body": "### Scope\n- 年代/別名密度/シリーズ知名度などから 0–100\n- Node/Browserパリティ\n- 分布チェック\n\n### DoD\n- 既存問題の分布が中央値±10pt以内\n- テスト緑"
+    "body": "### Scope\n- 年代/別名密度/シリーズ知名度などから 0–100\n- Node/Browserパリティ\n- 分布チェック\n\n### DoD\n- 既存問題の分布が中央値±10pt以内\n- テスト緑",
+    "state": "closed"
   },
   {
     "id": "authoring-distractors-v1",
     "title": "Authoring: distractors-v1（ダミー生成）",
     "labels": [
+      "area:pipeline",
       "roadmap:v1.7",
-      "area:pipeline"
+      "status:done"
     ],
-    "body": "### Scope\n- 同年代/作曲者/シリーズ近傍から抽出\n- 最低品質ガード\n\n### DoD\n- 明らかに不適切な選択肢が混入しない（軽量ルールベース）"
+    "body": "### Scope\n- 同年代/作曲者/シリーズ近傍から抽出\n- 最低品質ガード\n\n### DoD\n- 明らかに不適切な選択肢が混入しない（軽量ルールベース）",
+    "state": "closed"
   },
   {
     "id": "authoring-authoring-schema-json",
@@ -61,10 +65,12 @@
     "id": "authoring-ops-docs",
     "title": "Authoring: ops-docs（運用手順と監視ポイント）",
     "labels": [
+      "area:ops",
       "roadmap:v1.7",
-      "type:docs",
-      "area:ops"
+      "status:done",
+      "type:docs"
     ],
-    "body": "### Scope\n- Secrets/PAT、失敗時の手順、監視ディシプリン\n\n### DoD\n- Docs整備 & link-check緑"
+    "body": "### Scope\n- Secrets/PAT、失敗時の手順、監視ディシプリン\n\n### DoD\n- Docs整備 & link-check緑",
+    "state": "closed"
   }
 ]


### PR DESCRIPTION
## Summary
- mark completed i18n v1.6 tasks as done and update labels
- update v1.7 authoring issues with post-v1.7 and completed statuses

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bda5e24c588324b30ed9a0d778f086