### PR TITLE
ci: add gate dry-run matrix v2 workflow

### DIFF
--- a/.github/workflows/gate-dryrun-matrix-v2.yml
+++ b/.github/workflows/gate-dryrun-matrix-v2.yml
@@ -1,0 +1,68 @@
+name: gate (dry-run matrix v2)
+
+on:
+  workflow_dispatch:
+    inputs:
+      query:
+        description: 'iTunes Search query (例: Chrono Trigger)'
+        required: true
+      limit:
+        description: 'Discovery limit'
+        required: false
+        default: '25'
+      country:
+        description: 'Store country'
+        required: false
+        default: 'jp'
+
+jobs:
+  dryrun:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        theta: [ '0.72', '0.80', '0.85' ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Discovery (dry-run) and proposals dump
+        env:
+          DISCOVERY_QUERY: ${{ inputs.query }}
+          DISCOVERY_LIMIT: ${{ inputs.limit }}
+          DISCOVERY_COUNTRY: ${{ inputs.country }}
+          COLLECTOR_GATE_THRESHOLD: ${{ matrix.theta }}
+          GATE_DRY_RUN: '1'
+        run: |
+          node --version
+          node scripts/collector/discovery_dryrun_v1.mjs
+          OUT=$(ls -t public/app/discovery/proposals-*.jsonl | head -n1 || true)
+          if [ -z "$OUT" ]; then
+            echo "No proposals file found under public/app/discovery"
+            exit 1
+          fi
+          mkdir -p build
+          cp "$OUT" "build/proposals-${{ matrix.theta }}.jsonl"
+
+      - name: Gate apply (dry-run)
+        env:
+          GATE_PROPOSALS: build/proposals-${{ matrix.theta }}.jsonl
+          COLLECTOR_GATE_THRESHOLD: ${{ matrix.theta }}
+          GATE_DRY_RUN: '1'
+        run: |
+          node scripts/collector/gate_apply_v1.mjs
+
+      - name: KPI summary
+        run: |
+          node scripts/kpi/append_summary_gate_dryrun.mjs \
+            --in build/proposals-${{ matrix.theta }}.jsonl \
+            --threshold ${{ matrix.theta }} \
+            --label "θ=${{ matrix.theta }}"
+
+      - name: Upload proposals (artifact)
+        uses: actions/upload-artifact@v4
+        with:
+          name: proposals-${{ matrix.theta }}
+          path: build/proposals-${{ matrix.theta }}.jsonl


### PR DESCRIPTION
## Summary
- add GA dry-run matrix v2 workflow with gate apply and KPI summary

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d3fe215c83248c6b8ad51b8a881c