### PR TITLE
feat: add next hook to play controller

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -132,7 +132,11 @@ function initSeededRandom() {
 initSeededRandom();
 
 // v1.12 Phase 2: play-controller skeleton instance
-const __PLAY__ = createPlayController({ document, onTimeout: () => { try { submitAnswer(); } catch (_) {} try { nextQuestion(); } catch (_) {} } });
+const __PLAY__ = window.__PLAY__ = createPlayController();
+if (typeof nextQuestion === 'function' && window.__PLAY__ && typeof window.__PLAY__.onNext === 'function') {
+  // wire the next transition (behavior unchanged; just routed via controller)
+  window.__PLAY__.onNext(() => nextQuestion());
+}
 
 async function preloadDailyMap() {
   try {
@@ -593,9 +597,16 @@ function showQuestion() {
       break;
   }
   window.__expectedAnswer = q.expected;
-  __PLAY__.setTimerEnabled(useTimer);
-  __PLAY__.reset(20);
-  __PLAY__.start();
+  if (useTimer) {
+    __PLAY__.start(20000, {
+      onTimeout: () => {
+        try { submitAnswer(); } catch (_) {}
+        try { __PLAY__ && __PLAY__.next(); } catch (_) {}
+      }
+    });
+  } else {
+    try { __PLAY__.stop(); } catch (_) {}
+  }
 }
 
 function showHint() {

--- a/public/app/play-controller.mjs
+++ b/public/app/play-controller.mjs
@@ -6,7 +6,7 @@ export function createPlayController(deps = {}) {
   const { logger = console, now = () => Date.now() } = deps;
   let intervalId = null;
   let deadline = 0;
-  const hooks = { onTimeout: null, onAnswer: null };
+  const hooks = { onTimeout: null, onAnswer: null, onNext: null };
 
   function tick() {
     const remain = deadline - now();
@@ -47,8 +47,20 @@ export function createPlayController(deps = {}) {
   function onAnswer(cb) {
     hooks.onAnswer = cb;
   }
+  function onNext(cb) {
+    hooks.onNext = cb;
+  }
 
-  return { start, stop, afterAnswer, onAnswer };
+  // Flow entry: go to next question (callback is injected by app.js).
+  function next() {
+    try {
+      if (hooks.onNext) hooks.onNext();
+    } catch (e) {
+      try { logger && (logger.warn ? logger.warn(e) : logger.log(e)); } catch {}
+    }
+  }
+
+  return { start, stop, afterAnswer, onAnswer, onNext, next };
 }
 
 export default { createPlayController };


### PR DESCRIPTION
## Summary
- extend play controller with a next-question hook and dispatch method
- route app timer and question transitions through new controller API

## Testing
- `npm test` *(fails: clojure not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c15adbdf688324b8719cd7bc6d43b8