### PR TITLE
docs: add roadmap details and issue lists for v1.12–v1.15

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -363,3 +363,33 @@ DoD: Actions 全体が緑／ `daily_auto.json` が日次で増加（候補枯渇
 - Discovery ソースの拡張（YouTube Official / Bandcamp 等、ライセンス方針と併せて）
 - Ops 整備（PAT/Auto-merge/Artifact 取得手順の統合・簡略化）
 - Audio特性の活用（将来）／モデリング高度化／UI改善 等
+
+
+## v1.12〜v1.15 計画（確定）
+
+### v1.12（安定化＋リファクタ＋θ運用開始＋ドキュ骨格再編）
+- 目的: 後続MVPを安全に載せられる“土台”づくり（挙動は不変）
+- コード: scripts の lib 分離 / 命名統一 / 設定一元化（入口互換を維持, Node組み込み`node --test`で最小ユニット）
+- UI: app.js を bootstrap/state/engine/media/i18n/ui に**軽量分割**（挙動不変）、sw.js は routes/config へ整理
+- θ運用: 本線 θ=0.80、比較 θ=0.72/0.85 を **dry-run専用Workflow** で定期測定（KPIはStep Summaryへ）
+- ドキュ: 骨格再編（日本語統一）。`OPERATIONS_GATE.md` / `QUALITY_KPIS.md` / `ARCHITECTURE.md` などを整備
+- DoD: E2E 緑 / ユニットがCIで実行 / θ本線開始＆dry-run有効 / ドキュ骨格と必須章更新
+
+### v1.13（“1問/日” 自動MVP：埋め込みのみ＝Apple優先→YouTube→自前なし）
+- 既存 daily 系を拡張（必要に応じて補助Workflowは新設可）
+- 機能: クリップ開始秒選定 / 難易度 / 誤答肢 / 表記正規化 / 重複回避（v1.12のlibを再利用）
+- 成果物: Daily JSON / OGP / Feeds。失敗時の復旧手順を `OPERATIONS_DAILY_ONEQ.md` に明記
+- DoD: 無人運用で安定生成（埋め込みのみ）。復旧手順がドキュ化されている
+
+### v1.14（トリビア自動MVP：オフライン種スタート）
+- 種データ: キュレーション済み JSON/CSV を取り込み
+- 流れ: 取り込み→事実抽出→正規化→一意性ロック→誤答肢→信頼度スコア→出典URL格納
+- DoD: Actions上でフロー再現、トリビアJSONLに信頼度と出典URLが付与
+
+### v1.15（ハイブリッド前段：限定クロール→アーカイブ→抽出 + 追加プロバイダ設計）
+- クローリング: 許可ドメイン allowlist / robots順守 / レート制御 / 夜間ハーベスタ → アーカイブ(Artifacts/branch) → 本線CIはアーカイブのみ参照
+- 抽出: ルールベース抽出 + 正規化辞書。将来の一部自動化に備えスキーマ厳格化
+- プロバイダ: `config/providers.mjs` を軸に Spotify/Bandcamp等の追加設計（実装は後続）
+- DoD: ハーベスタ雛形が安定（レートと許可方針が文書化）。アーカイブ読取でCIが安定
+
+> 注: Workflow は「必要なら作る／不要なら消す」。最小本数主義だが、検証や長時間処理の分離は可。

--- a/docs/issues/v1_12.json
+++ b/docs/issues/v1_12.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "v112-refactor-core",
+    "title": "v1.12: コア分離（lib化）・命名統一・設定一元化（入口互換）",
+    "labels": [
+      "roadmap:v1.12",
+      "type:refactor",
+      "area:scripts"
+    ],
+    "body": "scripts/lib への分離（gate_score/normalize/dedup/provenance/providers）、config一元化、`node --test` の最小ユニット、既存入口は互換維持。",
+    "state": "open"
+  },
+  {
+    "id": "v112-refactor-ui-slim",
+    "title": "v1.12: UI軽量リファクタ（app.js分割 / sw.js整理、挙動不変）",
+    "labels": [
+      "roadmap:v1.12",
+      "type:refactor",
+      "area:ui"
+    ],
+    "body": "app.js を bootstrap/state/engine/media/i18n/ui に分割、sw.js を routes/config へ整理。互換モード/読み込み順維持、E2E緑がDoD。",
+    "state": "open"
+  },
+  {
+    "id": "v112-theta-ops",
+    "title": "v1.12: Gate θ 運用開始（0.80本線）＋ dry-run専用Workflow（0.72/0.85 比較）",
+    "labels": [
+      "roadmap:v1.12",
+      "area:kpi",
+      "area:ops"
+    ],
+    "body": "本線 θ=0.80。0.72/0.85 は dry-run専用Workflowで数回回し、KPI（auto_accept_rate 等）をStep Summary出力。標本数50–100目安で意思決定。",
+    "state": "open"
+  },
+  {
+    "id": "v112-docs-skeleton",
+    "title": "v1.12: ドキュ骨格再編＋必須章更新（日本語統一）",
+    "labels": [
+      "roadmap:v1.12",
+      "type:docs"
+    ],
+    "body": "章立て整備（ROADMAP/OPERATIONS_GATE/QUALITY_KPIS/ARCHITECTURE など）。既存の移設と決定事項の反映を優先。",
+    "state": "open"
+  },
+  {
+    "id": "v112-docs-lint",
+    "title": "v1.12: docs-lint（リンク切れ）軽量Workflow追加",
+    "labels": [
+      "roadmap:v1.12",
+      "type:docs",
+      "area:ci"
+    ],
+    "body": "docs内のリンク切れ検出のみを行う軽量ジョブを追加。コード側CIに影響を与えない設計。",
+    "state": "open"
+  }
+]
+

