### PR TITLE
test: check provenance fallback idempotency

### DIFF
--- a/.github/workflows/authoring-schema-check.yml
+++ b/.github/workflows/authoring-schema-check.yml
@@ -41,6 +41,9 @@ jobs:
         run: |
           node scripts/provenance_fallbacks_v1.mjs --json build/daily_today.json || true
 
+      - name: Provenance fallback idempotency check
+        run: node scripts/tests/provenance_fallback_idempotency.mjs --json build/daily_today.json
+
       - name: Upload authoring artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/docs/issues/v1_10.json
+++ b/docs/issues/v1_10.json
@@ -26,7 +26,7 @@
       "area:quality",
       "area:pipeline"
     ],
-    "body": "### Scope\n- source/provider/id/collected_at/hash/license_hint の継承\n- JSONL/JSON のスキーマ差分棚卸し\n- **stub 既定**の導入（`provider:'stub'`, `id:'stub:'+sha1hex(title|game|answers)`, `license_hint:'stub'`）\n- authoring の **export 後に fallback を必須適用**\n- ingest/harvest のアーティファクトは **fallback 後**を保存\n\n### DoD\n- candidates: provenance 付与率 **100%**（`provider/id` 欠落なし or stub付与）\n- authoring today: `item.meta.provenance` の有無 **100%**\n- POLICY_PROVENANCE.md / SPEC_PROVENANCE_WIRE_v1.md に実装例と stub 規定を反映"
+    "body": "### Scope\n- provenance 最低6項目の欠落なし継承：`source/provider/id/collected_at/hash/license_hint`\n- JSONL/JSON のスキーマ差分棚卸し\n- **stub 既定**の導入（`provider:'stub'`, `id:'stub:'+sha1hex(title|game|answers.canonical)`, `license_hint:'stub'`）\n- **authoring の export 後に fallback を必須適用**\n- **ingest/harvest のアーティファクトは fallback 後のみ保存**（“唯一の正”）\n\n### DoD\n- candidates（harvest）: provenance 付与率 **100%**（`provider/id` 欠落なし、または stub 付与）\n- authoring（today）: `item.meta.provenance` の有無 **100%**、`provider:'stub'` の場合 `id` は **`stub:` で開始**（sha1hex 付き）\n- fallback の **冪等性**（同一ファイルへ 2 回適用しても差分ゼロ）\n- POLICY_PROVENANCE.md / SPEC_PROVENANCE_WIRE_v1.md / OPERATIONS_AUTHORING.md に反映（日本語）"
   },
   {
     "id": "v110-kpi-summary",

--- a/scripts/tests/provenance_fallback_idempotency.mjs
+++ b/scripts/tests/provenance_fallback_idempotency.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+
+function execNode(args, opts={}) {
+  return new Promise((resolve, reject) => {
+    const ps = spawn(process.execPath, args, { stdio: ['ignore','pipe','pipe'], ...opts });
+    let out = '', err = '';
+    ps.stdout.on('data', d => out += String(d));
+    ps.stderr.on('data', d => err += String(d));
+    ps.on('close', (code) => code === 0 ? resolve({code, out, err}) : reject(new Error(err || `exit ${code}`)));
+  });
+}
+
+function parseArg(flag, def) {
+  const i = process.argv.indexOf(flag);
+  if (i >= 0 && i+1 < process.argv.length) return process.argv[i+1];
+  return def;
+}
+
+async function main(){
+  const jsonPath = parseArg('--json', 'build/daily_today.json');
+  const orig = await readFile(jsonPath, 'utf8');
+  const tmp = await mkdtemp(join(tmpdir(), 'prov-'));
+  const copy = join(tmp, 'daily_today.json');
+  await writeFile(copy, orig, 'utf8');
+
+  // re-apply fallback; idempotent => no diff
+  await execNode(['scripts/provenance_fallbacks_v1.mjs', '--json', copy], { cwd: process.cwd() });
+  const after = await readFile(copy, 'utf8');
+
+  if (orig !== after) {
+    const max = 1024;
+    const msg = [
+      'Provenance fallback is NOT idempotent: running twice changed the file.',
+      '--- before (head) ---',
+      orig.slice(0, max),
+      '--- after  (head) ---',
+      after.slice(0, max)
+    ].join('\n');
+    throw new Error(msg);
+  }
+  console.log('Idempotency OK: no changes after re-applying fallback.');
+}
+
+main().catch(e => {
+  console.error(e?.message || e);
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- ensure provenance fallback remains idempotent via new script
- run idempotency check in authoring schema workflow
- document provenance stub defaults and idempotency requirements

## Testing
- `node scripts/tests/provenance_fallback_idempotency.mjs --json build/daily_today.json`
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf71d8b8ac83248bf91bb399255164