### PR TITLE
docs: add DI guidelines for Phase 2

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,3 +84,32 @@
 ## フロントエンド（app/）の起動分割（v1.12 Phase 2）
 - `daily.mjs`: デイリーモードの状態（`DAILY`）とヘルパ（`detectDailyParam` / `initDaily` / `pickDailyWantedFromMap` / `applyDailyRestriction`）を集約。
 - `result-dialog.mjs`: 結果ダイアログのA11y制御と共有導線（コピー/Share）を集約。`setupResultShare(buildResultShareText)` を提供。
+
+### v1.12 Phase 2 — 集約単位と依存注入（DI）の原則
+
+**狙い**: 画面単位の分割を安全に進めるための基準を明文化する（Codex等のブレに依存しない）。
+
+#### 集約単位（最小スコープ）
+- **play-controller.mjs**（新設）  
+  責務: タイマー（`startCountdown` / `stopCountdown`）、残機（lives）監視、回答フロー（accept/reject/next）の集約。  
+  提供: `createPlayController(deps)` → `{ start(), stop(), onAnswer(cb), onTimeout(cb) }`。**DOM直接操作はしない**。
+- **media-select.mjs**（新設）  
+  責務: **Apple優先 → YouTubeフォールバック**の選択ロジックとプレーヤ初期化。  
+  提供: `createMediaSelector(deps)` → `{ pickFor(track), currentProvider(), teardown() }`。`providers.mjs` のIFのみに依存し、描画は呼び出し側。
+
+#### 依存注入（DI）
+- 原則: **モジュール単位のシングルトン禁止**。すべて **ファクトリ関数**で依存を受け取る。
+- 標準依存: `{ i18n, version, providers, storage, logger }`（必要なものだけ受け取り可）。
+- **app.js はオーケストレーター**: 起動時に `deps` を構築し、`play-controller` と `media-select` を生成して配線する。
+- テスト: `node --test` は **フェイク依存**（ダミー providers / fake storage）を注入。E2E は公開APIの挙動を確認。
+
+#### 挙動不変の原則（DoD）
+- UIの見た目・操作フローは **不変**。ARIA属性・イベント発火順も変更しない。
+- 既存 E2E（A11y/AUTO/結果ダイアログ）と Lighthouse が **緑**であること。
+- `public/app/app.js` からは **イベント配線のみ**が残り、ロジックは本節のモジュールへ移譲されている。
+
+#### 段階的抽出ガイド
+1) `play-controller` の骨格導入（`start/stop` と timeout のみ）→ E2E 緑  
+2) 残機と回答フローを移譲 → E2E 緑  
+3) `media-select` を導入し、Apple/YouTube 選択を移譲 → E2E 緑  
+4) リファクタ後に **差分レビュー**（提案との整合チェック）を実施。

--- a/docs/issues/v1_11.json
+++ b/docs/issues/v1_11.json
@@ -28,6 +28,7 @@
       "area:kpi",
       "area:ops"
     ],
-    "body": "### Scope\n- Discovery KPI: `official_rate`（公式ソース率）, `hit_rate`（正規化成功率）, `duplicate_ratio`（既存/近似重複率）, `fail_reasons_top3`\n- Harvest KPI: `with_provenance_rate`, `stub_ratio`, `dedup_pairs` と `θ≥0.7/0.8/0.9` 分布\n- Gate KPI: `auto_accept_rate`（θ≥閾値の割合）, `pr_queue_size`（PR送り件数）, `reject_top_reasons`\n- QUALITY_KPIS.md に Collector 章を追加し、**出力項目と算出式**を明文化\n\n### DoD\n- docs/QUALITY_KPIS.md に Collector KPI 章を追加（上記メトリクスを定義）\n- 各ワークフローの Step Summary で出力すべき**キー名**と**短い説明**をドキュメント化\n- 将来の実装時にドキュ差分なしで適用できる粒度まで具体化\n"
+    "body": "### Scope\n- Discovery KPI: `official_rate`（公式ソース率）, `hit_rate`（正規化成功率）, `duplicate_ratio`（既存/近似重複率）, `fail_reasons_top3`\n- Harvest KPI: `with_provenance_rate`, `stub_ratio`, `dedup_pairs` と `θ≥0.7/0.8/0.9` 分布\n- Gate KPI: `auto_accept_rate`（θ≥閾値の割合）, `pr_queue_size`（PR送り件数）, `reject_top_reasons`\n- QUALITY_KPIS.md に Collector 章を追加し、**出力項目と算出式**を明文化\n\n### DoD\n- docs/QUALITY_KPIS.md に Collector KPI 章を追加（上記メトリクスを定義）\n- 各ワークフローの Step Summary で出力すべき**キー名**と**短い説明**をドキュメント化\n- 将来の実装時にドキュ差分なしで適用できる粒度まで具体化\n",
+    "state": "closed"
   }
 ]

--- a/docs/issues/v1_12.json
+++ b/docs/issues/v1_12.json
@@ -71,5 +71,16 @@
     ],
     "body": "Scope:\n- プレイ制御（countdown / lives / answer フロー）を play-controller.mjs に集約（挙動不変）\n- メディア選択UI（Apple優先→YouTubeフォールバック）を media-select.mjs に分離（media_player.mjs と整合）\n- Codex整合の原則を ARCHITECTURE.md に明文化（画面単位の集約・DIでの依存注入）\nAlready Done (このチャット):\n- result-dialog.mjs（A11y/共有/サマリー描画）\n- daily.mjs（デイリー1問モード）\nDoD:\n- CI 緑（node-tests / docs-lint）\n- 手動検証（通常 / ?test=1）\n- 既存UI挙動の差異なし\n",
     "state": "open"
+  },
+  {
+    "id": "v112-architecture-di-guidelines",
+    "title": "v1.12: ARCHITECTURE.md に集約単位／依存注入（DI）の原則を追記",
+    "labels": [
+      "roadmap:v1.12",
+      "type:docs",
+      "area:architecture"
+    ],
+    "body": "### 背景\n- Phase 2（画面単位分割）に先立ち、**集約単位**（play-controller / media-select など）と**依存注入（DI）**の基準を明文化する。\n\n### 受け入れ基準（DoD）\n- ARCHITECTURE.md に『v1.12 Phase 2 — 集約単位と依存注入（DI）の原則』節を追加\n- 既存構成（Phase 1）との関係と責務境界が明確\n- 挙動不変を原則とする旨、およびテスト・E2E 影響の扱いを記載\n\n### 備考\n- 実装は `v112-refactor-ui-slim-phase2` と連動。先にドキュを確定させる。",
+    "state": "open"
   }
 ]


### PR DESCRIPTION
## Summary
- document Phase 2 module aggregation and dependency injection principles
- track architecture/DI guidelines in v1.12 issues and close v1.11 Collector KPI item

## Testing
- `npm test` *(fails: clojure not found)*
- `node scripts/docs_link_check.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68c141066da48324aae5e9fda9f08139