### PR TITLE
feat: guard mutual roadmap labels

### DIFF
--- a/docs/issues/v1_7.json
+++ b/docs/issues/v1_7.json
@@ -45,21 +45,25 @@
     "id": "authoring-authoring-schema-json",
     "title": "Authoring: authoring-schema（生成JSONスキーマ）",
     "labels": [
-      "roadmap:v1.7",
-      "type:test",
-      "area:pipeline"
+      "area:pipeline",
+      "roadmap:post-v1.7",
+      "status:done",
+      "type:test"
     ],
-    "body": "### Scope\n- 生成JSONのスキーマ定義\n- schema検証\n\n### DoD\n- CIでschemaバリデーションが走る"
+    "body": "### Scope\n- 生成JSONのスキーマ定義\n- schema検証\n\n### DoD\n- CIでschemaバリデーションが走る",
+    "state": "closed"
   },
   {
     "id": "authoring-daily-publish-json-ogp",
     "title": "Authoring: daily-publish（日次JSON/OGP生成と配置）",
     "labels": [
-      "roadmap:v1.7",
       "area:ops",
+      "roadmap:post-v1.7",
+      "status:done",
       "type:test"
     ],
-    "body": "### Scope\n- `public/daily/YYYY-MM-DD.json` と OGPを生成\n- latest連携・E2Eスモーク追加\n\n### DoD\n- `schedule: daily` で1問生成が安定\n- 失敗時のスキップと通知"
+    "body": "### Scope\n- `public/daily/YYYY-MM-DD.json` と OGPを生成\n- latest連携・E2Eスモーク追加\n\n### DoD\n- `schedule: daily` で1問生成が安定\n- 失敗時のスキップと通知",
+    "state": "closed"
   },
   {
     "id": "authoring-ops-docs",

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -80,3 +80,12 @@
 > Quick links（本番。`NOW` はキャッシュバスター置換）  
 > - `/build/version.json` / `/app/../build/version.json`  
 > - `/build.json?ts=NOW` / `/app/build.json?ts=NOW`
+
+## Issues 運用ルール（ラベル相互排他・汎用）
+
+- **唯一の正は `docs/issues/*.json`**。GitHub 側は `script/sync_issues_v3.mjs` で常に上書き。
+- `post-*` ラベルは **JSON が真実**（sync 時に GitHub ラベルも上書きされる）。
+- **相互排他（全バージョン共通）**: 同一 Issue に以下のラベルを **同時に付けない**。  
+  - `roadmap:vX.Y` **と** `roadmap:post-vX.Y`（X.Y は任意のバージョン、例: 1.5 / 1.7 / 1.11 …）  
+  → バリデータ（`script/validate_issue_specs.mjs`）で検出し、CI を **落とす** ようにしてある。
+- 先送り・保留項目は `roadmap:post-vX.Y` を **明示** し、タイトルや本文で文脈が変わる場合は Issue を分離（重複タイトルは v3.1 同期で安全に close される）。

--- a/script/validate_issue_specs.mjs
+++ b/script/validate_issue_specs.mjs
@@ -59,6 +59,31 @@ for (const f of files) {
   });
 }
 
+
+// --- Roadmap label mutual exclusion guard (generic) ---
+// Any issue must NOT have both `roadmap:vX.Y` and `roadmap:post-vX.Y` for the same X.Y.
+for (const f of files) {
+  const json = JSON.parse(fs.readFileSync(path.join(DIR, f), 'utf-8'));
+  json.forEach((it, idx) => {
+    const where = `${f}#${idx+1}${it.id ? `(${it.id})` : ''}`;
+    const labels = Array.isArray(it.labels) ? it.labels : [];
+    const v = new Set();
+    const post = new Set();
+    for (const lb of labels) {
+      let m = lb.match(/^roadmap:v(\d+\.\d+)$/);
+      if (m) v.add(m[1]);
+      m = lb.match(/^roadmap:post-v(\d+\.\d+)$/);
+      if (m) post.add(m[1]);
+    }
+    const both = [...v].filter(x => post.has(x));
+    if (both.length > 0) {
+      console.error(`✗ ${where}: mutually exclusive labels for roadmap version(s): ${both.join(', ')}`);
+      ok = false;
+    }
+  });
+}
+// --- end mutual exclusion guard ---
+
 if (!ok) {
   process.exit(1);
 } else {


### PR DESCRIPTION
## Summary
- validate issues to forbid simultaneous `roadmap:vX.Y` and `roadmap:post-vX.Y`
- document generic roadmap label exclusion rules
- mark closed v1.7 authoring tasks as post-v1.7

## Testing
- `node script/validate_issue_specs.mjs`
- `npm test` *(fails: clojure: not found; apt-get update fails with unsigned repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be3c3516688324a5b9c28c211a9698