### PR TITLE
feat: add dedup v1.5 KPI preview

### DIFF
--- a/.github/workflows/candidates-harvest.yml
+++ b/.github/workflows/candidates-harvest.yml
@@ -56,8 +56,11 @@ jobs:
           name: daily-candidates
           path: public/app/daily_candidates.jsonl
 
-      - name: KPI (provenance, candidates)
+      - name: Append KPI (provenance, candidates)
         run: node scripts/kpi/append_summary_provenance.mjs --jsonl public/app/daily_candidates.jsonl
+
+      - name: Append KPI (dedup v1.5 preview)
+        run: node scripts/kpi/append_summary_dedup_ngram_v1_5.mjs --in public/app/daily_candidates.jsonl --thresholds "0.7,0.8,0.9"
 
       - name: KPI summary (candidates, pre-dedup)
         run: node scripts/kpi/append_summary_candidates.mjs --in public/app/daily_candidates.jsonl --label "pre-dedup"

--- a/docs/SPEC_DEDUP_V1_5.md
+++ b/docs/SPEC_DEDUP_V1_5.md
@@ -1,0 +1,21 @@
+# De-dup v1.5（N-gram 類似 + 正規化）KPI
+
+## 目的
+候補集合（daily_candidates.jsonl）における重複・近似重複を **早期検知** する。  
+本仕様のKPIは **可視化のみ**（v1.10時点）。実際の削除・統合は v1.11+。
+
+## θ（類似度）の定義
+- 文字3-gram の Jaccard 係数。素材は `title | game | composer | answers.canonical` を正規化（NFKC・小文字化・空白圧縮）。
+- θ ∈ [0,1]。高いほど類似。
+
+## 出力（GITHUB_STEP_SUMMARY）
+- `pairs` 総数（n(n-1)/2）
+- しきい値バケット例：`θ ≥ 0.7 / 0.8 / 0.9` の件数
+- 上位ペアの抜粋（最大5）
+
+## 運用
+`candidates: harvest` の終端で `scripts/kpi/append_summary_dedup_ngram_v1_5.mjs` を実行し、Summary に追記する。
+
+## 注意
+- 日本語・多言語に対しては NFKC 正規化を採用（辞書は未使用）。将来、分かち書きベースへの切替を検討。
+- 本KPIは **アラート** 目的。自動除外は行わない。

--- a/docs/issues/v1_10.json
+++ b/docs/issues/v1_10.json
@@ -26,7 +26,7 @@
       "area:quality",
       "area:pipeline"
     ],
