### PR TITLE
feat: add media allowlist and clip start safeguards

### DIFF
--- a/docs/CLIP_START_HEURISTICS.md
+++ b/docs/CLIP_START_HEURISTICS.md
@@ -53,6 +53,15 @@ node scripts/generate_daily_from_candidates.js \
 - `Ending` を含むと `20` になる
 - `apple` で `15` / `youtube` で `10` になる
 - 既存 `clip.start=7` がある場合は上書きしない（`--force` でのみ上書き）
+ 
+## 閾値・NG検出（v1.7 最小）
+- **最短尺**: `MIN_SEGMENT_SEC=15` を保証（`clip.duration<15` は 15 に引き上げ）
+- **YouTube の冒頭回避**: `YT_MIN_OFFSET_SEC=3`（開始秒が 3 未満なら 3 に補正）
+- **サビ検出（テキスト準拠）**: タイトルに `Chorus/サビ` を含む場合は `start=45` を目安にする（`CHORUS_DEFAULT_SEC=45`）。
+- **遅すぎ補正**: `max`（既定120）を超える推定は **クランプ**し、`clip.flags` に `late_start_clamped` を記録
+- **フラグ付与**: `clip.flags=[too_short|start_below_min|late_start_clamped|...]` を付与して後段でレビュー可能にする
+
+> 注: v1 は**音響解析を行いません**。無音判定は未対応で、将来の v2+ にてピーク/ビート/スペクトルで補正予定。
 
 ## 将来拡張（v2+）
 - 音響解析（無音検出・ピーク・ビート）と組み合わせた補正

--- a/docs/HARVESTER_MIN.md
+++ b/docs/HARVESTER_MIN.md
@@ -1,0 +1,34 @@
+# Harvester (MIN) — 公式ソース最小導入
+
+目的: 候補（JSONL）生成の段階で、**外部ネットワークに依存せず**に「できる範囲で安全な media を付与」する最小版ハーベスタ。
+
+## 入出力
+- 入力: `public/build/dataset.json`（Clojure生成物）
+- 付随参照: `resources/data/apple_overrides.jsonc`（**手動管理**の公式 Apple 埋め込み辞書） / `sources/allowlist.json`（**公式IDのみ**許可）
+- 出力: `public/app/daily_candidates.jsonl` の各行（候補）に `media` を**可能なら**付与（付かない場合は `null` のまま）
+
+## ルール（安全サイド）
+1. **Apple優先**（`apple_overrides.jsonc` 該当があれば `media.apple.embedUrl|previewUrl|url` をそのまま付与）
+2. データセット内に `media.apple.*` が既にあれば、それも許容（上書きはしない）
+3. **YouTubeは厳格な allowlist のみ**（`sources/allowlist.json` の `youtube` に **動画IDが厳密一致** する場合だけ付与）
+4. 外部検索/APIコールは**行わない**（CIの再現性を担保）
+5. 付与できない場合は **`media: null` のまま**（後段 `ensure_min_items_v1_post.mjs` が空日を救済）
+
+## ノーマライズとキー
+- 既存の `normalizeAnswer` を用い、`norm.game` と `norm.title` を連結した `"${norm.game}__${norm.title}"`（lowercase）を **overrides のキー**として引く。
+
+## 由来（provenance）
+- 後続の `docs/POLICY_PROVENANCE.md` に従い、将来的には `provenance` を候補に持たせる（最小版では省略可）。
+  - `license_hint`: Apple=official / YouTube=label or official（allowlistを以て best-effort）
+
+## 実行（手動）
+```bash
+node scripts/harvest_candidates.js --out public/app/daily_candidates.jsonl
+```
+- 併用が望ましい補助:
+  - `node scripts/generate_apple_override_candidates.mjs`
+  - `node scripts/smoke_apple_override.mjs`
+
+## よくある質問
+- Q. media が全く付かないのは正常？  
+  A. はい。**MIN**では付与機会は限定的です。Apple overrides の拡充や allowlist の更新で段階的に増やします。

--- a/docs/OPERATIONS_AUTHORING.md
+++ b/docs/OPERATIONS_AUTHORING.md
@@ -186,4 +186,4 @@ node scripts/normalize_core.mjs --in public/app/daily_auto.json
 - 使い方:  
   `node scripts/normalize_core_guard_cli.mjs --in build/daily_today.json --out build/daily_today.json`  
 - `by_date` を検出した場合は **NO-OP** として終了します。
-
+- 参考: `docs/HARVESTER_MIN.md`（公式ソース最小導入ガイド）

--- a/scripts/clip_start_heuristics_v1.mjs
+++ b/scripts/clip_start_heuristics_v1.mjs
@@ -50,6 +50,10 @@ if (args.help || !args.in || !args.out) {
   usage();
   process.exit(args.help ? 0 : 1);
 }
+
+const MIN_SEGMENT_SEC = 15;     // 短すぎ対策（常に最低15sは確保）
+const YT_MIN_OFFSET_SEC = 3;    // YouTubeは冒頭ノイズ/ジングルを避けて+3s
+const CHORUS_DEFAULT_SEC = 45;  // サビ/Chorus は目安で45s（曲による）
 function clamp(n, lo, hi) {
   return Math.max(lo, Math.min(hi, n));
 }
