### PR TITLE
Extract daily mode logic into separate module

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -80,3 +80,6 @@
 - `a11y-helpers.mjs`: 起動時に `initA11y()` を呼び、タイマー/プログレスバーなどの ARIA 属性の整備を行う。
 
 > 目的: `public/app/app.js` の責務を明確化し、将来の UI 分割（Phase 2 以降）の基盤にする。
+
+## フロントエンド（app/）の起動分割（v1.12 Phase 2）
+- `daily.mjs`: デイリーモードの状態（`DAILY`）とヘルパ（`detectDailyParam` / `initDaily` / `pickDailyWantedFromMap` / `applyDailyRestriction`）を集約。

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -41,6 +41,7 @@ function ensureAliases() {
 }
 import { normalize as normalizeV2 } from './normalize.mjs';
 import { orderByYearBucket } from './question_pipeline.mjs';
+import { DAILY, detectDailyParam, initDaily, pickDailyWantedFromMap, applyDailyRestriction } from './daily.mjs';
 import { yieldToMain, getQueryParam, getQueryBool, xfnv1a, mulberry32 } from './utils-ui.mjs';
 import {
   readVersionNoStore,
@@ -128,31 +129,6 @@ function initSeededRandom() {
 
 initSeededRandom();
 
-// ---------------------
-// Daily 1-question mode
-// ---------------------
-const DAILY = {
-  active: false,
-  dateStr: null,        // 'YYYY-MM-DD'
-  wanted: null,         // { id?: string, title?: string }
-  mapLoaded: false,
-};
-
-function todayJST() {
-  // 'YYYY-MM-DD' を JST で作る
-  const fmt = new Intl.DateTimeFormat('ja-JP', { timeZone: 'Asia/Tokyo', year: 'numeric', month: '2-digit', day: '2-digit' });
-  const [{value: y}, , {value: m}, , {value: d}] = fmt.formatToParts(new Date());
-  return `${y}-${m}-${d}`;
-}
-
-function detectDailyParam() {
-  const v = getQueryParam('daily');
-  if (!v) return null;
-  if (v === '1' || v === 'true') return todayJST();
-  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return v;
-  return null;
-}
-
 async function preloadDailyMap() {
   try {
     const res = await fetch('./daily.json', { cache: 'no-cache' });
@@ -167,43 +143,6 @@ async function preloadDailyMap() {
   }
 }
 
-function initDaily() {
-  const date = detectDailyParam();
-  if (!date) return;
-  DAILY.active = true;
-  DAILY.dateStr = date;
-}
-
-// タイトル/IDの正規化一致
-function normKey(s) { return normalizeV2(String(s || '')); }
-function pickDailyWantedFromMap() {
-  if (!DAILY.active) return;
-  const entry = DAILY.map?.[DAILY.dateStr];
-  if (!entry) return;
-  if (typeof entry === 'string') {
-    DAILY.wanted = { id: entry }; // 旧式：そのままID扱い
-  } else if (entry && typeof entry === 'object') {
-    DAILY.wanted = { id: entry.id, title: entry.title };
-  }
-}
-
-// 質問配列を 1 問に絞る（可能なら該当トラックを優先）
-function applyDailyRestriction() {
-  if (!DAILY.active || !Array.isArray(questions) || questions.length === 0) return;
-  // 優先順位: ID → タイトル（正規化一致）
-  let idx = -1;
-  if (DAILY.wanted?.id) {
-    const target = normKey(DAILY.wanted.id);
-    idx = questions.findIndex(q => normKey(q?.track?.id) === target);
-  }
-  if (idx < 0 && DAILY.wanted?.title) {
-    const target = normKey(DAILY.wanted.title);
-    idx = questions.findIndex(q => normKey(q?.track?.title) === target);
-  }
-  if (idx < 0) idx = 0; // フォールバック
-  questions = [questions[idx]];
-}
-
 function afterQuestionsBuiltHook() {
   try {
     if (getQueryBool('qp') && Array.isArray(questions) && questions.length > 0) {
@@ -216,7 +155,7 @@ function afterQuestionsBuiltHook() {
         questions = [questions[0]];
       } else {
         pickDailyWantedFromMap();
-        applyDailyRestriction();
+        questions = applyDailyRestriction(questions);
       }
     }
     if (getQueryBool('test') && Array.isArray(questions)) {

--- a/public/app/daily.mjs
+++ b/public/app/daily.mjs
@@ -1,0 +1,70 @@
+// Daily mode module extracted by v1.12 UI-slim Phase 2 (step 1)
+
+import { normalize as normalizeV2 } from './normalize.mjs';
+import { getQueryParam } from './utils-ui.mjs';
+
+// ---------------------
+// Daily 1-question mode
+// ---------------------
+const DAILY = {
+  active: false,
+  dateStr: null,        // 'YYYY-MM-DD'
+  wanted: null,         // { id?: string, title?: string }
+  mapLoaded: false,
+};
+
+function todayJST() {
+  // 'YYYY-MM-DD' を JST で作る
+  const fmt = new Intl.DateTimeFormat('ja-JP', { timeZone: 'Asia/Tokyo', year: 'numeric', month: '2-digit', day: '2-digit' });
+  const [{ value: y }, , { value: m }, , { value: d }] = fmt.formatToParts(new Date());
+  return `${y}-${m}-${d}`;
+}
+
+function detectDailyParam() {
+  const v = getQueryParam('daily');
+  if (!v) return null;
+  if (v === '1' || v === 'true') return todayJST();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return v;
+  return null;
+}
+
+function initDaily() {
+  const date = detectDailyParam();
+  if (!date) return;
+  DAILY.active = true;
+  DAILY.dateStr = date;
+}
+
+function pickDailyWantedFromMap() {
+  if (!DAILY.active) return;
+  const entry = DAILY.map?.[DAILY.dateStr];
+  if (!entry) return;
+  if (typeof entry === 'string') {
+    DAILY.wanted = { id: entry }; // 旧式：そのままID扱い
+  } else if (entry && typeof entry === 'object') {
+    DAILY.wanted = { id: entry.id, title: entry.title };
+  }
+}
+
+// タイトル/IDの正規化一致
+function normKey(s) { return normalizeV2(String(s || '')); }
+
+// 質問配列を 1 問に絞る（可能なら該当トラックを優先）
+function applyDailyRestriction(qs) {
+  if (!DAILY.active || !Array.isArray(qs) || qs.length === 0) return qs;
+  // 優先順位: ID → タイトル（正規化一致）
+  let idx = -1;
+  if (DAILY.wanted?.id) {
+    const target = normKey(DAILY.wanted.id);
+    idx = qs.findIndex(q => normKey(q?.track?.id) === target);
+  }
+  if (idx < 0 && DAILY.wanted?.title) {
+    const target = normKey(DAILY.wanted.title);
+    idx = qs.findIndex(q => normKey(q?.track?.title) === target);
+  }
+  if (idx < 0) idx = 0; // フォールバック
+  return [qs[idx]];
+}
+
+export { DAILY, detectDailyParam, initDaily, pickDailyWantedFromMap, applyDailyRestriction };
+


### PR DESCRIPTION
## Summary
- factor out daily mode state and helpers into new `daily.mjs`
- adjust `app.js` to use the extracted daily utilities
- document Phase 2 frontend split in architecture notes

## Testing
- `npm test` *(fails: clojure: not found)*
- `npm run e2e` *(fails: Cannot find module 'playwright')*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1260301f48324837f43367fb0598c