### PR TITLE
Ensure provenance fallback idempotency

### DIFF
--- a/.github/workflows/authoring-schema-check.yml
+++ b/.github/workflows/authoring-schema-check.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           node scripts/provenance_fallbacks_v1.mjs --json build/daily_today.json || true
 
+      # 冪等性：同一ファイルに再適用して差分が出たら失敗
+      - name: Provenance fallback idempotency check
+        run: node scripts/tests/provenance_fallback_idempotency.mjs --json build/daily_today.json
+
       - name: Upload authoring artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/kpi/append_summary_authoring_today.mjs
+++ b/scripts/kpi/append_summary_authoring_today.mjs
@@ -40,6 +40,7 @@ function main(){
   const pv = (it.meta && it.meta.provenance) || it.provenance || {};
   if (pv && pv.provider) {
     lines.push(`- provenance.provider: **${pv.provider}**`);
+    lines.push(`- provenance.id: ${pv.id ?? '(missing)'}`);
     if (pv.provider==='stub') {
       lines.push(`- provenance.id (stub canonical): ${String(pv.id).startsWith('stub:') ? 'OK' : 'NEEDS_NORMALIZE'}`);
     }

--- a/scripts/kpi/append_summary_provenance.mjs
+++ b/scripts/kpi/append_summary_provenance.mjs
@@ -33,11 +33,14 @@ function getPv(obj){
 
 function kpiFromJSONL(path){
   const items = readJSONL(path);
-  const total = items.length || 1;
-  const have = items.filter(hasProv).length;
-  const pct = (100*have/total).toFixed(1);
-  const stub = items.filter(it => (getPv(it).provider==='stub')).length;
-  return { kind:'jsonl', path, total, with_provenance: have, coverage:`${pct}%`, stub };
+  const total = items.length;
+  const withProv = items.filter(hasProv).length;
+  const providers = {};
+  for (const it of items) {
+    const p = (getPv(it).provider)||'';
+    providers[p] = (providers[p]||0)+1;
+  }
+  return { total, withProv, providers };
 }
 function deepFindItem(node, depth=0){
   if (node==null || depth>4) return null;
@@ -73,12 +76,13 @@ function emit(title, lines){
 function main(){
   const { jsonl, json } = parseArgs();
   if (jsonl){
-    const s = kpiFromJSONL(jsonl);
-    emit('KPI (provenance, candidates)', [
-      `- file: ${s.path}`,
-      `- total: ${s.total}, with_provenance: ${s.with_provenance} (${s.coverage})`,
-      `- stub(provider): ${s.stub}`
-    ]);
+    const k = kpiFromJSONL(jsonl);
+    const lines = [
+      `- file: ${jsonl}`,
+      `- total: ${k.total}, with_provenance: ${k.withProv} (${(k.withProv*100/k.total||0).toFixed(1)}%)`,
+      `- providers: ${Object.entries(k.providers).map(([k2,v])=>k2?`${k2}:${v}`:`(missing):${v}`).join(', ')}`
+    ];
+    emit('KPI (provenance, candidates)', lines);
   }
   if (json){
     const s = kpiFromJSON(json);

--- a/scripts/provenance_fallbacks_v1.mjs
+++ b/scripts/provenance_fallbacks_v1.mjs
@@ -59,11 +59,15 @@ function ensureProvenance(item, nowIso) {
     pv.hash = sha1(base);
   }
 
-  // 変更検出（idempotent のため shallow 比較）
-  const before = JSON.stringify(item.meta.provenance || {});
-  item.meta.provenance = pv;
-  item.provenance = pv; // 後方互換
-  const after = JSON.stringify(pv);
+  // --- 正規化の最終保証：stub id を必ず "stub:<sha1hex>" へ
+  if (pv.provider === 'stub' && (!pv.id || !/^stub:/.test(String(pv.id)))) {
+    pv.id = 'stub:' + sha1hex(baseForHash);
+  }
+  // 書き戻しはディープコピー（参照共有を避ける）
+  const before = JSON.stringify(item.meta?.provenance || {});
+  item.meta.provenance = JSON.parse(JSON.stringify(pv));
+  item.provenance = JSON.parse(JSON.stringify(pv)); // 後方互換
+  const after = JSON.stringify(item.meta.provenance);
   return { fixed: before !== after, item };
 }
 

--- a/scripts/tests/provenance_fallback_idempotency.mjs
+++ b/scripts/tests/provenance_fallback_idempotency.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * Verify provenance_fallbacks_v1.mjs is idempotent for a given JSON file.
+ * Usage: node scripts/tests/provenance_fallback_idempotency.mjs --json <path>
+ * Runs provenance_fallbacks_v1.mjs again and fails if it mutates the file.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const args = process.argv.slice(2);
+const idx = args.indexOf('--json');
+const json = idx >= 0 ? args[idx + 1] : null;
+if (!json) {
+  console.error('Usage: node scripts/tests/provenance_fallback_idempotency.mjs --json <path>');
+  process.exit(2);
+}
+
+const before = readFileSync(json, 'utf8');
+// Run provenance_fallbacks_v1.mjs again on the same file
+spawnSync(process.execPath, ['scripts/provenance_fallbacks_v1.mjs', '--json', json], { stdio: 'inherit' });
+const after = readFileSync(json, 'utf8');
+
+if (before !== after) {
+  // revert file to original state so subsequent steps are not affected
+  writeFileSync(json, before, 'utf8');
+  console.error('::error::provenance_fallbacks_v1.mjs produced changes on re-run (not idempotent)');
+  process.exit(1);
+}
+console.log('provenance fallback idempotency: OK');


### PR DESCRIPTION
## Summary
- include provenance id in authoring KPI
- normalize stub provenance ids and deep copy fallback result
- report provider counts and add idempotency test step

## Testing
- `node scripts/tests/provenance_fallback_idempotency.mjs --json tmp.json`
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7765b5b083248c25be85e3da4e9d