### PR TITLE
feat: add dedup v1.5 script and workflow

### DIFF
--- a/.github/workflows/candidates-dedup.yml
+++ b/.github/workflows/candidates-dedup.yml
@@ -1,0 +1,47 @@
+
+name: candidates (dedup v1.5)
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  dedup:
+    runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Tokyo
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install deps
+        run: echo "no extra deps"
+
+      - name: Restore candidates artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: daily-candidates
+          path: public/app
+
+      - name: Run de-dup v1.5
+        env:
+          DEDUP_IN: public/app/daily_candidates.jsonl
+          DEDUP_OUT: public/app/daily_candidates_deduped.jsonl
+          DEDUP_REPLACE: '1'
+          DEDUP_THETA_MAIN: '0.80'
+          DEDUP_THETA_STRICT: '0.82'
+        run: node scripts/dedup_v1_5.mjs
+
+      - name: Upload candidates (deduped)
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-candidates
+          path: public/app/daily_candidates.jsonl
+          if-no-files-found: error
+
+      - name: Summary (result)
+        run: echo "### candidates (dedup v1.5) result" >> "$GITHUB_STEP_SUMMARY"
+

--- a/docs/SPEC_DEDUP_v1.md
+++ b/docs/SPEC_DEDUP_v1.md
@@ -35,3 +35,24 @@
 
 ## テスト
 - 代表曲の別表記セットでゴールデンテストを作成し、CIで閾値劣化を検出
+
+## 正規化（v1.5 実装）
+- Unicode 正規化: **NFKC**
+- 小文字化、記号→空白に置換、連続空白の圧縮
+- 結合対象: `title + game + composer` を半角スペースで連結
+
+## 類似度（3-gram Dice）
+- 文字列から**連続3文字の部分列**（3-gram）集合を作る
+- **Dice 係数**: `sim = 2 * |A∩B| / (|A| + |B|)`
+- **suspicious-title 減点**: either side が `cover/remix/extended/arrange/...` を含むと `sim -= 0.02`
+
+## しきい値
+- 既定: `θ_main = 0.80`
+- strict: `θ_strict = 0.82`
+- 判定: `sim >= θ` を **近似重複**として除外（`provider|id` 完全一致は即除外）
+
+## Step Summary 出力（必須）
+- `examined`（入力件数）
+- `dup-exact`（完全重複）
+- `dup-similar`（近似重複）
+- `samples`（最大5組: titleA ↔ titleB, sim）

