### PR TITLE
docs: close issues 808, 807, 806

### DIFF
--- a/docs/issues/state.json
+++ b/docs/issues/state.json
@@ -76,7 +76,7 @@
     {
       "number": 808,
       "title": "v1.12: E2E(i18n labels step2) を修正",
-      "state": "open",
+      "state": "closed",
       "html_url": "https://github.com/nantes-rfli/vgm-quiz/issues/808",
       "labels": [
         "type:test",
@@ -94,7 +94,7 @@
     {
       "number": 807,
       "title": "v1.12: E2E(i18n static labels smoke) を修正",
-      "state": "open",
+      "state": "closed",
       "html_url": "https://github.com/nantes-rfli/vgm-quiz/issues/807",
       "labels": [
         "type:test",
@@ -112,7 +112,7 @@
     {
       "number": 806,
       "title": "v1.12: E2E(i18n lang param smoke) を修正",
-      "state": "open",
+      "state": "closed",
       "html_url": "https://github.com/nantes-rfli/vgm-quiz/issues/806",
       "labels": [
         "type:test",


### PR DESCRIPTION
## Summary
- mark v1.12 E2E i18n issues 808, 807, 806 as closed in issue state registry

## Testing
- `npm test` *(fails: clojure: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c2543307f88324aa92b0da40b0b805