### PR TITLE
refactor: extract service worker registration

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1,5 +1,6 @@
 // i18n baseline (v1.6)
 import { initI18n, whenI18nReady, applyStaticLabels, t } from './i18n.mjs';
+import { registerSW } from './sw-register.js';
 void initI18n(); // non-blocking; updates <html lang> & document.title
 whenI18nReady().then(() => {
   // Try immediately, then after first paint, then once again after 500ms for safety
@@ -1414,23 +1415,12 @@ window.addEventListener('DOMContentLoaded', () => {
     if (__IS_TEST_MODE__) {
       // E2E / CI 用。SW は登録しない
     } else {
-      navigator.serviceWorker.register(`./sw.js?v=${encodeURIComponent(v)}`).then(reg => {
-        swRegistration = reg;
-        try { window.dispatchEvent(new CustomEvent('sw-registered', { detail: swRegistration })); } catch (_) {}
-        if (swRegistration.waiting) {
-          showUpdateBanner();
-        }
-        swRegistration.addEventListener('updatefound', () => {
-          const newWorker = swRegistration.installing;
-          if (newWorker) {
-            newWorker.addEventListener('statechange', () => {
-              if (swRegistration.waiting) {
-                showUpdateBanner();
-              }
-            });
-          }
-        });
-      });
+      registerSW(v, () => { try { showUpdateBanner(); } catch (_) {} })
+        .then(reg => {
+          swRegistration = reg;
+          try { window.dispatchEvent(new CustomEvent('sw-registered', { detail: swRegistration })); } catch (_) {}
+        })
+        .catch(() => {});
     }
   }
 });

--- a/public/app/sw-register.js
+++ b/public/app/sw-register.js
@@ -1,0 +1,23 @@
+// Service Worker registration (extracted by v1.12 UI-slim Phase 1)
+export async function registerSW(version, onWaiting) {
+  try {
+    const reg = await navigator.serviceWorker.register(`./sw.js?v=${encodeURIComponent(version)}`);
+    if (reg && reg.waiting) {
+      try { onWaiting && onWaiting(); } catch {}
+    }
+    reg.addEventListener('updatefound', () => {
+      const newWorker = reg.installing;
+      if (newWorker) {
+        newWorker.addEventListener('statechange', () => {
+          if (reg.waiting) {
+            try { onWaiting && onWaiting(); } catch {}
+          }
+        });
+      }
+    });
+    return reg;
+  } catch (e) {
+    // ignore registration errors to keep app boot resilient
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- factor out reusable service worker registration logic into `sw-register.js`
- replace inline SW registration in `app.js` with helper

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c10d070308832489dc49add4bb2637