### PR TITLE
Add stub provenance normalization and KPI updates

### DIFF
--- a/docs/OPERATIONS_AUTHORING.md
+++ b/docs/OPERATIONS_AUTHORING.md
@@ -15,9 +15,10 @@
 5) **distractors_v1 / difficulty_v1**（選択肢補完・難易度付与）  
 6) **finalize_daily_v1**（フラット形 + 必須フィールド補完）  
 7) **validate**（`validate_nonempty_today` → `validate_authoring`）
-8) **export_today_slim**（検収用 `build/daily_today.json/.md`）
+8) **export_today_slim**（検収用 `build/daily_today.json/.md`）  
 8.5) **provenance フォールバック**（`scripts/provenance_fallbacks_v1.mjs --json build/daily_today.json` を適用）
 9) **PR 作成 → Auto-merge**
+> 注: `authoring-schema-check` では入力 `public/app/daily_auto.json` が空の場合、`export_today_slim` が **stub アイテム**（`media.provider: "mock"`）を生成することがあります。これはスキーマ検証用の想定挙動です。実運用の作問は別途 daily パイプラインで行います。
 
 > ジョブ: `authoring (heuristics smoke)` / `daily (auto extended)`
 

--- a/docs/POLICY_PROVENANCE.md
+++ b/docs/POLICY_PROVENANCE.md
@@ -33,6 +33,7 @@ provenance: {
   - `id`: "stub:" + <sha1hex(title|game|answers.canonical)> （正規化後の連結文字列を SHA-1）
   - `license_hint`: "stub"
 - 既存の `provider/id` がある場合は**上書きしない**（idempotent）。
+- ただし `provider='stub'` かつ `id` が `"stub"` のみ、または `"stub:"` プレフィックスが無い場合は**正規化して再付与**（`"stub:<sha1hex(...)")`）。
 
 ## 参考
 - `docs/SPEC_DEDUP_v1.md`, `docs/SPEC_NOTABILITY.md`, `docs/QUALITY_KPIS.md`

--- a/docs/SPEC_PROVENANCE_WIRE_v1.md
+++ b/docs/SPEC_PROVENANCE_WIRE_v1.md
@@ -30,7 +30,8 @@ provenance: {
 ## フォールバック（v1.10）
 - 目的: media が無い／手入力 item でも `meta.provenance` を欠かさない。
 - 方式: **fallback** として `source=manual|fallback` を付与し、`provider/id` は `media` から推定（無ければ `title|game|composer` 派生）。
-- `provider/id` が欠落する場合は **stub** を付与（`provider:'stub'`, `id:'stub:'+sha1hex(title|game|answers)`）
+- `provider/id` が欠落する場合は **stub** を付与（`provider:'stub'`, `id:'stub:'+sha1hex(title|game|answers)`）。
+`id` が `"stub"` のみ、または `"stub:"` で始まらない場合は `"stub:<sha1hex(...)"` に**正規化**する。
 - 実装:
   - コード内: `export_today_slim.mjs`／`ensure_min_items_v1_post.mjs` で **欠落時に動的付与**。
   - 運用: `scripts/provenance_fallbacks_v1.mjs` を **candidates / authoring** 両方のWFに追加。

--- a/scripts/kpi/append_summary_authoring_today.mjs
+++ b/scripts/kpi/append_summary_authoring_today.mjs
@@ -32,10 +32,18 @@ function main(){
     media: !!(it.media && (it.media.apple && (it.media.apple.embedUrl||it.media.apple.url||it.media.apple.previewUrl) || (it.media.provider==='youtube' && it.media.id)))
   };
   const prov = it.media?.apple ? 'apple' : (it.media?.provider || 'none');
-  const lines = [];
-  lines.push(`### KPI (authoring today)`);
+  const lines = ['### KPI (authoring today)'];
   lines.push(`- ok: title=${ok.title}, game=${ok.game}, composer=${ok.composer}, answers=${ok.answers}, media=${ok.media}`);
-  lines.push(`- media.provider: **${prov}**`);
+  if (ok.media) {
+    lines.push(`- media.provider: **${prov}**`);
+  }
+  const pv = (it.meta && it.meta.provenance) || it.provenance || {};
+  if (pv && pv.provider) {
+    lines.push(`- provenance.provider: **${pv.provider}**`);
+    if (pv.provider==='stub') {
+      lines.push(`- provenance.id (stub canonical): ${String(pv.id).startsWith('stub:') ? 'OK' : 'NEEDS_NORMALIZE'}`);
+    }
+  }
   const SUM = process.env.GITHUB_STEP_SUMMARY;
   if (SUM) fs.appendFileSync(SUM, lines.join('\n')+'\n');
   console.log(lines.join('\n'));

--- a/scripts/kpi/append_summary_provenance.mjs
+++ b/scripts/kpi/append_summary_provenance.mjs
@@ -27,13 +27,17 @@ function hasProv(obj){
   if (!pv || typeof pv!=='object') return false;
   return !!(pv.provider && pv.id && pv.collected_at);
 }
+function getPv(obj){
+  return obj?.provenance || obj?.meta?.provenance || {};
+}
 
 function kpiFromJSONL(path){
   const items = readJSONL(path);
   const total = items.length || 1;
   const have = items.filter(hasProv).length;
   const pct = (100*have/total).toFixed(1);
-  return { kind:'jsonl', path, total, with_provenance: have, coverage:`${pct}%` };
+  const stub = items.filter(it => (getPv(it).provider==='stub')).length;
+  return { kind:'jsonl', path, total, with_provenance: have, coverage:`${pct}%`, stub };
 }
 function deepFindItem(node, depth=0){
   if (node==null || depth>4) return null;
@@ -54,7 +58,9 @@ function kpiFromJSON(path){
   const obj = readJSON(path) || {};
   const it = deepFindItem(obj) || obj.item || obj;
   const ok = hasProv(it);
-  return { kind:'json', path, has_provenance: ok };
+  const pv = getPv(it);
+  const stub = pv?.provider === 'stub';
+  return { kind:'json', path, has_provenance: ok, stub };
 }
 
 function emit(title, lines){
@@ -70,14 +76,16 @@ function main(){
     const s = kpiFromJSONL(jsonl);
     emit('KPI (provenance, candidates)', [
       `- file: ${s.path}`,
-      `- total: ${s.total}, with_provenance: ${s.with_provenance} (${s.coverage})`
+      `- total: ${s.total}, with_provenance: ${s.with_provenance} (${s.coverage})`,
+      `- stub(provider): ${s.stub}`
     ]);
   }
   if (json){
     const s = kpiFromJSON(json);
     emit('KPI (provenance, authoring today)', [
       `- file: ${s.path}`,
-      `- has_provenance: ${s.has_provenance}`
+      `- has_provenance: ${s.has_provenance}`,
+      `- provider_is_stub: ${s.stub}`
     ]);
   }
 }

--- a/scripts/provenance_fallbacks_v1.mjs
+++ b/scripts/provenance_fallbacks_v1.mjs
@@ -30,17 +30,25 @@ function ensureProvenance(item, nowIso) {
   if (!pv.collected_at) pv.collected_at = nowIso;
   if (!pv.license_hint) pv.license_hint = 'unknown';
 
-  // provider/id が依然として欠落 → stub 既定を付与（idempotent）
+  // ---- STUB 既定 & 正規化（v1.10）
+  const baseForHash = [
+    item?.norm?.title || item.title,
+    item?.norm?.game || (item.game && (item.game.name || item.game)),
+    item?.norm?.composer || item.composer,
+    item.answers && item.answers.canonical
+  ].filter(Boolean).join('|');
   if (!pv.provider || !pv.id) {
-    const base = [
-      item?.norm?.title || item.title,
-      item?.norm?.game || (item.game && (item.game.name || item.game)),
-      item?.norm?.composer || item.composer,
-      item.answers && item.answers.canonical
-    ].filter(Boolean).join('|');
     if (!pv.provider) pv.provider = 'stub';
-    if (!pv.id) pv.id = 'stub:' + sha1hex(base);
+    if (!pv.id) pv.id = 'stub:' + sha1hex(baseForHash);
     if (!basePv.license_hint) pv.license_hint = 'stub';
+  }
+  if (pv.provider === 'stub') {
+    if (!pv.id || !/^stub:/.test(String(pv.id))) {
+      pv.id = 'stub:' + sha1hex(baseForHash);
+    }
+    if (!pv.license_hint || pv.license_hint === 'unknown') {
+      pv.license_hint = 'stub';
+    }
   }
 
   if (!pv.hash) {


### PR DESCRIPTION
## Summary
- normalize and enforce stub provenance IDs
- report stub provenance in KPI summaries
- document stub handling and schema-check stub generation

## Testing
- `npm test` *(fails: clojure not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6d5967548324815c3e8771c76850