### PR TITLE
refactor: extract media provider selection

### DIFF
--- a/public/app/media-select.mjs
+++ b/public/app/media-select.mjs
@@ -1,0 +1,27 @@
+// media-select.mjs
+// Provider selection logic: Apple preference → YouTube fallback (+ ?provider override)
+// Keep DOM-free and UI-agnostic to allow unit tests.
+function q(name, d=location.search){ try{ return new URLSearchParams(d).get(name); }catch{ return null; } }
+
+export function chooseProvider(media){
+  const forced = (q('provider') || '').toLowerCase(); // dev flag: apple|youtube|auto
+  if (forced === 'apple' || forced === 'itunes') return 'apple';
+  if (forced === 'youtube' || forced === 'yt') return 'youtube';
+  // auto
+  if (media && media.apple && (media.apple.embedUrl || media.apple.previewUrl || media.apple.url)) return 'apple';
+  return media && media.provider ? media.provider : 'youtube';
+}
+
+export function createMediaSelector(/* deps */){
+  return {
+    pickFor(trackOrMedia){
+      const media = trackOrMedia && (trackOrMedia.media || trackOrMedia);
+      return { provider: chooseProvider(media), media };
+    },
+    currentProvider(media){
+      return chooseProvider(media && (media.media || media));
+    }
+  };
+}
+
+export default { createMediaSelector, chooseProvider };

--- a/public/app/media_player.mjs
+++ b/public/app/media_player.mjs
@@ -1,16 +1,8 @@
+import { chooseProvider } from './media-select.mjs';
 // Media player: Apple Music preview > YouTube fallback (+ test/LHCI stubbing)
 function secOf(ms) { return Math.max(0, Math.floor((ms || 0) / 1000)); }
 function q(name, d=location.search){ try{ return new URLSearchParams(d).get(name); }catch{ return null; } }
 function isFlagOn(name) { const v = q(name); return v === '1' || v === 'true'; }
-
-function chooseProvider(media){
-  const forced = (q('provider') || '').toLowerCase(); // dev flag: apple|youtube|auto
-  if (forced === 'apple' || forced === 'itunes') return 'apple';
-  if (forced === 'youtube' || forced === 'yt') return 'youtube';
-  // auto
-  if (media && media.apple && (media.apple.embedUrl || media.apple.previewUrl || media.apple.url)) return 'apple';
-  return media && media.provider ? media.provider : 'youtube';
-}
 
 function buildAppleEmbed(media){
   const root = document.createElement('div');


### PR DESCRIPTION
## Summary
- factor out media provider selection into new `media-select.mjs` module
- reuse shared `chooseProvider` logic in `media_player.mjs`

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1495e4c0c83249f08eee04b4d6809