### PR TITLE
Invoke post-answer hooks and recalc lives

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -648,6 +648,11 @@ function submitAnswer() {
   }
   q.userAnswer = rawInput;
   q.correct = correct;
+
+  // v1.12 Phase2: delegate post-answer hooks
+  try { if (window.__PLAY__ && typeof window.__PLAY__.afterAnswer === 'function') { window.__PLAY__.afterAnswer({ correct, remaining }); } } catch (_) {}
+  // Lives: 即時再集計とエンド判定（挙動不変: HUDのみ即時反映）
+  try { setTimeout(recomputeMistakes, 0); maybeEndGameByLives(); } catch (_) {}
   recordPlay({
     runId: currentRunId,
     trackId: trackId(q.track),


### PR DESCRIPTION
## Summary
- delegate after-answer hooks to `window.__PLAY__`
- recompute lives immediately and check for game end

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c14dc4b9788324b536e6a49ced91a5