### PR TITLE
Add accept/reject hooks to play controller

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -633,6 +633,14 @@ function submitAnswer() {
   const scoreBar = document.getElementById('score-bar');
   const correct = userAns === expected;
   const aliasBtn = document.getElementById('propose-alias-btn');
+  // Phase2 hook routing（挙動不変）
+  try {
+    if (window.__PLAY__) {
+      if (correct && typeof window.__PLAY__.accept === 'function') window.__PLAY__.accept({ remaining });
+      if (!correct && typeof window.__PLAY__.reject === 'function') window.__PLAY__.reject({ remaining });
+      if (typeof window.__PLAY__.afterAnswer === 'function') window.__PLAY__.afterAnswer({ correct, remaining });
+    }
+  } catch (_) {}
   q.elapsed = 20 - remaining;
   document.querySelectorAll('#choices button').forEach(b => b.disabled = true);
   aliasBtn.style.display = 'none';
@@ -660,8 +668,6 @@ function submitAnswer() {
   q.userAnswer = rawInput;
   q.correct = correct;
 
-  // v1.12 Phase2: delegate post-answer hooks
-  try { if (window.__PLAY__ && typeof window.__PLAY__.afterAnswer === 'function') { window.__PLAY__.afterAnswer({ correct, remaining }); } } catch (_) {}
   // Lives: 即時再集計とエンド判定（挙動不変: HUDのみ即時反映）
   try { setTimeout(recomputeMistakes, 0); maybeEndGameByLives(); } catch (_) {}
   recordPlay({

--- a/public/app/play-controller.mjs
+++ b/public/app/play-controller.mjs
@@ -1,12 +1,12 @@
 // play-controller.mjs
-// v1.12 Phase2: timer & afterAnswer hook (no behavior change)
+// v1.12 Phase2: timer & afterAnswer/accept/reject hooks (no behavior change)
 // Keep this module DOM-free and UI-agnostic.
 
 export function createPlayController(deps = {}) {
   const { logger = console, now = () => Date.now() } = deps;
   let intervalId = null;
   let deadline = 0;
-  const hooks = { onTimeout: null, onAnswer: null, onNext: null };
+  const hooks = { onTimeout: null, onAnswer: null, onNext: null, onAccept: null, onReject: null };
 
   function tick() {
     const remain = deadline - now();
@@ -51,6 +51,28 @@ export function createPlayController(deps = {}) {
     hooks.onNext = cb;
   }
 
+  // Flow: accept/reject wrappers (behavior-neutral; only forward to hooks)
+  function accept(payload = {}) {
+    try {
+      if (hooks.onAccept) hooks.onAccept(payload);
+    } catch (e) {
+      try { logger && (logger.warn ? logger.warn(e) : logger.log(e)); } catch {}
+    }
+  }
+  function reject(payload = {}) {
+    try {
+      if (hooks.onReject) hooks.onReject(payload);
+    } catch (e) {
+      try { logger && (logger.warn ? logger.warn(e) : logger.log(e)); } catch {}
+    }
+  }
+  function onAccept(cb) {
+    hooks.onAccept = cb;
+  }
+  function onReject(cb) {
+    hooks.onReject = cb;
+  }
+
   // Flow entry: go to next question (callback is injected by app.js).
   function next() {
     try {
@@ -60,7 +82,7 @@ export function createPlayController(deps = {}) {
     }
   }
 
-  return { start, stop, afterAnswer, onAnswer, onNext, next };
+  return { start, stop, afterAnswer, onAnswer, onNext, next, accept, reject, onAccept, onReject };
 }
 
 export default { createPlayController };

--- a/tests/play_controller.test.mjs
+++ b/tests/play_controller.test.mjs
@@ -23,6 +23,18 @@ test('afterAnswer invokes onAnswer hook', () => {
   assert.deepEqual(got, { correct: true, remaining: 2 });
 });
 
+test('accept/reject invoke respective hooks', () => {
+  const pc = createPlayController();
+  let accepted = null;
+  let rejected = null;
+  pc.onAccept(p => { accepted = p; });
+  pc.onReject(p => { rejected = p; });
+  pc.accept({ remaining: 5 });
+  pc.reject({ remaining: 3 });
+  assert.deepEqual(accepted, { remaining: 5 });
+  assert.deepEqual(rejected, { remaining: 3 });
+});
+
 test('stop() is idempotent', () => {
   const pc = createPlayController({ now: () => Date.now() });
   pc.start(10, { onTimeout: () => {} });


### PR DESCRIPTION
## Summary
- forward accept/reject callbacks through play controller and expose hook registration
- invoke accept/reject/afterAnswer hooks from app submit logic
- test accept/reject hook wiring

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c15d8a5cf88324b262bff7a962563b