### PR TITLE
chore: extract A11y helpers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -77,5 +77,6 @@
 - `sw-register.js`: Service Worker 登録の薄いラッパ。`registerSW(version, onWaiting)` を提供。
 - `i18n-boot.mjs`: i18n 初期化と静的ラベル適用・`i18n:changed` ハンドラを集約。
 - `version.mjs`: バージョン情報の読込（`readVersionNoStore` など）を集約。TTL/ETag メモ化は従来通り。
+- `a11y-helpers.mjs`: 起動時に `initA11y()` を呼び、タイマー/プログレスバーなどの ARIA 属性の整備を行う。
 
 > 目的: `public/app/app.js` の責務を明確化し、将来の UI 分割（Phase 2 以降）の基盤にする。

--- a/public/app/a11y-helpers.mjs
+++ b/public/app/a11y-helpers.mjs
@@ -1,0 +1,119 @@
+// A11y helpers extracted by v1.12 UI-slim Phase 1
+export function initA11y() {
+  const once = (fn) => {
+    let done = false;
+    return (...args) => {
+      if (!done) {
+        done = true;
+        fn(...args);
+      }
+    };
+  };
+
+  const ensureTimerAria = () => {
+    const t = document.querySelector('[data-testid="timer"], #timer');
+    if (!t) return;
+    if (!t.getAttribute('aria-live')) t.setAttribute('aria-live', 'polite');
+    if (!t.getAttribute('aria-atomic')) t.setAttribute('aria-atomic', 'true');
+  };
+
+  const ensureProgressbarAria = () => {
+    const bar = document.querySelector('[data-testid="score-bar"], #score-bar');
+    if (!bar) return;
+    bar.setAttribute('role', 'progressbar');
+    bar.setAttribute('aria-valuemin', '0');
+    bar.setAttribute('aria-valuemax', '100');
+    const updateNow = () => {
+      // 期待: style="width: NN%"
+      const w = (bar.style && bar.style.width) || '';
+      const m = w.match(/(\d+(?:\.\d+)?)%/);
+      if (m) bar.setAttribute('aria-valuenow', String(Math.round(parseFloat(m[1]))));
+    };
+    updateNow();
+    // 変化を監視して now を追従（重複バインド防止）
+    if (!bar.dataset._a11yProgressMoBound) {
+      const mo = new MutationObserver(() => updateNow());
+      mo.observe(bar, { attributes: true, attributeFilter: ['style'] });
+      bar.dataset._a11yProgressMoBound = '1';
+    }
+  };
+
+  const annotateChoices = () => {
+    const container = document.querySelector('#choices') || document.querySelector('[data-testid="choices"]');
+    if (!container) return;
+    container
+      .querySelectorAll('button, .choice, [data-testid="choice"]')
+      .forEach((el) => {
+        el.setAttribute('role', 'button'); // button要素でも冗長OK
+        if (!el.hasAttribute('aria-pressed')) el.setAttribute('aria-pressed', 'false');
+      });
+    // クリックで aria-pressed をトグル（選択反映）: 重複バインド防止
+    if (!container.dataset._a11yChoiceBound) {
+      container.addEventListener(
+        'click',
+        (e) => {
+          const target = e.target.closest('button, .choice, [data-testid="choice"]');
+          if (!target) return;
+          container
+            .querySelectorAll('button, .choice, [data-testid="choice"]')
+            .forEach((el) => {
+              el.setAttribute('aria-pressed', el === target ? 'true' : 'false');
+            });
+        },
+        { passive: true },
+      );
+      container.dataset._a11yChoiceBound = '1';
+    }
+  };
+
+  const focusFirstControl = once(() => {
+    // Free: answer、MC: 最初の選択肢
+    const answer = document.querySelector('[data-testid="answer"], #answer');
+    if (answer) {
+      answer.focus?.();
+      return;
+    }
+    const firstChoice = document.querySelector('#choices button, .choice, [data-testid="choice"]');
+    firstChoice?.focus?.();
+  });
+
+  const observeQuiz = () => {
+    const quizView =
+      document.querySelector('#question-view') ||
+      document.querySelector('[data-testid="quiz-view"]');
+    if (!quizView) return;
+    // 出題レンダ後にA11yを適用（属性変化は監視しない＝自己再帰ループ回避）
+    const apply = () => {
+      ensureTimerAria();
+      ensureProgressbarAria();
+      annotateChoices();
+      focusFirstControl();
+    };
+    const mo = new MutationObserver((mutations) => {
+      if (mutations.some((m) => m.type === 'childList')) apply();
+    });
+    mo.observe(quizView, { childList: true, subtree: true }); // attributes: false
+    apply();
+  };
+
+  window.addEventListener(
+    'DOMContentLoaded',
+    () => {
+      // Start押下後にもフォーカスが飛ぶよう保険
+      const startBtn = document.querySelector('[data-testid="start-btn"], #start-btn');
+      if (startBtn)
+        startBtn.addEventListener(
+          'click',
+          () => setTimeout(() => focusFirstControl(), 0),
+          { once: true },
+        );
+      observeQuiz();
+      // 初期描画時にも最低限のA11yを適用
+      ensureTimerAria();
+      ensureProgressbarAria();
+      focusFirstControl();
+    },
+    { once: true },
+  );
+}
+

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1,5 +1,6 @@
 import { registerSW } from './sw-register.js';
 import './i18n-boot.mjs';
