### PR TITLE
refactor: use shared query helpers

### DIFF
--- a/public/app/media-select.mjs
+++ b/public/app/media-select.mjs
@@ -1,10 +1,10 @@
 // media-select.mjs
 // Provider selection logic: Apple preference → YouTube fallback (+ ?provider override)
 // Keep DOM-free and UI-agnostic to allow unit tests.
-function q(name, d=location.search){ try{ return new URLSearchParams(d).get(name); }catch{ return null; } }
+import { getQueryParam } from './utils-ui.mjs';
 
 export function chooseProvider(media){
-  const forced = (q('provider') || '').toLowerCase(); // dev flag: apple|youtube|auto
+  const forced = (getQueryParam('provider') || '').toLowerCase(); // dev flag: apple|youtube|auto
   if (forced === 'apple' || forced === 'itunes') return 'apple';
   if (forced === 'youtube' || forced === 'yt') return 'youtube';
   // auto

--- a/public/app/media_player.mjs
+++ b/public/app/media_player.mjs
@@ -1,8 +1,7 @@
 import { chooseProvider } from './media-select.mjs';
+import { getQueryParam, getQueryBool } from './utils-ui.mjs';
 // Media player: Apple Music preview > YouTube fallback (+ test/LHCI stubbing)
 function secOf(ms) { return Math.max(0, Math.floor((ms || 0) / 1000)); }
-function q(name, d=location.search){ try{ return new URLSearchParams(d).get(name); }catch{ return null; } }
-function isFlagOn(name) { const v = q(name); return v === '1' || v === 'true'; }
 
 function buildAppleEmbed(media){
   const root = document.createElement('div');
@@ -12,7 +11,7 @@ function buildAppleEmbed(media){
   root.setAttribute('aria-label','Media player (Apple Music)');
   const slot = document.createElement('div'); slot.id = 'media-inner'; root.appendChild(slot);
 
-  const stubOnly = isFlagOn('test') || isFlagOn('lhci') || isFlagOn('nomedia');
+  const stubOnly = getQueryBool('test') || getQueryBool('lhci') || getQueryBool('nomedia');
   if (stubOnly){
     const stub = document.createElement('div');
     stub.id = 'media-stub';
@@ -73,7 +72,7 @@ function buildYouTubeEmbed(media){
   root.setAttribute('aria-label','Media player (YouTube)');
   const slot = document.createElement('div'); slot.id = 'media-inner'; root.appendChild(slot);
 
-  const stubOnly = isFlagOn('test') || isFlagOn('lhci') || isFlagOn('nomedia');
+  const stubOnly = getQueryBool('test') || getQueryBool('lhci') || getQueryBool('nomedia');
   if (stubOnly){
     const stub = document.createElement('div');
     stub.id = 'media-stub';


### PR DESCRIPTION
## Summary
- use shared `getQueryParam` in media provider selector
- replace flag checks with `getQueryBool` in media player

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c158bb7dc083249d320e6182fa1e6e