@@ -72,7 +76,9 @@ function keywordStart(text) {
   if (battle.test(text)) return 12;
   // 末尾系
   const ending = /(ending|credits|staff\s*roll|エンディング|スタッフ.?ロール)/i;
+  const chorus = /(chorus|サビ)/i;
   if (ending.test(text)) return 20;
+  if (chorus.test(text)) return CHORUS_DEFAULT_SEC;
   return null;
 }
 function providerDefault(provider) {
@@ -111,12 +117,23 @@ async function run(inputPath, outputPath, { defaultStart, max, force }) {
     obj.clip = obj.clip || {};
     const hadNumeric = hasNumericStart(obj.clip);
     if (!hadNumeric || force) {
-      const s = guessStart(obj, { defaultStart, maxStart: max });
+      let flags = [];
+      let s = guessStart(obj, { defaultStart, maxStart: max });
       if (!Number.isFinite(obj.clip.duration)) {
-        // duration 未設定なら最小安全値 15 をセット（UI側で上限60を尊重）
-        obj.clip.duration = 15;
+        obj.clip.duration = MIN_SEGMENT_SEC;
+      } else if (obj.clip.duration < MIN_SEGMENT_SEC) {
+        obj.clip.duration = MIN_SEGMENT_SEC;
+        flags.push('too_short');
+      }
+      if (obj.clip.provider && String(obj.clip.provider).toLowerCase().includes('youtube') && s < YT_MIN_OFFSET_SEC) {
+        s = YT_MIN_OFFSET_SEC;
+        flags.push('start_below_min');
+      }
+      if (s === max) {
+        flags.push('late_start_clamped');
       }
       obj.clip.start = s;
+      if (flags.length) obj.clip.flags = Array.from(new Set([...(obj.clip.flags||[]), ...flags]));
       updated++;
     }
     out.write(JSON.stringify(obj) + '\n');

--- a/scripts/harvest_candidates.js
+++ b/scripts/harvest_candidates.js
@@ -9,6 +9,69 @@
 const fs = require('fs');
 const path = require('path');
 const { normalizeAnswer } = require('./pipeline/normalize');
+const JSONC = {
+  parse(src){
+    // very small JSONC: strip // and /* */ comments
+    const noBlock = src.replace(/\/\*[\s\S]*?\*\//g, '');
+    const noLine = noBlock.replace(/(^|\s+)\/\/.*$/gm, '$1');
+    return JSON.parse(noLine);
+  }
+};
+
+function loadAllowlist(p){
+  try {
+    const txt = fs.readFileSync(p, 'utf-8');
+    return JSON.parse(txt);
+  } catch {
+    return null;
+  }
+}
+
+function loadAppleOverrides(p){
+  try {
+    const txt = fs.readFileSync(p, 'utf-8');
+    return JSONC.parse(txt);
+  } catch {
+    return null;
+  }
+}
+
+function toAppleMediaFromOverride(entry){
+  if (!entry || !entry.media || !entry.media.apple) return null;
+  const a = entry.media.apple;
+  const apple = {};
+  if (a.embedUrl) apple.embedUrl = a.embedUrl;
+  if (a.previewUrl) apple.previewUrl = a.previewUrl;
+  if (a.url) apple.url = a.url;
+  const media = { apple };
+  if (a.start_ms) media.start_ms = a.start_ms;
+  return media.apple.embedUrl || media.apple.previewUrl || media.apple.url ? media : null;
+}
+
+function fillMedia(candidate, rec, opts){
+  const { allowlist, appleOverrides } = opts || {};
+  // 1) Apple overrides (official & safest)
+  const key = `${candidate.norm.game}__${candidate.norm.title}`.toLowerCase().trim();
+  if (appleOverrides && appleOverrides[key]){
+    const m = toAppleMediaFromOverride(appleOverrides[key]);
+    if (m) return m;
+  }
+  // 2) Dataset-provided Apple (if any)
+  if (rec?.media?.apple && (rec.media.apple.embedUrl || rec.media.apple.previewUrl || rec.media.apple.url)){
+    return { apple: {
+      embedUrl: rec.media.apple.embedUrl,
+      previewUrl: rec.media.apple.previewUrl,
+      url: rec.media.apple.url
+    }};
+  }
+  // 3) YouTube fallback (strict allowlist: video id exact matchのみ)
+  const vid = rec?.media?.youtube?.id || rec?.youtubeId || rec?.yt || null;
+  if (vid && allowlist?.youtube && (allowlist.youtube[vid] === true)){
+    return { provider: 'youtube', id: vid, start_ms: rec?.media?.youtube?.start_ms || 0 };
+  }
+  // 4) none
+  return null;
+}
 
 function readJSON(p){ return JSON.parse(fs.readFileSync(p,'utf-8')); }
 function ensureDir(dir){ fs.mkdirSync(dir, { recursive:true }); }
@@ -57,6 +120,13 @@ function toCandidate(rec){
 function main(){
   const { out, src: srcArg } = parseArgs();
   const src = resolveSrc(srcArg);
+
+  // Load allowlist / apple overrides (optional)
+  const allowlistPath = path.join(process.cwd(), 'sources/allowlist.json');
+  const appleOverridesPath = path.join(process.cwd(), 'resources/data/apple_overrides.jsonc');
+  const allowlist = loadAllowlist(allowlistPath);
+  const appleOverrides = loadAppleOverrides(appleOverridesPath);
+
   if(!src){
     console.error(`[harvest] source not found: ${srcArg}`);
     console.error('[harvest] Tips:');
@@ -74,6 +144,7 @@ function main(){
   for(const rec of list){
     total++;
     const c = toCandidate(rec);
+    if(!c.media){ c.media = fillMedia(c, rec, { allowlist, appleOverrides }); }
     const key = `${c.norm.title}|${c.norm.game}|${c.norm.composer}`;
     if(!c.norm.title || !c.norm.game || !c.norm.composer) continue;
     if(seen.has(key)) continue;


### PR DESCRIPTION
## Summary
- support optional allowlist and Apple Music overrides during candidate harvesting
- document minimal harvester workflow and update operations/clip heuristics docs
- strengthen clip start heuristics with minimum segment, YouTube offset, chorus keyword, and flags

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be7191404c8324bcb9c15a36009779