### PR TITLE
Add flexible node test workflow

### DIFF
--- a/.github/workflows/node-tests-v2.yml
+++ b/.github/workflows/node-tests-v2.yml
@@ -1,0 +1,37 @@
+name: node-tests (v1.12 v2)
+
+on:
+  push:
+    paths:
+      - 'scripts/lib/**'
+      - 'scripts/config/**'
+      - 'scripts/**/__tests__/**'
+      - '.github/workflows/node-tests-v2.yml'
+  pull_request:
+    paths:
+      - 'scripts/lib/**'
+      - 'scripts/config/**'
+      - 'scripts/**/__tests__/**'
+      - '.github/workflows/node-tests-v2.yml'
+  workflow_dispatch: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run unit tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s globstar nullglob
+          files=(scripts/**/__tests__/*.mjs)
+          if (( ${#files[@]} == 0 )); then
+            echo "No unit tests found; skipping."
+            exit 0
+          fi
+          node --version
+          node --test "${files[@]}"


### PR DESCRIPTION
## Summary
- add node-tests v2 workflow that runs script unit tests and skips when none found

## Testing
- `npm test` *(fails: clojure not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e536597083248235f4fb8074bfbd