### PR TITLE
Add KPI summary steps to workflows

### DIFF
--- a/.github/workflows/authoring-heuristics-smoke.yml
+++ b/.github/workflows/authoring-heuristics-smoke.yml
@@ -117,3 +117,6 @@ jobs:
             public/app/daily_auto.json
             build/daily_today.json
             build/daily_today.md
+
+      - name: KPI summary (authoring today)
+        run: node scripts/kpi/append_summary_authoring_today.mjs --in build/daily_today.json

--- a/.github/workflows/authoring-schema-check.yml
+++ b/.github/workflows/authoring-schema-check.yml
@@ -53,6 +53,9 @@ jobs:
           SCHEMA_CHECK_STRICT=true node scripts/validate_authoring_schema.mjs
         # v1.8: strict mode (fail-fast)
 
+      - name: KPI summary (authoring today)
+        run: node scripts/kpi/append_summary_authoring_today.mjs --in build/daily_today.json
+
       - name: Summary
         run: |
           echo "### Authoring schema check (strict)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/candidates-harvest.yml
+++ b/.github/workflows/candidates-harvest.yml
@@ -49,5 +49,8 @@ jobs:
           name: daily-candidates
           path: public/app/daily_candidates.jsonl
 
+      - name: KPI summary (candidates, pre-dedup)
+        run: node scripts/kpi/append_summary_candidates.mjs --in public/app/daily_candidates.jsonl --label "pre-dedup"
+
       - name: Summary (result)
         run: echo "### candidates (harvest) result" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/candidates-ingest.yml
+++ b/.github/workflows/candidates-ingest.yml
@@ -27,5 +27,8 @@ jobs:
           path: public/app/daily_candidates.jsonl
           if-no-files-found: error
 
+      - name: KPI summary (candidates, pre-dedup)
+        run: node scripts/kpi/append_summary_candidates.mjs --in public/app/daily_candidates.jsonl --label "pre-dedup"
+
       - name: Summary (result)
         run: echo "### candidates (ingest) result" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/kpi/append_summary_authoring_today.mjs
+++ b/scripts/kpi/append_summary_authoring_today.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Append KPI summary for build/daily_today.json to $GITHUB_STEP_SUMMARY
+ * Usage: node scripts/kpi/append_summary_authoring_today.mjs --in build/daily_today.json
+ */
+import fs from 'node:fs';
+
+const args = process.argv.slice(2);
+let IN = 'build/daily_today.json';
+for (let i=0;i<args.length;i++){
+  if (args[i]==='--in') IN = args[i+1];
+}
+
+function readJSON(p){
+  return JSON.parse(fs.readFileSync(p,'utf-8'));
+}
+
+function main(){
+  if (!fs.existsSync(IN)){
+    console.log(`::warning::KPI authoring: file not found: ${IN}`);
+    return;
+  }
+  const j = readJSON(IN);
+  const it = j.item || j.flat || j;
+  const ok = {
+    title: !!it.title,
+    game: !!it.game,
+    composer: !!it.composer,
+    answers: !!(it.answers && (it.answers.canonical || it.answers.acceptables)),
+    media: !!(it.media && (it.media.apple && (it.media.apple.embedUrl||it.media.apple.url||it.media.apple.previewUrl) || (it.media.provider==='youtube' && it.media.id)))
+  };
+  const prov = it.media?.apple ? 'apple' : (it.media?.provider || 'none');
+  const SUM = process.env.GITHUB_STEP_SUMMARY;
+  const lines = [];
+  lines.push(`### KPI (authoring today)`);
+  lines.push(`- ok: title=${ok.title}, game=${ok.game}, composer=${ok.composer}, answers=${ok.answers}, media=${ok.media}`);
+  lines.push(`- media.provider: **${prov}**`);
+  if (SUM) fs.appendFileSync(SUM, lines.join('\n')+'\n');
+  else console.log(lines.join('\n'));
+}
+main();

--- a/scripts/kpi/append_summary_candidates.mjs
+++ b/scripts/kpi/append_summary_candidates.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * Append KPI summary for candidates JSONL to $GITHUB_STEP_SUMMARY
+ * Usage: node scripts/kpi/append_summary_candidates.mjs --in public/app/daily_candidates.jsonl --label "pre-dedup"
+ */
+import fs from 'node:fs';
+
+const args = process.argv.slice(2);
+let IN = 'public/app/daily_candidates.jsonl';
+let LABEL = 'pre-dedup';
+for (let i=0;i<args.length;i++){
+  if (args[i]==='--in') IN = args[i+1];
+  if (args[i]==='--label') LABEL = args[i+1];
+}
+
+function readJSONL(file){
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file,'utf-8').split(/\r?\n/).filter(Boolean).map(l=>{try{return JSON.parse(l)}catch{return null}}).filter(Boolean);
+}
+
+function summarize(items){
+  const out = { total: items.length, apple:0, youtube:0, null:0, other:0, clip_flags:{} };
+  for (const o of items){
+    const m = o?.media;
+    if (m && typeof m==='object'){
+      if (m.apple && typeof m.apple==='object' && (m.apple.embedUrl || m.apple.url || m.apple.previewUrl)){
+        out.apple++;
+      } else if (m.provider==='youtube' && m.id){
+        out.youtube++;
+      } else {
+        out.other++;
+      }
+    } else {
+      out.null++;
+    }
+    const flags = (o?.clip?.flags && Array.isArray(o.clip.flags)) ? o.clip.flags : [];
+    for (const f of flags){ out.clip_flags[f] = (out.clip_flags[f]||0)+1; }
+  }
+  return out;
+}
+
+function appendSummary(label, s){
+  const SUM = process.env.GITHUB_STEP_SUMMARY;
+  const lines = [];
+  lines.push(`### KPI (candidates) — ${label}`);
+  lines.push(`- total: **${s.total}**`);
+  lines.push(`- media: apple=${s.apple}, youtube=${s.youtube}, null=${s.null}, other=${s.other}`);
+  const fkeys = Object.keys(s.clip_flags);
+  if (fkeys.length){
+    lines.push(`- clip.flags:`);
+    for (const k of fkeys.sort()){
+      lines.push(`  - ${k}: ${s.clip_flags[k]}`);
+    }
+  }
+  if (SUM) fs.appendFileSync(SUM, lines.join('\n')+'\n');
+  else console.log(lines.join('\n'));
+}
+
+const items = readJSONL(IN);
+appendSummary(LABEL, summarize(items));


### PR DESCRIPTION
## Summary
- append KPI summary for candidate ingestion and harvesting
- capture authoring today KPI in heuristics smoke and schema check workflows

## Testing
- `npm test` *(fails: clojure not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb31811c48324af9a1e6d03ce482e