### PR TITLE
feat: add provenance stub fallback

### DIFF
--- a/docs/OPERATIONS_AUTHORING.md
+++ b/docs/OPERATIONS_AUTHORING.md
@@ -14,8 +14,9 @@
 4) **ensure_min_items**（空なら 1 件注入）  
 5) **distractors_v1 / difficulty_v1**（選択肢補完・難易度付与）  
 6) **finalize_daily_v1**（フラット形 + 必須フィールド補完）  
-7) **validate**（`validate_nonempty_today` → `validate_authoring`）  
-8) **export_today_slim**（検収用 `build/daily_today.json/.md`）  
+7) **validate**（`validate_nonempty_today` → `validate_authoring`）
+8) **export_today_slim**（検収用 `build/daily_today.json/.md`）
+8.5) **provenance フォールバック**（`scripts/provenance_fallbacks_v1.mjs --json build/daily_today.json` を適用）
 9) **PR 作成 → Auto-merge**
 
 > ジョブ: `authoring (heuristics smoke)` / `daily (auto extended)`

--- a/docs/POLICY_PROVENANCE.md
+++ b/docs/POLICY_PROVENANCE.md
@@ -11,7 +11,7 @@ provenance: {
   "id": "external id",
   "collected_at": "ISO-8601 UTC",
   "hash": "sha1:... (payloadの安定ハッシュ)",
-  "license_hint": "official|label|unknown"
+  "license_hint": "apple_embed|youtube_embed|ugc_youtube|official_site|label|unknown|stub"
 }
 ```
 
@@ -26,6 +26,13 @@ provenance: {
 
 ## 例外
 - 手動seed（`source=manual`）は `collected_at` の記録だけでも許容する。
+
+## Stub 既定（v1.10）
+- `provider/id` が取得不能なケースでは **stub 既定**を採用する。
+  - `provider`: "stub"
+  - `id`: "stub:" + <sha1hex(title|game|answers.canonical)> （正規化後の連結文字列を SHA-1）
+  - `license_hint`: "stub"
+- 既存の `provider/id` がある場合は**上書きしない**（idempotent）。
 
 ## 参考
 - `docs/SPEC_DEDUP_v1.md`, `docs/SPEC_NOTABILITY.md`, `docs/QUALITY_KPIS.md`

--- a/docs/SPEC_PROVENANCE_WIRE_v1.md
+++ b/docs/SPEC_PROVENANCE_WIRE_v1.md
@@ -12,7 +12,7 @@ provenance: {
   "id": "external id or url",
   "collected_at": "ISO-8601 UTC",
   "hash": "sha1:<stable-hash>",
-  "license_hint": "official|label|unknown"
+  "license_hint": "official|label|unknown|stub"
 }
 ```
 
@@ -30,6 +30,7 @@ provenance: {
 ## フォールバック（v1.10）
 - 目的: media が無い／手入力 item でも `meta.provenance` を欠かさない。
 - 方式: **fallback** として `source=manual|fallback` を付与し、`provider/id` は `media` から推定（無ければ `title|game|composer` 派生）。
+- `provider/id` が欠落する場合は **stub** を付与（`provider:'stub'`, `id:'stub:'+sha1hex(title|game|answers)`）
 - 実装:
   - コード内: `export_today_slim.mjs`／`ensure_min_items_v1_post.mjs` で **欠落時に動的付与**。
   - 運用: `scripts/provenance_fallbacks_v1.mjs` を **candidates / authoring** 両方のWFに追加。

--- a/docs/issues/v1_10.json
+++ b/docs/issues/v1_10.json
@@ -26,7 +26,7 @@
       "area:quality",
       "area:pipeline"
     ],
-    "body": "### Scope\n- source/provider/id/collected_at/hash/license_hint の継承\n- JSONL/JSON のスキーマ差分棚卸し\n\n### DoD\n- 欠落なしで通過\n- POLICY_PROVENANCE.md に実装例追記"
+    "body": "### Scope\n- source/provider/id/collected_at/hash/license_hint の継承\n- JSONL/JSON のスキーマ差分棚卸し\n- **stub 既定**の導入（`provider:'stub'`, `id:'stub:'+sha1hex(title|game|answers)`, `license_hint:'stub'`）\n- authoring の **export 後に fallback を必須適用**\n- ingest/harvest のアーティファクトは **fallback 後**を保存\n\n### DoD\n- candidates: provenance 付与率 **100%**（`provider/id` 欠落なし or stub付与）\n- authoring today: `item.meta.provenance` の有無 **100%**\n- POLICY_PROVENANCE.md / SPEC_PROVENANCE_WIRE_v1.md に実装例と stub 規定を反映"
   },
   {
     "id": "v110-kpi-summary",

--- a/scripts/provenance_fallbacks_v1.mjs
+++ b/scripts/provenance_fallbacks_v1.mjs
@@ -15,6 +15,7 @@ import { createHash } from 'node:crypto';
 function sha1(s) {
   return 'sha1:' + createHash('sha1').update(String(s)).digest('hex');
 }
+function sha1hex(s){ return createHash('sha1').update(String(s)).digest('hex'); }
 
 function ensureProvenance(item, nowIso) {
   if (!item || typeof item !== 'object') return { fixed: false, item };
@@ -22,21 +23,35 @@ function ensureProvenance(item, nowIso) {
   const basePv = (item.meta && item.meta.provenance) || item.provenance || {};
   const pv = { ...basePv };
 
-  // 必須フィールドを埋める
+  // 必須フィールドを埋める（idempotent）
   if (!pv.source) pv.source = basePv.source || 'seed';
   if (!pv.provider && item.provider) pv.provider = item.provider;
   if (!pv.id && (item.id || (item.media && item.media.id))) pv.id = item.id || item.media.id;
   if (!pv.collected_at) pv.collected_at = nowIso;
   if (!pv.license_hint) pv.license_hint = 'unknown';
+
+  // provider/id が依然として欠落 → stub 既定を付与（idempotent）
+  if (!pv.provider || !pv.id) {
+    const base = [
+      item?.norm?.title || item.title,
+      item?.norm?.game || (item.game && (item.game.name || item.game)),
+      item?.norm?.composer || item.composer,
+      item.answers && item.answers.canonical
+    ].filter(Boolean).join('|');
+    if (!pv.provider) pv.provider = 'stub';
+    if (!pv.id) pv.id = 'stub:' + sha1hex(base);
+    if (!basePv.license_hint) pv.license_hint = 'stub';
+  }
+
   if (!pv.hash) {
-    // provider+id を優先。なければ title/game を畳み込む。
+    // provider+id を優先。なければ title|game|answers を畳み込む。
     const base = pv.provider && pv.id ? `${pv.provider}:${pv.id}`
       : [item.title, item.game && (item.game.name || item.game), item.answers && item.answers.canonical]
           .filter(Boolean).join('|');
     pv.hash = sha1(base);
   }
 
-  // 変更検出（idempotentのため shallow 比較）
+  // 変更検出（idempotent のため shallow 比較）
   const before = JSON.stringify(item.meta.provenance || {});
   item.meta.provenance = pv;
   item.provenance = pv; // 後方互換


### PR DESCRIPTION
## Summary
- add stub fallback for missing provenance provider/id
- document provenance stub policy and authoring step

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf69193f6c8324aec02abd5a35ad75