--- a/scripts/dedup_v1_5.mjs
+++ b/scripts/dedup_v1_5.mjs
@@ -1,0 +1,169 @@
+
+/**
+ * De-dup v1.5 (N-gram similarity + normalization)
+ * - 3-gram Dice similarity on normalized string of (title + game + composer)
+ * - exact dup: same provider|id
+ * - suspicious-title penalty: -0.02 if either side contains suspicious keywords
+ * - thresholds: θ_main=0.80, θ_strict=0.82
+ * Input:  public/app/daily_candidates.jsonl
+ * Output: public/app/daily_candidates_deduped.jsonl (and optionally replace original)
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const IN = process.env.DEDUP_IN || 'public/app/daily_candidates.jsonl';
+const OUT = process.env.DEDUP_OUT || 'public/app/daily_candidates_deduped.jsonl';
+const REPLACE_ORIGINAL = (process.env.DEDUP_REPLACE || '1') === '1';
+
+const THETA_MAIN = Number(process.env.DEDUP_THETA_MAIN ?? '0.80');
+const THETA_STRICT = Number(process.env.DEDUP_THETA_STRICT ?? '0.82');
+const MODE_STRICT = (process.env.DEDUP_MODE ?? '').toLowerCase() === 'strict';
+const THETA = MODE_STRICT ? THETA_STRICT : THETA_MAIN;
+
+const SUSPICIOUS = [
+  'cover','remix','extended','arrange','arranged','ost mix','long ver','longver','long version',
+  'karaoke','instrumental','bgm edit','edit ver','tv size','tv-size','tvsize','full size','fullsize'
+];
+const PENALTY = 0.02;
+
+function readJSONL(file){
+  if (!fs.existsSync(file)) return [];
+  const lines = fs.readFileSync(file, 'utf-8').split(/\r?\n/).filter(Boolean);
+  return lines.map(l => {
+    try { return JSON.parse(l); } catch { return null; }
+  }).filter(Boolean);
+}
+
+function writeJSONL(file, arr){
+  const dir = path.dirname(file);
+  fs.mkdirSync(dir, { recursive: true });
+  const lines = arr.map(o => JSON.stringify(o));
+  fs.writeFileSync(file, lines.join('\n')+'\n');
+}
+
+function nfkc(s){ try { return s.normalize('NFKC'); } catch { return s; } }
+
+function normalizeText(s){
+  if (!s) return '';
+  s = nfkc(String(s)).toLowerCase();
+  // unify punctuation/space
+  s = s.replace(/[【】\[\]（）()]/g, ' ');
+  s = s.replace(/[^\p{L}\p{N}\s]/gu, ' ');
+  s = s.replace(/\s+/g, ' ').trim();
+  return s;
+}
+
+function trigramTokens(s){
+  const t = s.replace(/\s+/g, ' ');
+  if (t.length < 3) return [];
+  const grams = new Set();
+  for (let i=0; i<=t.length-3; i++){
+    grams.add(t.slice(i,i+3));
+  }
+  return grams;
+}
+
+function diceSim(aSet, bSet){
+  if (aSet.size===0 && bSet.size===0) return 1;
+  let inter = 0;
+  for (const x of aSet) if (bSet.has(x)) inter++;
+  return (2*inter) / (aSet.size + bSet.size || 1);
+}
+
+function suspiciousPenalty(titleA, titleB){
+  const tA = (titleA||'').toLowerCase();
+  const tB = (titleB||'').toLowerCase();
+  const hit = SUSPICIOUS.some(k => tA.includes(k) || tB.includes(k));
+  return hit ? PENALTY : 0;
+}
+
+function keyProviderId(o){
+  const prov = o?.media?.provider || (o?.media?.apple ? 'apple' : null);
+  const id = o?.media?.id || o?.media?.apple?.embedUrl || o?.media?.apple?.url || o?.media?.apple?.previewUrl;
+  return prov && id ? `${prov}|${id}` : null;
+}
+
+function buildNorm(o){
+  const parts = [o?.title, o?.game, o?.composer].map(normalizeText).filter(Boolean);
+  const joined = parts.join(' ');
+  const grams = trigramTokens(joined);
+  return { joined, grams };
+}
+
+function main(){
+  const arr = readJSONL(IN);
+  const kept = [];
+  const exactSeen = new Set();
+  let dup_exact = 0, dup_similar = 0, examined = 0;
+  const examples = [];
+
+  const memo = new Map(); // index -> {norm, providerId}
+
+  for (let i=0;i<arr.length;i++){
+    const o = arr[i];
+    examined++;
+    const provId = keyProviderId(o);
+    if (provId){
+      if (exactSeen.has(provId)){
+        dup_exact++;
+        continue;
+      }
+    }
+    const norm = buildNorm(o);
+    let isDup = false;
+    let best = { sim: 0, j: -1 };
+    for (let j=0;j<kept.length;j++){
+      const prev = memo.get(j);
+      const sim0 = diceSim(norm.grams, prev.norm.grams);
+      const sim = sim0 - suspiciousPenalty(o?.title, kept[j]?.title);
+      if (sim > best.sim){ best = { sim, j }; }
+      if (sim >= THETA){
+        isDup = true;
+        break;
+      }
+    }
+    if (isDup){
+      dup_similar++;
+      // keep example sample (limit 5)
+      if (examples.length < 5){
+        examples.push({ a: o.title, b: kept[best.j]?.title, sim: Number(best.sim.toFixed(3)) });
+      }
+      continue;
+    }
+    // Keep
+    const idx = kept.push(o) - 1;
+    memo.set(idx, { norm, providerId: provId });
+    if (provId) exactSeen.add(provId);
+  }
+
+  writeJSONL(OUT, kept);
+
+  // Optional replace
+  if (REPLACE_ORIGINAL){
+    fs.copyFileSync(OUT, IN);
+  }
+
+  // Step Summary
+  try {
+    const SUM = process.env.GITHUB_STEP_SUMMARY;
+    if (SUM){
+      const lines = [];
+      lines.push('### de-dup v1.5 summary');
+      lines.push(`- examined: **${examined}**`);
+      lines.push(`- dup-exact: **${dup_exact}**`);
+      lines.push(`- dup-similar (≥θ=${THETA.toFixed(2)}): **${dup_similar}**`);
+      if (examples.length){
+        lines.push('- samples:');
+        for (const ex of examples){
+          lines.push(`  - "${ex.a}" ↔ "${ex.b}" (sim=${ex.sim})`);
+        }
+      }
+      fs.appendFileSync(SUM, lines.join('\n')+'\n');
+    }
+  } catch {}
+
+  console.log(JSON.stringify({ examined, dup_exact, dup_similar, kept: kept.length, theta: THETA }, null, 2));
+}
+
+main();
+

--- a/scripts/test_dedup_v1_5.mjs
+++ b/scripts/test_dedup_v1_5.mjs
@@ -1,0 +1,26 @@
+
+// Simple test harness for dedup_v1_5 using the fixture.
+// Asserts that similar/duplicate collapse reduces items below input size.
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+
+const run = spawnSync('node', ['scripts/dedup_v1_5.mjs'], {
+  env: { ...process.env,
+    DEDUP_IN: 'test/fixtures/dedup_fixture.jsonl',
+    DEDUP_OUT: 'test/fixtures/dedup_out.jsonl',
+    DEDUP_REPLACE: '0',
+    DEDUP_THETA_MAIN: '0.80',
+    DEDUP_THETA_STRICT: '0.82',
+  },
+  stdio: 'inherit'
+});
+
+if (run.status !== 0) process.exit(run.status);
+const inp = fs.readFileSync('test/fixtures/dedup_fixture.jsonl','utf-8').trim().split(/\n+/);
+const out = fs.readFileSync('test/fixtures/dedup_out.jsonl','utf-8').trim().split(/\n+/);
+if (!(out.length < inp.length)) {
+  console.error('Expected deduped length < input length, but got', out.length, '>=', inp.length);
+  process.exit(1);
+}
+console.log('dedup test passed:', { input: inp.length, output: out.length });
+

--- a/test/fixtures/dedup_fixture.jsonl
+++ b/test/fixtures/dedup_fixture.jsonl
@@ -1,0 +1,10 @@
+{"title":"Main Theme","game":"Sample Game","composer":"John Doe","media":{"provider":"youtube","id":"aaaaaaaaaaa"}}
+{"title":"Main Theme (Long Ver.)","game":"Sample Game","composer":"John Doe","media":{"provider":"youtube","id":"bbbbbbbbbbb"}}
+{"title":"Boss Battle","game":"Sample Game","composer":"John Doe","media":{"provider":"youtube","id":"ccccccccccc"}}
+{"title":"Boss Battle (Arrange)","game":"Sample Game","composer":"John Doe","media":{"provider":"youtube","id":"ddddddddddd"}}
+{"title":"Another Track","game":"Other Game","composer":"Jane","media":{"provider":"youtube","id":"eeeeeeeeeee"}}
+{"title":"Another Track","game":"Other Game","composer":"Jane","media":{"provider":"youtube","id":"eeeeeeeeeee"}}
+{"title":"Ending Theme","game":"Sample Game","composer":"John Doe","media":{"apple":{"embedUrl":"https://embed.apple.com/t/123"}}}
+{"title":"Ending Theme","game":"Sample Game","composer":"John Doe","media":{"apple":{"embedUrl":"https://embed.apple.com/t/123"}}}
+{"title":"Victory Fanfare","game":"Sample Game","composer":"John Doe","media":{"provider":"youtube","id":"ffffffffffg"}}
+{"title":"Victory","game":"Sample Game","composer":"John Doe","media":{"provider":"youtube","id":"ffffffffffg"}}


### PR DESCRIPTION
## Summary
- add Node script to deduplicate candidate songs using NFKC normalization and 3-gram Dice similarity
- document v1.5 spec and wire up a GitHub workflow to run the dedup step
- include a small fixture and test harness

## Testing
- `node scripts/test_dedup_v1_5.mjs`
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bea173e6948324a822629b0b281dc2