### PR TITLE
feat: wire lives HUD with play controller

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -137,6 +137,11 @@ if (typeof nextQuestion === 'function' && window.__PLAY__ && typeof window.__PLA
   // wire the next transition (behavior unchanged; just routed via controller)
   window.__PLAY__.onNext(() => nextQuestion());
 }
+if (window.__PLAY__ && typeof window.__PLAY__.wireLives === 'function') {
+  // Inject existing HUD recompute & end-check (no behavior change)
+  // These functions already exist in this module; we just pass references.
+  window.__PLAY__.wireLives({ recomputeMistakes, maybeEndGameByLives });
+}
 
 async function preloadDailyMap() {
   try {
@@ -668,8 +673,14 @@ function submitAnswer() {
   q.userAnswer = rawInput;
   q.correct = correct;
 
-  // Lives: 即時再集計とエンド判定（挙動不変: HUDのみ即時反映）
-  try { setTimeout(recomputeMistakes, 0); maybeEndGameByLives(); } catch (_) {}
+  // Lives: route through controller if available to keep sequencing identical
+  try {
+    if (window.__PLAY__ && typeof window.__PLAY__.refreshLives === 'function') {
+      window.__PLAY__.refreshLives();
+    } else {
+      setTimeout(recomputeMistakes, 0); maybeEndGameByLives();
+    }
+  } catch (_) {}
   recordPlay({
     runId: currentRunId,
     trackId: trackId(q.track),

--- a/public/app/play-controller.mjs
+++ b/public/app/play-controller.mjs
@@ -7,6 +7,9 @@ export function createPlayController(deps = {}) {
   let intervalId = null;
   let deadline = 0;
   const hooks = { onTimeout: null, onAnswer: null, onNext: null, onAccept: null, onReject: null };
+  // lives HUD & end-check (wired from app.js; kept optional)
+  let _recomputeMistakes = null;
+  let _maybeEndGameByLives = null;
 
   function tick() {
     const remain = deadline - now();
@@ -82,7 +85,27 @@ export function createPlayController(deps = {}) {
     }
   }
 
-  return { start, stop, afterAnswer, onAnswer, onNext, next, accept, reject, onAccept, onReject };
+  // --- Lives wiring (DI) ---
+  function wireLives({ recomputeMistakes, maybeEndGameByLives } = {}) {
+    _recomputeMistakes = typeof recomputeMistakes === 'function' ? recomputeMistakes : null;
+    _maybeEndGameByLives = typeof maybeEndGameByLives === 'function' ? maybeEndGameByLives : null;
+  }
+  // Keep behavior identical to historical sequence:
+  // schedule recompute via setTimeout(0) and then invoke end-check sync.
+  function refreshLives() {
+    try {
+      if (_recomputeMistakes) setTimeout(() => { try { _recomputeMistakes(); } catch(e) {} }, 0);
+      if (_maybeEndGameByLives) _maybeEndGameByLives();
+    } catch (e) {
+      try { logger && (logger.warn ? logger.warn(e) : logger.log(e)); } catch {}
+    }
+  }
+
+  return {
+    start, stop, afterAnswer, onAnswer, onNext, next,
+    accept, reject, onAccept, onReject,
+    wireLives, refreshLives
+  };
 }
 
 export default { createPlayController };


### PR DESCRIPTION
## Summary
- expose hooks to recompute and check lives via play controller
- route lives handling through controller in app

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1601575588324821e27e31f13ab0c