### PR TITLE
feat: add gate scoring utilities

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,0 +1,28 @@
+name: node-tests (v1.12)
+
+on:
+  push:
+    paths:
+      - 'scripts/lib/**'
+      - 'scripts/config/**'
+      - 'scripts/**/__tests__/**'
+      - '.github/workflows/node-tests.yml'
+  pull_request:
+    paths:
+      - 'scripts/lib/**'
+      - 'scripts/config/**'
+      - 'scripts/**/__tests__/**'
+      - '.github/workflows/node-tests.yml'
+  workflow_dispatch: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run unit tests
+        run: |
+          node --test "scripts/**/__tests__/*.mjs"

--- a/scripts/collector/gate_apply_v1.mjs
+++ b/scripts/collector/gate_apply_v1.mjs
@@ -1,6 +1,7 @@
 // scripts/collector/gate_apply_v1.mjs
 import fs from 'node:fs';
 import path from 'node:path';
+import { computeGateScore } from '../lib/gate_score.mjs';
 
 const PROPOSALS = process.env.GATE_PROPOSALS || '';
 const THRESHOLD = process.env.COLLECTOR_GATE_THRESHOLD || '';
@@ -19,47 +20,6 @@ function readJsonl(p){
   return lines.map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
 }
 
-function clamp01(x){ return Math.max(0, Math.min(1, x)); }
-
-function notabilityOf(o){
-  // 初期ヒューリスティク: previewありなら0.75、なければ0.55（将来はSPECに沿って算出）
-  const lic = o?.meta?.provenance?.license_hint || 'unknown';
-  return lic === 'preview' ? 0.75 : 0.55;
-}
-
-function providerTrust(p){
-  const v = String(p||'').toLowerCase();
-  if (v === 'apple') return 1.00;
-  if (v === 'youtube_official') return 0.85;
-  if (v === 'youtube') return 0.35;
-  if (v === 'stub') return 0.10;
-  return 0.20;
-}
-
-function guardScore(o){
-  // 初期値 1.0 からの減点
-  let g = 1.0;
-  const prov = o?.meta?.provenance || {};
-  const provKeys = ['source','provider','id','collected_at','hash','license_hint'];
-  const provOk = provKeys.every(k => !!prov[k]);
-  if (!provOk) return 0;
-
-  if ((prov.license_hint||'unknown') === 'unknown') g *= 0.5;
-  const comp = Array.isArray(o?.composer) ? o.composer : (Array.isArray(o?.track?.composer) ? o.track.composer : []);
-  if (!comp.length) g *= 0.8;
-  const theta = Number(o?.dedup?.theta || 0);
-  if (theta >= 0.95) return 0;
-  if (theta >= 0.85) g *= 0.5;
-  return clamp01(g);
-}
-
-function score(o){
-  const notab = notabilityOf(o);
-  const ptrust = providerTrust(o?.meta?.provenance?.provider);
-  const g = guardScore(o);
-  const s = 0.5*notab + 0.3*ptrust + 0.2*g;
-  return clamp01(s);
-}
 
 function writeJsonl(file, arr){
   if (!arr.length) return;
@@ -73,7 +33,7 @@ function main(){
   const list = readJsonl(PROPOSALS);
   const theta = THRESHOLD ? Number(THRESHOLD) : NaN;
   const accepted = [], queued = [], rejected = [];
-  const scored = list.map(o => ({ ...o, gate: { score: Number(score(o).toFixed(4)) } }));
+  const scored = list.map(o => ({ ...o, gate: { score: Number(computeGateScore(o).toFixed(4)) } }));
 
   for (const o of scored){
     const s = o.gate.score;

--- a/scripts/config/gate.mjs
+++ b/scripts/config/gate.mjs
@@ -1,0 +1,5 @@
+/**
+ * Gate config (v1.12)
+ */
+export const DEFAULT_THRESHOLD = 0.80;
+// ここに将来の係数・減点ルールを集約予定（v1.12では参照のみ）

--- a/scripts/config/providers.mjs
+++ b/scripts/config/providers.mjs
@@ -1,0 +1,11 @@
+/**
+ * Provider trust mapping (v1.12)
+ * apple=1.00, youtube_official=0.85, youtube=0.35, stub=0.10, default=0.20
+ */
+export const PROVIDER_TRUST = {
+  apple: 1.00,
+  youtube_official: 0.85,
+  youtube: 0.35,
+  stub: 0.10,
+  __default: 0.20,
+};

--- a/scripts/lib/__tests__/gate_score.test.mjs
+++ b/scripts/lib/__tests__/gate_score.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeGateScore, guardScore, providerTrust, clamp01 } from '../../lib/gate_score.mjs';
+
+test('clamp01 clamps values', () => {
+  assert.equal(clamp01(-1), 0);
+  assert.equal(clamp01(2), 1);
+  assert.equal(clamp01(0.5), 0.5);
+});
+
+test('providerTrust mapping', () => {
+  assert.equal(providerTrust('apple'), 1.00);
+  assert.equal(providerTrust('youtube_official'), 0.85);
+  assert.equal(providerTrust('youtube'), 0.35);
+  assert.equal(providerTrust('stub'), 0.10);
+  assert.equal(providerTrust('unknown'), 0.20);
+});
+
+test('guardScore penalties', () => {
+  const base = { meta:{ provenance:{ source:'x',provider:'apple',id:'1',collected_at:'t',hash:'h',license_hint:'preview' } }, composer:['a'], dedup:{theta:0.0} };
+  assert.equal(guardScore(base), 1.0);
+  assert.equal(guardScore({ ...base, meta:{ provenance:{...base.meta.provenance, license_hint:'unknown'} } }) <= 0.5, true);
+  assert.equal(guardScore({ ...base, composer:[] }) <= 0.8, true);
+  assert.equal(guardScore({ ...base, dedup:{theta:0.95} }), 0);
+});
+
+test('computeGateScore in [0,1]', () => {
+  const o = { meta:{ provenance:{ source:'x',provider:'apple',id:'1',collected_at:'t',hash:'h',license_hint:'preview' } }, composer:['a'], dedup:{theta:0.0} };
+  const s = computeGateScore(o);
+  assert.ok(s >= 0 && s <= 1);
+});

--- a/scripts/lib/gate_score.mjs
+++ b/scripts/lib/gate_score.mjs
@@ -1,0 +1,44 @@
+/**
+ * Gate scoring utilities (v1.12)
+ * Keep in sync with docs/OPERATIONS_GATE.md
+ */
+import { PROVIDER_TRUST } from '../config/providers.mjs';
+
+export function clamp01(x){ return Math.max(0, Math.min(1, Number(x))); }
+
+export function notabilityOf(o){
+  // 初期ヒューリスティク: previewありなら0.75、なければ0.55（SPEC整備までは互換を維持）
+  const lic = o?.meta?.provenance?.license_hint || 'unknown';
+  return lic === 'preview' ? 0.75 : 0.55;
+}
+
+export function providerTrust(p){
+  const v = String(p||'').toLowerCase();
+  if (v in PROVIDER_TRUST) return PROVIDER_TRUST[v];
+  return PROVIDER_TRUST.__default;
+}
+
+export function guardScore(o){
+  // 初期値 1.0 からの減点（provenance欠落=0、license unknown×0.5、composer欠落×0.8、dedup θ減点）
+  let g = 1.0;
+  const prov = o?.meta?.provenance || {};
+  const provKeys = ['source','provider','id','collected_at','hash','license_hint'];
+  const provOk = provKeys.every(k => !!prov[k]);
+  if (!provOk) return 0;
+
+  if ((prov.license_hint||'unknown') === 'unknown') g *= 0.5;
+  const comp = Array.isArray(o?.composer) ? o.composer : (Array.isArray(o?.track?.composer) ? o.track.composer : []);
+  if (!comp.length) g *= 0.8;
+  const theta = Number(o?.dedup?.theta || 0);
+  if (theta >= 0.95) return 0;
+  if (theta >= 0.85) g *= 0.5;
+  return clamp01(g);
+}
+
+export function computeGateScore(o){
+  const notab = notabilityOf(o);
+  const ptrust = providerTrust(o?.meta?.provenance?.provider);
+  const g = guardScore(o);
+  const s = 0.5*notab + 0.3*ptrust + 0.2*g;
+  return clamp01(s);
+}


### PR DESCRIPTION
## Summary
- centralize gate scoring logic in `gate_score.mjs`
- record provider trust and default threshold configs
- update collector gate script to use shared scoring
- add unit tests and CI workflow

## Testing
- `node --test "scripts/**/__tests__/*.mjs"`
- `npm test` *(fails: clojure not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e00d01548324b0a689f73ffa8340