### PR TITLE
Propagate provenance metadata and report coverage

### DIFF
--- a/.github/workflows/authoring-schema-check.yml
+++ b/.github/workflows/authoring-schema-check.yml
@@ -56,6 +56,9 @@ jobs:
       - name: KPI summary (authoring today)
         run: node scripts/kpi/append_summary_authoring_today.mjs --in build/daily_today.json
 
+      - name: KPI (provenance, authoring today)
+        run: node scripts/kpi/append_summary_provenance.mjs --json build/daily_today.json
+
       - name: Summary
         run: |
           echo "### Authoring schema check (strict)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/candidates-harvest.yml
+++ b/.github/workflows/candidates-harvest.yml
@@ -53,6 +53,9 @@ jobs:
           name: daily-candidates
           path: public/app/daily_candidates.jsonl
 
+      - name: KPI (provenance, candidates)
+        run: node scripts/kpi/append_summary_provenance.mjs --jsonl public/app/daily_candidates.jsonl
+
       - name: KPI summary (candidates, pre-dedup)
         run: node scripts/kpi/append_summary_candidates.mjs --in public/app/daily_candidates.jsonl --label "pre-dedup"
 

--- a/.github/workflows/candidates-ingest.yml
+++ b/.github/workflows/candidates-ingest.yml
@@ -27,6 +27,9 @@ jobs:
           path: public/app/daily_candidates.jsonl
           if-no-files-found: error
 
+      - name: KPI (provenance, candidates)
+        run: node scripts/kpi/append_summary_provenance.mjs --jsonl public/app/daily_candidates.jsonl
+
       - name: KPI summary (candidates, pre-dedup)
         run: node scripts/kpi/append_summary_candidates.mjs --in public/app/daily_candidates.jsonl --label "pre-dedup"
 

--- a/docs/QUALITY_KPIS.md
+++ b/docs/QUALITY_KPIS.md
@@ -30,3 +30,9 @@
 ## 運用
 - 赤信号の閾値を越えたら自動採用を停止（Repo Variables）
 - 重要KPIは README バッジ化 or 週次PRのSummaryに集約
+
+
+## provenance（存在チェック, v1.10）
+- candidates: `public/app/daily_candidates.jsonl` の `provenance` 付与率（provider/id/collected_at）
+- authoring today: `build/daily_today.json` の `item.meta.provenance` 有無
+> 実装: `scripts/kpi/append_summary_provenance.mjs`

--- a/docs/SPEC_PROVENANCE_WIRE_v1.md
+++ b/docs/SPEC_PROVENANCE_WIRE_v1.md
@@ -1,0 +1,33 @@
+
+# SPEC_PROVENANCE_WIRE v1（v1.10）
+
+**目的**: 候補（candidates）→ pick（daily_auto）→ authoring（build/daily_today.json）まで、
+`provenance`（由来メタ）を**欠落させずに伝搬**させる。
+
+## 形（最小）
+```jsonc
+provenance: {
+  "source": "seed|dataset|yt-search|itunes-lookup|manual|other",
+  "provider": "apple|youtube|...",
+  "id": "external id or url",
+  "collected_at": "ISO-8601 UTC",
+  "hash": "sha1:<stable-hash>",
+  "license_hint": "official|label|unknown"
+}
+```
+
+- **candidates**: 各行に `provenance` を持つ（`meta.provenance` にもミラー）。
+- **daily_auto.by_date[YYYY-MM-DD]**: 候補オブジェクトそのものを格納するため `provenance` が保持される。
+- **build/daily_today.json**: `item.meta.provenance` を付与（coerce 時に原データからコピー）。
+
+## 実装ポイント
+- `ingest_candidates_v0.mjs` / `harvest_candidates.js`：`ensureProvenance()` で最低限を補完。
+- `ensure_min_items_v1_post.mjs`：`buildItem()` で `meta.provenance` を引き継ぐ。
+- `export_today_slim.mjs`：`coerce()` で `raw.meta.provenance` もしくは `raw.provenance` を `item.meta.provenance` に反映。
+
+## KPI（存在チェック）
+- **candidates**: `public/app/daily_candidates.jsonl` に対し、`provenance` の**付与率**を Step Summary に出力。
+- **authoring today**: `build/daily_today.json` に対し、`item.meta.provenance` の**有無**を Step Summary に出力。
+
+> 実装: `scripts/kpi/append_summary_provenance.mjs`
+

--- a/scripts/ensure_min_items_v1_post.mjs
+++ b/scripts/ensure_min_items_v1_post.mjs
@@ -143,6 +143,8 @@ function buildItem(c) {
     answers,
     sources: Array.isArray(c.sources) ? c.sources : undefined
   };
