### PR TITLE
Handle feedback live region initialization

### DIFF
--- a/docs/a11y.md
+++ b/docs/a11y.md
@@ -7,6 +7,7 @@ This project aims to provide an accessible experience with a lightweight markup-
 - **Landmarks**: `<main id="main">` is present; footer has `role="contentinfo"`; skip link `Skip to main content` exists.
 - **Labels**: Form controls have a label or `aria-label`/`aria-describedby`. Choice buttons expose `aria-pressed`.
 - **Live regions**: Feedback (#feedback) and toasts use `role="status" aria-live="polite"` (atomic where needed).
+**Note (v1.12)**: 初期アナウンスは `#feedback` に `aria-live="polite" role="status"` で書き込みます。文言は `a11y.ready` を使用し、`i18n-boot.mjs` → `seedLiveRegion()` の順で一度だけ非空化します（言語切替時は `i18n:changed` で再シード）。
 - **Dialogs**: Result view uses `role="dialog"` + `aria-modal="true"` and gets focus on open, returns it on close.
 
 ## Developer checklist

--- a/public/app/i18n.mjs
+++ b/public/app/i18n.mjs
@@ -112,12 +112,13 @@ export function seedLiveRegion(doc = document) {
   try {
     const root = doc || document;
     const live =
+      root.getElementById('feedback') ||
+      root.getElementById('sr-live') ||
       root.querySelector('[role="status"][aria-live]') ||
       root.querySelector('[aria-live="polite"]') ||
-      root.querySelector('[aria-live="assertive"]') ||
-      root.getElementById('sr-live');
+      root.querySelector('[aria-live="assertive"]');
     if (!live) return;
-    const keys = ['live.ready', 'aria.ready', 'sr.ready', 'ui.start', 'common.ready', 'app.title'];
+    const keys = ['a11y.ready', 'live.ready', 'aria.ready', 'sr.ready', 'ui.start', 'common.ready', 'app.title'];
     let msg = '';
     for (const k of keys) {
       try {


### PR DESCRIPTION
## Summary
- seed `#feedback` or `#sr-live` as the first live region and include `a11y.ready` in i18n seeding
- document initial a11y announcement in `docs/a11y.md`

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c25452293c83249394c700fb5366ba