### PR TITLE
docs: update i18n roadmap labels

### DIFF
--- a/docs/issues/v1_6_i18n.json
+++ b/docs/issues/v1_6_i18n.json
@@ -42,10 +42,10 @@
     "id": "replace-strings-step1",
     "title": "i18n: Start/History/Share のテキスト外部化（第1段）",
     "labels": [
-      "roadmap:v1.6",
       "area:ui",
       "type:code",
-      "i18n"
+      "i18n",
+      "roadmap:post-v1.6"
     ],
     "body": "### Scope\n- 目に触れるUIテキストのキー化（Start/History/Share）\n\n### DoD\n- スクリーンショット差分で視覚回帰なし\n- 既存E2E緑維持",
     "state": "open"
@@ -54,10 +54,10 @@
     "id": "intl-dates-numbers",
     "title": "i18n: Intl.DateTimeFormat/NumberFormat での表記統一",
     "labels": [
-      "roadmap:v1.6",
       "area:app",
       "type:code",
-      "i18n"
+      "i18n",
+      "roadmap:post-v1.6"
     ],
     "body": "### Scope\n- 日付/数値表示の Intl.* 化\n\n### DoD\n- ロケールに応じた表記\n- 未対応環境でもフォールバック（英語）",
     "state": "open"

--- a/docs/issues/v1_7.json
+++ b/docs/issues/v1_7.json
@@ -12,9 +12,9 @@
     "id": "authoring-clip-start-heuristics-v1",
     "title": "Authoring: clip-start-heuristics-v1",
     "labels": [
-      "roadmap:v1.7",
       "area:pipeline",
-      "type:test"
+      "type:test",
+      "roadmap:post-v1.7"
     ],
     "body": "### Scope\n- t=/start=>メタ=>既定値の優先順位\n- 異常値ガード\n- ユニットテスト\n\n### DoD\n- 代表ケースで期待値\n- エッジケースでフェイルセーフ"
   },


### PR DESCRIPTION
## Summary
- shift unfinished v1.6 i18n work to post-v1.6 roadmap
- shift clip-start heuristics to post-v1.7 roadmap

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be3167ab888324a976803049cbf8b0