### PR TITLE
docs: expand dedup v1.5 and backfill guidelines

### DIFF
--- a/docs/OPERATIONS_BACKFILL.md
+++ b/docs/OPERATIONS_BACKFILL.md
@@ -42,3 +42,44 @@
 
 ## KPI
 - 1PRあたり追加件数、追加後のエラー率、dedup率の推移、ユーザ正答率帯の変化
+
+
+## by_year スキーマ（JSON Schema, 抜粋）
+```jsonc
+{
+  "type": "object",
+  "required": ["year", "items"],
+  "properties": {
+    "year": { "type": "integer", "minimum": 1970, "maximum": 2100 },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["date", "id", "title", "game"],
+        "properties": {
+          "date": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+          "id": { "type": "string", "minLength": 3 },
+          "title": { "type": "string", "minLength": 1 },
+          "game": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": true
+      },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+## 失敗時のフォールバック
+- **日重複**: 既存 `by_date/YYYY-MM-DD.json` がある日は**スキップ**（重複挿入しない）。
+- **無効ID**: `provider:id` 形式でない場合は `provider=stub` として採用可（`POLICY_PROVENANCE.md` 準拠）。
+- **不可視メディア**: 再生不可が想定される場合は `license_hint=stub` に落としつつ採用（長期は上流改善）。
+
+## KPI（backfill）
+- 追加件数、スキップ件数（既存/重複/検証NG）、`provider=stub` の割合、適用後のE2E/Schemaエラー率。
+
+## 検証・ドライラン
+- `scripts/backfill/verify_by_year.mjs --file public/app/by_year/1995.json --dry-run`  
+  - 検証のみ（JSON Schema / 既存日衝突 / id 形式 / media 可視性ヒント）
+- 成功後に `--apply` で `by_date/` を生成し PR 作成。PR 粒度は **30–90日** を推奨。

--- a/docs/OPERATIONS_CANDIDATES.md
+++ b/docs/OPERATIONS_CANDIDATES.md
@@ -2,7 +2,7 @@
 
 > 参照:
 > - `docs/POLICY_PROVENANCE.md`（由来メタデータ）
-> - `docs/SPEC_DEDUP_v1.md`（近似重複抑制）
+> - `docs/SPEC_DEDUP_V1_5.md`（KPI/ゲート） / `docs/SPEC_DEDUP_v1.md`（将来の自動抑制方針）
 > - `docs/SPEC_NOTABILITY.md`（知名度スコア）
 > - `docs/OPERATIONS_BACKFILL.md`（大量追加の指針）
 > - `docs/QUALITY_KPIS.md`（品質KPIとSLO）
@@ -67,3 +67,7 @@
 ## 関連ドキュメント
 - `docs/COLLECTOR_V0.md`
 - `docs/ALLOWLIST_SEED.md`
+
+
+- **KPI/Gate**: `scripts/kpi/append_summary_dedup_ngram_v1_5.mjs` を `harvest` 終端で実行。  
+  `DEDUP_FAIL_THRESHOLD`（例: `0.88`）を設定すると **任意ゲート**が有効化され、θ がしきい値以上のペア検出時にジョブを失敗させる。

--- a/docs/QUALITY_KPIS.md
+++ b/docs/QUALITY_KPIS.md
@@ -5,7 +5,7 @@
 
 ## 最小必須セット（Step Summary への出力）
 - **guard**: `in/kept/drop`、`warn` 件数、主な理由トップ3
-- **dedup**: `examined/dup-exact/dup-similar`、`θ_main`（実行値）
+- **dedup**: `pairs` / `θ≥0.7/0.8/0.9` / `top pairs (≤5)`、`DEDUP_FAIL_THRESHOLD`（設定時のみ表示）
 - **score/notability**: `mean/median`、帯域比（High/Med/Low）
 - **pick**: 採用件数 / スキップ理由（重複/枯渇/既存日）
 

--- a/docs/SPEC_DEDUP_V1_5.md
+++ b/docs/SPEC_DEDUP_V1_5.md
@@ -26,3 +26,22 @@
 ## 注意
 - 日本語・多言語に対しては NFKC 正規化を採用（辞書は未使用）。将来、分かち書きベースへの切替を検討。
 - 本KPIは **アラート** 目的。自動除外は行わない。
+
+
+## 推奨しきい値（初期運用）
+- 初期値は **0.88** を推奨（保守的）。KPIの分布が安定したら 0.85–0.90 の範囲で微調整。
+- `DEDUP_FAIL_THRESHOLD` が未設定（空）の場合は **ゲート無効**（Summary だけ出す）。
+
+## Step Summary（例）
+```
+[dedup v1.5] pairs=12345
+[dedup v1.5] θ≥0.7: 12 / θ≥0.8: 5 / θ≥0.9: 1
+[dedup v1.5] top pairs:
+  - 0.91: "Corridors of Time" vs "時の回廊" (Chrono Trigger)
+  - 0.83: "Battle with Magus" vs "Decisive Battle" (Chrono Trigger)
+```
+> **運用**: θ≥0.9 が継続する場合は seed / aliases を見直す。
+
+## 性能とスケール
+- n 件に対し **O(n²)** ペア判定。実運用では **Top-K** 抽出と θ 下限の早期打切りを実装。
+- 大規模時は年/シリーズで分割して集計し、Summary に合算を掲載。

--- a/docs/issues/v1_10.json
+++ b/docs/issues/v1_10.json
@@ -7,7 +7,7 @@
       "area:quality",
       "area:pipeline"
     ],
-    "body": "### Scope\n- N-gram（3-gram）での近似重複KPI\n- 正規化（NFKC/小文字/空白圧縮）\n- **任意ゲート**（`DEDUP_FAIL_THRESHOLD` 設定時のみCIを落とす）\n\n### DoD（v1.10）\n- KPI を Step Summary に常設（pairs/θバケット/topペア）\n- docs/SPEC_DEDUP_V1_5.md に運用記載（日本語）\n- 任意ゲートの導入（デフォルトOFF、値は運用で調整）\n\n### Status\n- **IN PROGRESS**（このチャットでKPI導入済／ゲート追加済）"
+    "body": "### Scope\n- N-gram（3-gram）での近似重複KPI\n- 正規化（NFKC/小文字/空白圧縮）\n- **任意ゲート**（`DEDUP_FAIL_THRESHOLD` 設定時のみCIを落とす）\n\n### DoD（v1.10）\n- KPI を Step Summary に常設（pairs/θバケット/topペア）\n- docs/SPEC_DEDUP_V1_5.md に運用記載（日本語）\n- 任意ゲートの導入（デフォルトOFF、値は運用で調整）\n\n### Status\n- **IN PROGRESS**（このチャットでKPI導入済／ゲート追加済）\n### DoD 追加\n- `docs/SPEC_DEDUP_V1_5.md` に**推奨しきい値(0.88)**・Step Summary 例・スケール注意を追記\n- `docs/OPERATIONS_CANDIDATES.md` / `docs/QUALITY_KPIS.md` に **θバケット** と **任意ゲート** を明記\n"
   },
   {
     "id": "v110-notability-v1",
@@ -47,7 +47,7 @@
       "roadmap:v1.10",
       "area:ops"
     ],
-    "body": "### Scope\n- public/app/by_year/YYYY.json のI/F確定\n- 未来地平線90日・PR粒度30–90日\n\n### DoD\n- OPERATIONS_BACKFILL.md にI/F例を追記\n- 小規模試験が可能"
+    "body": "### Scope\n- public/app/by_year/YYYY.json のI/F確定\n- 未来地平線90日・PR粒度30–90日\n\n### DoD\n- OPERATIONS_BACKFILL.md にI/F例を追記\n- 小規模試験が可能\n### DoD 追加\n- `docs/OPERATIONS_BACKFILL.md` に **JSON Schema 抜粋**・**失敗時フォールバック**・**KPI**・**検証/ドライラン手順** を追記\n"
   },
   {
     "id": "v110-rate-cost-doc",


### PR DESCRIPTION
## Summary
- document recommended dedup v1.5 threshold, step summary example, and scaling notes
- note optional dedup gate in candidate ops and KPI output expectations
- flesh out backfill doc with JSON schema, fallback rules, and verification steps

## Testing
- `npm test` *(fails: clojure not found)*
- `sudo apt-get update` *(fails: repository signatures / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa548756883248e479c4962ddefa2