### PR TITLE
Use cross-workflow artifact download

### DIFF
--- a/.github/workflows/candidates-dedup.yml
+++ b/.github/workflows/candidates-dedup.yml
@@ -20,9 +20,13 @@ jobs:
       - name: Install deps
         run: echo "no extra deps"
 
-      - name: Restore candidates artifact
-        uses: actions/download-artifact@v4
+      - name: Download candidates artifact from latest successful 'candidates-harvest'
+        uses: dawidd6/action-download-artifact@v2
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: candidates-harvest.yml
+          workflow_conclusion: success
+          branch: ${{ github.ref_name }}
           name: daily-candidates
           path: public/app
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -81,6 +81,11 @@
 > - `/build/version.json` / `/app/../build/version.json`  
 > - `/build.json?ts=NOW` / `/app/build.json?ts=NOW`
 
+### Artifacts（ワークフロー間の受け渡し）
+- `actions/download-artifact` は **同一ワークフロー実行(run)** の成果物のみ取得可能。
+- **別ワークフローの成果物**を取得する場合は `dawidd6/action-download-artifact@v2` を使用し、
+  `workflow: <workflow file> / workflow_conclusion: success / branch: <branch> / name: <artifact>` を指定する。
+
 ## Issues の重複（タイトル一致）の後始末
 
 - まれに `sync_issues_v3.mjs` の初回同期やラベル移行で **同一タイトルの Open が複数** 残ることがあります。


### PR DESCRIPTION
## Summary
- fetch candidate artifacts across workflows using `dawidd6/action-download-artifact`
- document cross-workflow artifact usage

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bea51c27a88324a367b6bbe323eec9