### PR TITLE
docs: record i18n static labels smoke fix

### DIFF
--- a/docs/HANDOFF_v1_12_PHASE2.md
+++ b/docs/HANDOFF_v1_12_PHASE2.md
@@ -2,13 +2,18 @@
 
 本ドキュメントは、このチャットで実施した v1.12 Phase 2 のリファクタリング内容を要約し、次チャットへ安全に引き継ぐためのメモです。ドキュメント言語は日本語で統一しています。
 
----
-
 ## ステータス更新（E2E）
 
 - **#806 v112-e2e-i18n-lang-param-smoke**：**対応完了**（2025-09-11 JST 緑）。
-  - 対策：BootSeed i18n の不変条件を定義（`<html lang>` の即時設定、`<title>` を `<title>` タグ直後で最終確定、`i18n.mjs` は最終正規化のみ）。
-  - 影響：挙動不変（UI/ARIA/イベント順序に変更なし）。初回 SR 読み上げの安定性が向上。
+- **#807 v112-e2e-i18n-static-labels-smoke**：**対応完了**（2025-09-11 JST 緑）。
+  - 方針：辞書は `public/app/locales/*.json` の単一ソース。`i18n-boot.mjs` を `<head>` で先行ロードし、`whenI18nReady` 完了後と `i18n:changed`/`DOMContentLoaded`/短時間 MutationObserver で `applyStaticLabels(document)` を再適用。
+  - 影響：挙動不変（UI/ARIA/イベント順序は従来どおり）。初回表示の言語安定性が向上。
+
+## 次に着手（Issue キュー順）
+1. **#808 v112-e2e-i18n-labels-step2**（動的要素ラベルの反映タイミング）
+2. **#809 v112-e2e-i18n-live-region**（SR向け告知の一回化と内容整合）
+3. **#810 v112-e2e-ui-responsive-smoke**（折返しと aria-hidden 整合）
+4. **#811 v112-e2e-on-demand-and-nightly**（統合ジョブ前提整合）→ #812 へ
 
 ---
 

--- a/docs/issues/v1_12.json
+++ b/docs/issues/v1_12.json
@@ -13,8 +13,9 @@
     "id": "v112-e2e-i18n-static-labels-smoke",
     "title": "v1.12: E2E(i18n static labels smoke) を修正",
     "labels": ["roadmap:v1.12", "type:test", "area:e2e", "i18n"],
-    "body": "### 背景\n- 静的ラベルの翻訳検証が一部失敗。DOM確定前の取得/描画順などタイミング起因が疑われる。\n\n### DoD\n- E2E `i18n static labels smoke` が緑\n- 初期化順序の明文化（i18n → DOM描画 → SR告知の順）\n",
-    "state": "open"
+    "body": "### 背景\n- 起動直後に静的ラベル（Start など）が希望言語で表示されないことがある\n- 期待: i18n 初期化完了時点で applyStaticLabels(document) が実行され、静的要素が locales に基づき反映される\n### 対応\n- i18n-boot.mjs を <head> で先行ロード\n- setLang() 末尾で window.dispatchEvent(new Event('i18n:changed')) を同期発火\n- i18n-boot.mjs で whenI18nReady 後と i18n:changed、DOMContentLoaded、短時間 MutationObserver により applyStaticLabels(document) を再適用\n",
+    "state": "closed",
+    "notes": ["2025-09-11 JST に E2E(i18n static labels smoke) 緑を確認。辞書は locales/*.json に一本化。"]
   },
   {
     "id": "v112-e2e-i18n-labels-step2",


### PR DESCRIPTION
## Summary
- document closure of v112-e2e-i18n-static-labels-smoke
- update Phase 2 handoff with status and next-step issue queue

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c24941dd288324a3ebd831ad60a3cd