### PR TITLE
Label closed issue duplicates

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -89,6 +89,10 @@
   1. Actions → **issues (cleanup duplicates)** を手動実行
   2. もしくは次回以降の **issues (sync)** 実行後、自動のグローバル重複掃除で収束（本スクリプトに内蔵）
 
+### 重複クローズ時のラベル
+- 同一タイトルの重複を自動クローズした Issue には **`duplicate`** ラベルを付与します（存在しない場合は作成して付与）。
+- 手動で `issues (cleanup duplicates)` を実行した場合も同様に付与されます。
+
 ## Issues 運用ルール（ラベル相互排他・汎用）
 
 - **唯一の正は `docs/issues/*.json`**。GitHub 側は `script/sync_issues_v3.mjs` で常に上書き。

--- a/script/cleanup_issue_title_duplicates.mjs
+++ b/script/cleanup_issue_title_duplicates.mjs
@@ -1,6 +1,7 @@
 /**
  * Standalone: Close duplicate open issues that share the same title.
  * Canonical: prefer issue that contains an <!-- issue-id: ... --> marker; else most recently updated.
+ * Adds 'duplicate' label to closed duplicates.
  */
 const REPO = process.env.GITHUB_REPOSITORY;
 const TOKEN = process.env.GITHUB_TOKEN;
@@ -27,7 +28,19 @@ async function gh(path, init = {}) {
   return ctype.includes('application/json') ? res.json() : res.text();
 }
 
+async function ensureLabelDuplicate() {
+  // Try to add; if fails because label doesn't exist, create it then add again.
+  async function addLabel(number) {
+    await gh(`/repos/${owner}/${repo}/issues/${number}/labels`, {
+      method: 'POST',
+      body: JSON.stringify({ labels: ['duplicate'] }),
+    });
+  }
+  return { addLabel };
+}
+
 async function run() {
+  const { addLabel } = await ensureLabelDuplicate();
   const open = [];
   let page = 1;
   while (true) {
@@ -59,6 +72,20 @@ async function run() {
         method: 'POST',
         body: JSON.stringify({ body: `Closed as duplicate of #${keep.number} (title match).` }),
       });
+      try {
+        await addLabel(it.number);
+      } catch (e) {
+        // Attempt to create label then re-add
+        try {
+          await gh(`/repos/${owner}/${repo}/labels`, {
+            method: 'POST',
+            body: JSON.stringify({ name: 'duplicate', color: 'cccccc', description: 'Closed as duplicate' }),
+          });
+          await addLabel(it.number);
+        } catch (e2) {
+          console.warn(`[cleanup] failed to add 'duplicate' label to #${it.number}:`, e2.message || e2);
+        }
+      }
       console.log(`[cleanup] closed dup #${it.number} -> keep #${keep.number}: ${title}`);
     }
   }


### PR DESCRIPTION
## Summary
- label automatically closed duplicate issues with `duplicate`
- document duplicate label behavior for issue cleanup

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be7b1c5cb88324b72b11d3e49c2915