+import { initA11y } from './a11y-helpers.mjs';
 
 // --- perf helpers ---
 async function parseJsonOffMainThread(text) {
@@ -1177,91 +1178,7 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 });
 // --- A11y: focus/roles/progressbar（視覚は不変）を常時有効化 ---
-(() => {
-  const once = (fn) => {
-    let done = false;
-    return (...args) => { if (!done) { done = true; fn(...args); } };
-  };
-
-  const ensureTimerAria = () => {
-    const t = document.querySelector('[data-testid="timer"], #timer');
-    if (!t) return;
-    if (!t.getAttribute('aria-live'))   t.setAttribute('aria-live', 'polite');
-    if (!t.getAttribute('aria-atomic')) t.setAttribute('aria-atomic', 'true');
-  };
-
-  const ensureProgressbarAria = () => {
-    const bar = document.querySelector('[data-testid="score-bar"], #score-bar');
-    if (!bar) return;
-    bar.setAttribute('role', 'progressbar');
-    bar.setAttribute('aria-valuemin', '0');
-    bar.setAttribute('aria-valuemax', '100');
-    const updateNow = () => {
-      // 期待: style="width: NN%"
-      const w = (bar.style && bar.style.width) || '';
-      const m = w.match(/(\d+(?:\.\d+)?)%/);
-      if (m) bar.setAttribute('aria-valuenow', String(Math.round(parseFloat(m[1]))));
-    };
-    updateNow();
-    // 変化を監視して now を追従（重複バインド防止）
-    if (!bar.dataset._a11yProgressMoBound) {
-      const mo = new MutationObserver(() => updateNow());
-      mo.observe(bar, { attributes: true, attributeFilter: ['style'] });
-      bar.dataset._a11yProgressMoBound = '1';
-    }
-  };
-
-  const annotateChoices = () => {
-    const container = document.querySelector('#choices') || document.querySelector('[data-testid="choices"]');
-    if (!container) return;
-    container.querySelectorAll('button, .choice, [data-testid="choice"]').forEach((el) => {
-      el.setAttribute('role', 'button'); // button要素でも冗長OK
-      if (!el.hasAttribute('aria-pressed')) el.setAttribute('aria-pressed', 'false');
-    });
-    // クリックで aria-pressed をトグル（選択反映）: 重複バインド防止
-    if (!container.dataset._a11yChoiceBound) {
-      container.addEventListener('click', (e) => {
-        const target = e.target.closest('button, .choice, [data-testid="choice"]');
-        if (!target) return;
-        container.querySelectorAll('button, .choice, [data-testid="choice"]').forEach((el) => {
-          el.setAttribute('aria-pressed', el === target ? 'true' : 'false');
-        });
-      }, { passive: true });
-      container.dataset._a11yChoiceBound = '1';
-    }
-  };
-
-  const focusFirstControl = once(() => {
-    // Free: answer、MC: 最初の選択肢
-    const answer = document.querySelector('[data-testid="answer"], #answer');
-    if (answer) { answer.focus?.(); return; }
-    const firstChoice = document.querySelector('#choices button, .choice, [data-testid="choice"]');
-    firstChoice?.focus?.();
-  });
-
-  const observeQuiz = () => {
-    const quizView = document.querySelector('#question-view') || document.querySelector('[data-testid="quiz-view"]');
-    if (!quizView) return;
-    // 出題レンダ後にA11yを適用（属性変化は監視しない＝自己再帰ループ回避）
-    const apply = () => { ensureTimerAria(); ensureProgressbarAria(); annotateChoices(); focusFirstControl(); };
-    const mo = new MutationObserver((mutations) => {
-      if (mutations.some(m => m.type === 'childList')) apply();
-    });
-    mo.observe(quizView, { childList: true, subtree: true }); // attributes: false
-    apply();
-  };
-
-  window.addEventListener('DOMContentLoaded', () => {
-    // Start押下後にもフォーカスが飛ぶよう保険
-    const startBtn = document.querySelector('[data-testid="start-btn"], #start-btn');
-    if (startBtn) startBtn.addEventListener('click', () => setTimeout(() => focusFirstControl(), 0), { once: true });
-    observeQuiz();
-    // 初期描画時にも最低限のA11yを適用
-    ensureTimerAria();
-    ensureProgressbarAria();
-    focusFirstControl();
-  }, { once: true });
-})();
+initA11y();
 // --- /A11y ---
 
 // デバッグ/検証用（TTL/in-flight挙動の確認に使用）


### PR DESCRIPTION
## Summary
- extract A11y initialization logic into `a11y-helpers.mjs`
- call `initA11y` from `app.js`
- document new module in architecture doc

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1206bc6a083249808ba6978802f88