-    "body": "### Scope\n- source/provider/id/collected_at/hash/license_hint の継承\n- JSONL/JSON のスキーマ差分棚卸し\n- **stub 既定**の導入（`provider:'stub'`, `id:'stub:'+sha1hex(title|game|answers)`, `license_hint:'stub'`）\n- authoring の **export 後に fallback を必須適用**\n- ingest/harvest のアーティファクトは **fallback 後**を保存\n\n### DoD\n- candidates: provenance 付与率 **100%**（`provider/id` 欠落なし or stub付与）\n- authoring today: `item.meta.provenance` の有無 **100%**\n- POLICY_PROVENANCE.md / SPEC_PROVENANCE_WIRE_v1.md に実装例と stub 規定を反映"
+    "body": "### Scope\n- provenance 最低6項目の欠落なし継承：`source/provider/id/collected_at/hash/license_hint`\n- JSONL/JSON のスキーマ差分棚卸し\n- **stub 既定**の導入（`provider:'stub'`, `id:'stub:'+sha1hex(title|game|answers.canonical)`, `license_hint:'stub'`）\n- **authoring の export 後に fallback を必須適用**\n- **ingest/harvest のアーティファクトは fallback 後のみ保存**（“唯一の正”）\n\n### DoD\n- candidates（harvest）: provenance 付与率 **100%**（`provider/id` 欠落なし、または stub 付与）\n- authoring（today）: `item.meta.provenance` の有無 **100%**、`provider:'stub'` の場合 `id` は **`stub:` で開始**（sha1hex 付き）\n- fallback の **冪等性**（同一ファイルへ 2 回適用しても差分ゼロ）\n- POLICY_PROVENANCE.md / SPEC_PROVENANCE_WIRE_v1.md / OPERATIONS_AUTHORING.md に反映（日本語）\n\n### Status\n- **DONE**（このチャット実行で確認）\n  - candidates（harvest）: `total=4, with_provenance=4 (100%)`, `providers: stub:4`\n  - authoring（schema-check）: `has_provenance:true`, `provenance.provider=stub`, `provenance.id=stub:<sha1hex…>`（canonical OK）\n"
   },
   {
     "id": "v110-kpi-summary",

--- a/scripts/kpi/append_summary_dedup_ngram_v1_5.mjs
+++ b/scripts/kpi/append_summary_dedup_ngram_v1_5.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+function readJSONL(p){
+  const s = fs.readFileSync(p,'utf8').split(/\r?\n/).filter(Boolean);
+  return s.map(l=>JSON.parse(l));
+}
+function norm(s){
+  return String(s||'').normalize('NFKC').toLowerCase().replace(/\s+/g,' ').trim();
+}
+function keyOf(it){
+  const t = norm(it.title);
+  const g = norm(it.game?.name ?? it.game);
+  const c = norm(it.composer ?? it.track?.composer);
+  const a = norm(it.answers?.canonical);
+  return [t,g,c,a].filter(Boolean).join(' | ');
+}
+function shingles(s, n=3){
+  const z = s.replace(/\s+/g,'');
+  const out = new Set();
+  for (let i=0;i<=Math.max(0,z.length-n);i++){
+    out.add(z.slice(i,i+n));
+  }
+  return out;
+}
+function jaccard(a,b){
+  const A = shingles(a), B = shingles(b);
+  let inter = 0;
+  for (const x of A) if (B.has(x)) inter++;
+  const uni = A.size + B.size - inter;
+  return uni ? inter/uni : 0;
+}
+function parseArg(flag, def){
+  const i = process.argv.indexOf(flag);
+  if (i>=0 && i+1<process.argv.length) return process.argv[i+1];
+  return def;
+}
+function append(lines){
+  const sum = process.env.GITHUB_STEP_SUMMARY;
+  if (sum) fs.appendFileSync(sum, lines.join('\n')+'\n');
+  console.log(lines.join('\n'));
+}
+
+const IN = parseArg('--in','public/app/daily_candidates.jsonl');
+const TH = (parseArg('--thresholds','0.7,0.8,0.9')||'').split(',').map(x=>Number(x)).filter(x=>!Number.isNaN(x)).sort((a,b)=>a-b);
+const items = readJSONL(IN).slice(0,200);
+const keys = items.map(keyOf);
+const pairs = [];
+for (let i=0;i<keys.length;i++){
+  for (let j=i+1;j<keys.length;j++){
+    const theta = jaccard(keys[i], keys[j]);
+    pairs.push({i,j,theta});
+  }
+}
+pairs.sort((a,b)=>b.theta-a.theta);
+
+const buckets = {};
+for (const t of TH){ buckets[t] = pairs.filter(p=>p.theta>=t).length; }
+const top = pairs.slice(0,Math.min(5,pairs.length)).map(p=>{
+  return `- θ=${p.theta.toFixed(3)} :: [${p.i}] ${keys[p.i]}  <->  [${p.j}] ${keys[p.j]}`;
+});
+
+append([
+  '### KPI (dedup v1.5 preview)',
+  `- file: ${IN}`,
+  `- pairs: ${pairs.length}`,
+  `- thresholds: ${TH.join(', ')}`,
+  ...TH.map(t=>`- θ ≥ ${t}: ${buckets[t]}`),
+  top.length ? '- top pairs:\n'+top.join('\n') : '- top pairs: (none)'
+]);


### PR DESCRIPTION
## Summary
- add completion status metrics to v1.10 provenance issue
- document dedup v1.5 KPI and add script to compute n-gram similarity
- run dedup preview KPI in candidates harvest workflow

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7e44dba88324886c91e641b4a288