### PR TITLE
feat: stage candidates in REST gate workflow

### DIFF
--- a/.github/workflows/collector-gate-from-artifact-by-id-rest.yml
+++ b/.github/workflows/collector-gate-from-artifact-by-id-rest.yml
@@ -2,7 +2,8 @@ name: collector (gate from artifact by id - REST)
 
 permissions:
   actions: read
-  contents: read
+  contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch:
@@ -95,6 +96,14 @@ jobs:
         run: |
           node scripts/collector/gate_apply_v1.mjs
 
+      - name: Stage candidate files
+        if: ${{ inputs.dry_run != 'true' && inputs.threshold != '' }}
+        run: |
+          git status --porcelain
+          git add -A resources/candidates || true
+          echo 'Staged files:'
+          git status --porcelain
+
       - name: Create PR (queued + auto) if not dry-run and threshold set
         if: ${{ inputs.dry_run != 'true' && inputs.threshold != '' }}
         uses: peter-evans/create-pull-request@v6
@@ -113,8 +122,8 @@ jobs:
             queue:collector
             docs:skip
           add-paths: |
-            resources/candidates/auto/*
-            resources/candidates/queue/*
+            resources/candidates/**
 
       - name: Summary
         run: echo "### collector (gate from artifact by id - REST) finished" >> "$GITHUB_STEP_SUMMARY"
+


### PR DESCRIPTION
## Summary
- stage candidate files before PR creation in REST artifact gate workflow
- grant workflow write permissions for contents and pull requests
- simplify PR add-paths to include all candidate files

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c024ca3b948324ade3342ed9bf558c