### PR TITLE
Seed localized title from query parameter

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -12,6 +12,14 @@
       var lang = p.get('lang');
       if (lang) {
         document.documentElement.setAttribute('lang', lang);
+        // Seed <title> early so E2E can assert localized title without waiting for modules.
+        // i18n.mjs may later normalize; this is a harmless early hint.
+        var t = document.title || '';
+        if (lang === 'ja') {
+          if (!/VGM.?クイズ/.test(t)) document.title = 'VGMクイズ';
+        } else if (lang === 'en') {
+          if (!/VGM.?Quiz/.test(t)) document.title = 'VGM Quiz';
+        }
       }
     } catch (e) {}
   })();


### PR DESCRIPTION
## Summary
- Early-seed page title based on `lang` query parameter for EN and JA

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: repository InRelease not signed; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c224c86ec08324b6e1486b72a0bd44