### PR TITLE
docs: document discovery discovery dry-run

### DIFF
--- a/docs/OPERATIONS_DISCOVERY.md
+++ b/docs/OPERATIONS_DISCOVERY.md
@@ -1,0 +1,40 @@
+# OPERATIONS: Discovery（dry-run）
+
+## 目的
+- **自動探索（Discovery）**を安全に段階導入するため、まず **dry-run** のみで提案 seed を生成し、レビュー可能なアーティファクトとして出力する。
+
+## 入出力
+- 入力: クエリ（ゲーム名 / アルバム名 / シリーズ名 等）
+- 出力: `artifacts/discovery/proposals-YYYYMMDD-HHmm.jsonl`（**JSONL**、1行=1候補、書き込みは一切しない）
+
+## ソース（v1）
+- **iTunes Search** を起点にする（将来: Apple Music API / YouTube Data API を段階導入）。
+
+## 正規化（最低限）
+- `title`（曲名）, `game`（作品名）, `album`（任意）, `composer`（任意）, `release_date`（任意）
+- `answers.canonical`: `title` を基本とした1要素配列（未確定のため暫定）
+- `meta.provenance`（**6項目必須**）  
+  `source`（"discovery"）, `provider`（"apple" など）, `id`（例: `"itunes:"+trackId`）  
+  `collected_at`（ISO8601）, `hash`（title|game|album|composer を NFKC+lower→sha1hex）, `license_hint`（"preview"/"official"/"unknown"）
+
+## 公式性の最小ルール（暫定）
+- provider=apple の iTunes Preview → `license_hint:"preview"`（公式系）
+- provider=youtube の公式チャンネル（将来対応）→ `license_hint:"official"`
+- 不明な場合は `license_hint:"unknown"`
+
+## De-dup v1.5（advice モード）
+- 候補は**落とさず**スコアだけ付与（`dedup.theta`）。最終採否は Gate の θ で判断。
+
+## Rate/Cost（方針）
+- バースト回避: 1 QPS 程度（将来、Repo Variables で調整）
+- リトライ: エラー時は指数バックオフ（max 3）
+- キャッシュ: 同一クエリは 24h キャッシュ
+
+## Step Summary（このIssueで出す項目）
+- `official_rate`, `hit_rate`, `duplicate_ratio`, `fail_reasons_top3`  
+  ※ Collector 全体のKPI章（QUALITY_KPIS.md）は別Issueで整備
+
+## 手順（dry-run）
+1. 手動実行（`workflow_dispatch`）でクエリ文字列を入力
+2. 収集→正規化→provenance付与→de-dup (advice) を実施
+3. **アーティファクト(JSONL)** をダウンロードしてレビュー（seedへは書き込まない）

--- a/docs/SPEC_DISCOVERY_V1.md
+++ b/docs/SPEC_DISCOVERY_V1.md
@@ -1,0 +1,40 @@
+# SPEC: Discovery v1（dry-run）
+
+## データモデル（JSONL 1行の例）
+```jsonc
+{
+  "title": "Corridors of Time",
+  "game": "Chrono Trigger",
+  "album": "Chrono Trigger (Original Soundtrack)",
+  "composer": ["Yasunori Mitsuda"],
+  "release_date": "1995-03-11",
+  "answers": { "canonical": ["Corridors of Time"] },
+  "meta": {
+    "provenance": {
+      "source": "discovery",
+      "provider": "apple",
+      "id": "itunes:123456789",
+      "collected_at": "2025-09-09T09:00:00Z",
+      "hash": "sha1hex(nfkc-lower of title|game|album|composer)",
+      "license_hint": "preview"
+    }
+  },
+  "dedup": { "theta": 0.12 },
+  "confidence": 0.73,
+  "notes": "normalized from iTunes Search"
+}
+```
+
+## 正規化規則（要点）
+- 文字種: **NFKC + lower**、記号/全角半角/長音を正規化
+- `composer` は配列化、`answers.canonical` は1要素以上を確保
+- `id` は `provider` の名前空間を付し、**一意**にする（例: `itunes:{trackId}`）
+- `hash` は `title|game|album|composer` を `NFKC+lower` 後に `sha1hex`
+
+## スコア
+- `confidence`（0–1）: 公式性/一致度/メタ完備度の合成
+- `dedup.theta`（0–1）: 既存データとの近似度（**advice**用途）
+
+## KPI（このIssue）
+- `official_rate`, `hit_rate`, `duplicate_ratio`, `fail_reasons_top3` を Step Summary へ出力設計
+- Collector 全体 KPI の統合は `v111-kpi-collector` で実施

--- a/docs/issues/v1_11.json
+++ b/docs/issues/v1_11.json
@@ -6,7 +6,7 @@
       "roadmap:v1.11",
       "area:collector"
     ],
-    "body": "### Scope\n- game/album 語 → 正規化 → 公式候補を探索（iTunes Search 起点、将来 Apple Music / YouTube API を段階導入）\n- **dry-run のみ**：提案 seed を**アーティファクト**として出力（JSONL: 1行=1候補）\n- 正規化: title/game/composer/aliases、`meta.provenance`（6項目）付与ルールの雛形\n- 重複排除: de-dup v1.5 を**adviceモード**で実行（落とさずスコアだけ付与）\n\n### DoD\n- Actions 実行で**dry-runアーティファクト**が生成（`artifacts/discovery/proposals-*.jsonl`）\n- Step Summary に KPI（official_rate/hit_rate/duplicate_ratio/fail_reasons_top3）が常設\n- 実際の seed への書き込みは**しない**（本Issueではドキュ/設計と dry-run のみ）\n"
+    "body": "### Scope\n- game/album 語 → 正規化 → 公式候補を探索（iTunes Search 起点、将来 Apple Music / YouTube API を段階導入）\n- **dry-run のみ**：提案 seed を**アーティファクト**として出力（JSONL: 1行=1候補）\n- 正規化: title/game/composer/aliases、`meta.provenance`（6項目）付与ルールの雛形\n- 重複排除: de-dup v1.5 を**adviceモード**で実行（落とさずスコアだけ付与）\n\n### DoD\n- Actions 実行で**dry-runアーティファクト**が生成（`artifacts/discovery/proposals-*.jsonl`）\n- Step Summary に KPI（official_rate/hit_rate/duplicate_ratio/fail_reasons_top3）が常設\n- 実際の seed への書き込みは**しない**（本Issueではドキュ/設計と dry-run のみ）\n\n### Status\n- documented（このチャット）: `OPERATIONS_DISCOVERY.md` / `SPEC_DISCOVERY_V1.md` に dry-run の I/F・正規化・provenance・KPI を記載。\n- 実装（dry-runワークフロー作成）は後続チャットで対応。\n"
   },
   {
     "id": "v111-gate-threshold",


### PR DESCRIPTION
## Summary
- outline dry-run discovery process with inputs, provenance fields and de-dup scoring
- specify data model and normalization for discovery v1
- note documentation status for discovery-dryrun issue

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bff6d0ab9c8324bbbbadb7b45077eb