### PR TITLE
refactor: move result summary rendering

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -41,7 +41,7 @@ function ensureAliases() {
 }
 import { normalize as normalizeV2 } from './normalize.mjs';
 import { orderByYearBucket } from './question_pipeline.mjs';
-import { copyToClipboard, canonicalAppUrl, setupResultShare, openResultDialogA11y, closeResultDialogA11y } from './result-dialog.mjs';
+import { copyToClipboard, canonicalAppUrl, setupResultShare, openResultDialogA11y, closeResultDialogA11y, renderResultSummary } from './result-dialog.mjs';
 import { DAILY, detectDailyParam, initDaily, pickDailyWantedFromMap, applyDailyRestriction } from './daily.mjs';
 import { yieldToMain, getQueryParam, getQueryBool, xfnv1a, mulberry32 } from './utils-ui.mjs';
 import {
@@ -696,13 +696,8 @@ function showResult() {
   // 結果画面では定期更新を停止し、最終値を表示
   stopLivesTicker();
   recomputeMistakes();
-  const list = document.getElementById('summary-list');
-  list.innerHTML = '';
-  questions.forEach(q => {
-    const li = document.createElement('li');
-    li.textContent = `${TYPE_LABELS[q.type]} - ${q.correct ? '✅' : '❌'} - ${q.expected} - ${q.userAnswer || ''} - ${q.track.year} - ${q.track.game} - ${q.elapsed}s`;
-    list.appendChild(li);
-  });
+  // サマリー描画はモジュールへ集約（Codex整合：画面単位のまとまりで分割）
+  renderResultSummary(questions, TYPE_LABELS);
 
   // v2: 結果の共有導線（コピー／Share）をセットアップ
   setupResultShare(buildResultShareText);

--- a/public/app/result-dialog.mjs
+++ b/public/app/result-dialog.mjs
@@ -2,6 +2,29 @@
 
 // Depends only on DOM APIs and a provided share-text builder callback.
 
+/**
+ * 結果サマリーを描画（UIロジックのみ；データ加工は呼び出し側で完了している前提）
+ * @param {Array} questions - 出題配列（{type, correct, answer, track:{year,game}, elapsed} を想定）
+ * @param {Object} TYPE_LABELS - タイプごとの表示ラベル
+ * @param {HTMLElement} [listEl=document.getElementById('summary-list')]
+ */
+export function renderResultSummary(questions, TYPE_LABELS, listEl = document.getElementById('summary-list')) {
+  if (!Array.isArray(questions)) return;
+  if (!listEl) return;
+  listEl.innerHTML = '';
+  for (const q of questions) {
+    const li = document.createElement('li');
+    const mark = q && q.correct ? '✅' : '❌';
+    const ans = q && q.answer != null ? String(q.answer) : '';
+    const year = q && q.track && q.track.year != null ? q.track.year : '';
+    const game = q && q.track && q.track.game != null ? q.track.game : '';
+    const elapsed = (q && q.elapsed != null ? q.elapsed : '').toString();
+    const typeLabel = TYPE_LABELS && q ? (TYPE_LABELS[q.type] ?? String(q.type)) : '';
+    li.textContent = `${typeLabel} - ${mark} - ${ans} - ${year} - ${game} - ${elapsed}s`;
+    listEl.appendChild(li);
+  }
+}
+
 let _copyToastTimer = null;
 
 async function copyToClipboard(text) {
@@ -193,5 +216,5 @@ function closeResultDialogA11y(goStart = false) {
   _resultDialogPrevFocus = null;
 }
 
-export { copyToClipboard, canonicalAppUrl, setupResultShare, openResultDialogA11y, closeResultDialogA11y };
+export { copyToClipboard, canonicalAppUrl, setupResultShare, openResultDialogA11y, closeResultDialogA11y, renderResultSummary };
 


### PR DESCRIPTION
## Summary
- encapsulate result summary rendering in result-dialog module
- use renderResultSummary in showResult

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1348ba6f883248a0a7d64b34c2bba