+  // carry provenance
+  const pv = c?.meta?.provenance || c?.provenance; if (pv){ item.meta = Object.assign({}, item.meta||{}, { provenance: pv }); }
   ensureNorm(item);
   // debug: 出力アイテムの主要キーをログに出す
   try {

--- a/scripts/export_today_slim.mjs
+++ b/scripts/export_today_slim.mjs
@@ -151,6 +151,7 @@ async function coerce(raw){
   }
   const difficulty = typeof raw.difficulty === 'number' ? raw.difficulty : undefined;
   const item = { title, game, composer, media, answers };
+  const pv = (raw?.meta && raw.meta.provenance) || raw?.provenance; if (pv && typeof pv==='object'){ item.meta = Object.assign({}, item.meta||{}, { provenance: pv }); }
   if (typeof difficulty !== 'undefined') item.difficulty = difficulty;
   // Attach Apple overrides if available
   try {

--- a/scripts/harvest_candidates.js
+++ b/scripts/harvest_candidates.js
@@ -9,6 +9,34 @@
 const fs = require('fs');
 const path = require('path');
 const { normalizeAnswer } = require('./pipeline/normalize');
+const crypto = require('crypto');
+function deriveProviderId(media){
+  const a = (media && typeof media==='object' && media.apple) ? media.apple : null;
+  if (a && (a.embedUrl || a.url || a.previewUrl)){
+    return { provider: 'apple', id: a.embedUrl || a.url || a.previewUrl };
+  }
+  if (media && media.provider && media.id){
+    return { provider: media.provider, id: String(media.id) };
+  }
+  return null;
+}
+function ensureProvenance(c, source='dataset'){
+  if (!c || typeof c!=='object') return c;
+  const prev = c.provenance || (c.meta && c.meta.provenance) || {};
+  const prov = { ...prev };
+  if (!prov.source) prov.source = source;
+  const pid = deriveProviderId(c.media || c.clip);
+  if (pid){ prov.provider = prov.provider || pid.provider; prov.id = prov.id || pid.id; }
+  if (!prov.collected_at) prov.collected_at = new Date().toISOString();
+  if (!prov.license_hint) prov.license_hint = (c.media && c.media.apple) ? 'official' : 'unknown';
+  if (!prov.hash){
+    const base = `${c.norm?.title||c.title||''}|${c.norm?.game||c.game||''}|${c.norm?.composer||c.composer||''}|${prov.provider||''}|${prov.id||''}`;
+    prov.hash = 'sha1:'+crypto.createHash('sha1').update(base).digest('hex');
+  }
+  c.provenance = prov;
+  c.meta = c.meta || {}; c.meta.provenance = prov;
+  return c;
+}
 const JSONC = {
   parse(src){
     // very small JSONC: strip // and /* */ comments
@@ -149,7 +177,7 @@ function main(){
     if(!c.norm.title || !c.norm.game || !c.norm.composer) continue;
     if(seen.has(key)) continue;
     seen.add(key);
-    ws.write(JSON.stringify(c) + '\n');
+    ws.write(JSON.stringify(ensureProvenance(c)) + '\n');
     kept++;
   }
   ws.end();

--- a/scripts/ingest_candidates_v0.mjs
+++ b/scripts/ingest_candidates_v0.mjs
@@ -8,6 +8,34 @@
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
+import crypto from 'node:crypto';
+function deriveProviderId(media){
+  const a = (media && typeof media==='object' && media.apple) ? media.apple : null;
+  if (a && (a.embedUrl || a.url || a.previewUrl)){
+    return { provider: 'apple', id: a.embedUrl || a.url || a.previewUrl };
+  }
+  if (media && media.provider && media.id){
+    return { provider: media.provider, id: String(media.id) };
+  }
+  return null;
+}
+function ensureProvenance(c, source='seed'){
+  if (!c || typeof c!=='object') return c;
+  const prev = c.provenance || (c.meta && c.meta.provenance) || {};
+  const prov = { ...prev };
+  if (!prov.source) prov.source = source;
+  const pid = deriveProviderId(c.media || c.clip);
+  if (pid){ prov.provider = prov.provider || pid.provider; prov.id = prov.id || pid.id; }
+  if (!prov.collected_at) prov.collected_at = new Date().toISOString();
+  if (!prov.license_hint) prov.license_hint = (c.media && c.media.apple) ? 'official' : 'unknown';
+  if (!prov.hash){
+    const base = `${c.norm?.title||c.title||''}|${c.norm?.game||c.game||''}|${c.norm?.composer||c.composer||''}|${prov.provider||''}|${prov.id||''}`;
+    prov.hash = 'sha1:'+crypto.createHash('sha1').update(base).digest('hex');
+  }
+  c.provenance = prov;
+  c.meta = c.meta || {}; c.meta.provenance = prov;
+  return c;
+}
 
 function normText(s){
   return String(s||'')
@@ -69,7 +97,7 @@ async function main(){
     kept.push(c); stats.kept++;
   }
   await fsp.mkdir(path.dirname(out), { recursive:true });
-  await fsp.writeFile(out, kept.map(o=>JSON.stringify(o)).join('\n')+'\n', 'utf-8');
+  await fsp.writeFile(out, kept.map(o=>JSON.stringify(ensureProvenance(o))).join('\n')+'\n', 'utf-8');
   // Step Summary
   const s = [
     '### candidates (ingest) details',

--- a/scripts/kpi/append_summary_provenance.mjs
+++ b/scripts/kpi/append_summary_provenance.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Append provenance coverage KPI to $GITHUB_STEP_SUMMARY and console.
+ * Usage:
+ *  - JSONL: node scripts/kpi/append_summary_provenance.mjs --jsonl public/app/daily_candidates.jsonl
+ *  - JSON : node scripts/kpi/append_summary_provenance.mjs --json build/daily_today.json
+ */
+import fs from 'node:fs';
+
+function parseArgs(){
+  const a=process.argv.slice(2);
+  const j=a.indexOf('--jsonl'); const jl=j>=0 ? a[j+1] : null;
+  const k=a.indexOf('--json');  const js=k>=0 ? a[k+1] : null;
+  if (!jl && !js){ console.log('::warning::provenance-kpi: no input specified'); }
+  return { jsonl: jl, json: js };
+}
+function readJSONL(p){
+  if (!p || !fs.existsSync(p)) return [];
+  return fs.readFileSync(p,'utf-8').split(/\r?\n/).filter(Boolean).map(l=>{try{return JSON.parse(l)}catch{return null}}).filter(Boolean);
+}
+function readJSON(p){
+  if (!p || !fs.existsSync(p)) return null;
+  return JSON.parse(fs.readFileSync(p,'utf-8'));
+}
+function hasProv(obj){
+  const pv = obj?.provenance || obj?.meta?.provenance;
+  if (!pv || typeof pv!=='object') return false;
+  return !!(pv.provider && pv.id && pv.collected_at);
+}
+
+function kpiFromJSONL(path){
+  const items = readJSONL(path);
+  const total = items.length || 1;
+  const have = items.filter(hasProv).length;
+  const pct = (100*have/total).toFixed(1);
+  return { kind:'jsonl', path, total, with_provenance: have, coverage:`${pct}%` };
+}
+function deepFindItem(node, depth=0){
+  if (node==null || depth>4) return null;
+  if (node.item && typeof node.item==='object') return node.item;
+  if (node.flat && typeof node.flat==='object') return node.flat;
+  if (node.items && Array.isArray(node.items)) return node.items[0];
+  if (node.by_date && typeof node.by_date==='object'){
+    const keys = Object.keys(node.by_date).sort();
+    const last = keys[keys.length-1];
+    return deepFindItem(node.by_date[last], depth+1) || node.by_date[last];
+  }
+  for (const v of Object.values(node)){
+    if (typeof v==='object'){ const f=deepFindItem(v, depth+1); if (f) return f; }
+  }
+  return null;
+}
+function kpiFromJSON(path){
+  const obj = readJSON(path) || {};
+  const it = deepFindItem(obj) || obj.item || obj;
+  const ok = hasProv(it);
+  return { kind:'json', path, has_provenance: ok };
+}
+
+function emit(title, lines){
+  const SUM = process.env.GITHUB_STEP_SUMMARY;
+  const body = [ `### ${title}`, ...lines ].join('\n');
+  if (SUM) fs.appendFileSync(SUM, body+'\n');
+  console.log(body);
+}
+
+function main(){
+  const { jsonl, json } = parseArgs();
+  if (jsonl){
+    const s = kpiFromJSONL(jsonl);
+    emit('KPI (provenance, candidates)', [
+      `- file: ${s.path}`,
+      `- total: ${s.total}, with_provenance: ${s.with_provenance} (${s.coverage})`
+    ]);
+  }
+  if (json){
+    const s = kpiFromJSON(json);
+    emit('KPI (provenance, authoring today)', [
+      `- file: ${s.path}`,
+      `- has_provenance: ${s.has_provenance}`
+    ]);
+  }
+}
+main();
+


### PR DESCRIPTION
## Summary
- document and wire provenance metadata through candidate ingestion, harvest, and export
- add KPI script and workflow steps to report provenance coverage
- update quality KPI docs

## Testing
- `npm test` *(fails: clojure not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bec621469c8324ab226f653a27ee81