--- a/docs/issues/v1_13.json
+++ b/docs/issues/v1_13.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "v113-daily-oneq-mvp",
+    "title": "v1.13: “1問/日” 自動MVP（埋め込みのみ: Apple優先→YouTube→自前なし）",
+    "labels": [
+      "roadmap:v1.13",
+      "area:daily",
+      "type:feature"
+    ],
+    "body": "既存 daily を拡張し、クリップ開始秒選定/難易度/誤答肢/正規化/重複回避をv1.12のlibで実装。OGP/feeds生成と復旧手順を伴う。",
+    "state": "open"
+  },
+  {
+    "id": "v113-daily-recovery-docs",
+    "title": "v1.13: 復旧手順・運用ドキュ整備（OPERATIONS_DAILY_ONEQ.md）",
+    "labels": [
+      "roadmap:v1.13",
+      "type:docs",
+      "area:ops"
+    ],
+    "body": "失敗時の手順（手動再実行/強制skip/PR巻き戻し）を文書化。",
+    "state": "open"
+  },
+  {
+    "id": "v113-daily-kpi",
+    "title": "v1.13: KPI計測の組み込み（Step Summary）",
+    "labels": [
+      "roadmap:v1.13",
+      "area:kpi"
+    ],
+    "body": "日次生成の成功率・リードタイム・メディア解決率などをStep Summaryに出力。",
+    "state": "open"
+  }
+]
+

--- a/docs/issues/v1_14.json
+++ b/docs/issues/v1_14.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "v114-trivia-mvp-offline",
+    "title": "v1.14: トリビア自動MVP（オフライン種）",
+    "labels": [
+      "roadmap:v1.14",
+      "area:trivia",
+      "type:feature"
+    ],
+    "body": "キュレーション済みJSON/CSVの取り込み→事実抽出→正規化→一意性ロック→誤答肢→信頼度→出典URL格納のパイプラインをActions上で再現。",
+    "state": "open"
+  },
+  {
+    "id": "v114-trivia-schema",
+    "title": "v1.14: トリビアのスキーマ定義・一意性ロック・信頼度スコア",
+    "labels": [
+      "roadmap:v1.14",
+      "area:trivia",
+      "type:spec"
+    ],
+    "body": "データ項目の定義・正規化ルール・一意性ロックの条件付与・confidenceの算出式を docs/ に明文化。",
+    "state": "open"
+  },
+  {
+    "id": "v114-trivia-pipeline",
+    "title": "v1.14: 取り込み〜抽出〜正規化〜誤答肢生成 パイプライン実装",
+    "labels": [
+      "roadmap:v1.14",
+      "area:trivia",
+      "type:impl"
+    ],
+    "body": "オフライン種を入力として最小の自動生成パイプラインを構築し、成果物を artifacts として保存。",
+    "state": "open"
+  }
+]
+

--- a/docs/issues/v1_15.json
+++ b/docs/issues/v1_15.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "v115-harvester-hybrid",
+    "title": "v1.15: ハーベスタ雛形（限定クロール→アーカイブ→抽出）",
+    "labels": [
+      "roadmap:v1.15",
+      "area:harvest",
+      "type:infra"
+    ],
+    "body": "許可ドメインの限定クロールを夜間Workflowで実行し、成果をアーカイブ（Artifacts/branch）。本線CIはアーカイブのみ参照。",
+    "state": "open"
+  },
+  {
+    "id": "v115-rate-limit-policy",
+    "title": "v1.15: レート制御・許可ドメイン・アーカイブ運用のポリシー文書化",
+    "labels": [
+      "roadmap:v1.15",
+      "type:docs",
+      "area:policy"
+    ],
+    "body": "robots順守・レート設定・アーカイブの保持/更新方針・再現性について docs/ に記載。",
+    "state": "open"
+  },
+  {
+    "id": "v115-provider-ext-design",
+    "title": "v1.15: 追加プロバイダ設計（Spotify/Bandcamp等、実装は後続）",
+    "labels": [
+      "roadmap:v1.15",
+      "area:media",
+      "type:design"
+    ],
+    "body": "`config/providers.mjs` を軸に、将来追加のための設計（優先度/可否判定/エンベッド条件）を具体化。",
+    "state": "open"
+  }
+]
+


### PR DESCRIPTION
## Summary
- outline concrete plans for upcoming versions v1.12 through v1.15 in the roadmap
- add JSON issue lists for v1.12–v1.15

## Testing
- `npm test` *(fails: clojure not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c0c8156bd483249a53404242188b74