### PR TITLE
Add unit tests for media selector and play controller

### DIFF
--- a/tests/media_select.test.mjs
+++ b/tests/media_select.test.mjs
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { chooseProvider, createMediaSelector } from '../public/app/media-select.mjs';
+
+test('chooseProvider respects ?provider override: apple', () => {
+  const orig = global.location;
+  global.location = { search: '?provider=apple' };
+  try {
+    const media = { youtube: { id: 'x' } };
+    assert.equal(chooseProvider(media), 'apple');
+  } finally {
+    global.location = orig;
+  }
+});
+
+test('chooseProvider respects ?provider override: youtube', () => {
+  const orig = global.location;
+  global.location = { search: '?provider=youtube' };
+  try {
+    const media = { apple: { previewUrl: '...' } };
+    assert.equal(chooseProvider(media), 'youtube');
+  } finally {
+    global.location = orig;
+  }
+});
+
+test('chooseProvider: auto prefers apple when available', () => {
+  const orig = global.location;
+  global.location = { search: '' };
+  try {
+    const media = { apple: { previewUrl: '...' }, youtube: { id: 'y' } };
+    assert.equal(chooseProvider(media), 'apple');
+  } finally {
+    global.location = orig;
+  }
+});
+
+test('chooseProvider: auto falls back to youtube', () => {
+  const orig = global.location;
+  global.location = { search: '' };
+  try {
+    const media = { youtube: { id: 'y' } };
+    assert.equal(chooseProvider(media), 'youtube');
+  } finally {
+    global.location = orig;
+  }
+});
+
+test('createMediaSelector.pickFor returns provider+media', () => {
+  const sel = createMediaSelector();
+  const ret = sel.pickFor({ media: { youtube: { id: 'y' } } });
+  assert.equal(ret.provider === 'apple' || ret.provider === 'youtube', true);
+  assert.ok(ret.media);
+});

--- a/tests/play_controller.test.mjs
+++ b/tests/play_controller.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createPlayController } from '../public/app/play-controller.mjs';
+
+test('start/stop set and clear timer', async (t) => {
+  let now = 0;
+  const pc = createPlayController({ now: () => now });
+  let timedOut = false;
+  pc.start(1000, { onTimeout: () => { timedOut = true; } });
+  // fast-forward "time"
+  now = 1500;
+  // wait a tick for interval (200ms) to check
+  await new Promise(r => setTimeout(r, 250));
+  assert.equal(timedOut, true);
+  pc.stop();
+});
+
+test('afterAnswer invokes onAnswer hook', () => {
+  const pc = createPlayController();
+  let got = null;
+  pc.onAnswer((p) => { got = p; });
+  pc.afterAnswer({ correct: true, remaining: 2 });
+  assert.deepEqual(got, { correct: true, remaining: 2 });
+});
+
+test('stop() is idempotent', () => {
+  const pc = createPlayController({ now: () => Date.now() });
+  pc.start(10, { onTimeout: () => {} });
+  pc.stop();
+  pc.stop();
+  // if no exception, pass
+  assert.ok(true);
+});


### PR DESCRIPTION
## Summary
- add Node.js tests covering query-parameter overrides and auto-selection logic in media-select
- add tests verifying timer and hooks in play controller

## Testing
- `node --test tests/*.mjs`
- `npm test` *(fails: clojure not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c159dd2fd08324a17d5e08383065a4