### PR TITLE
feat: load dataset immediately in test modes

### DIFF
--- a/docs/DEV_TIPS.md
+++ b/docs/DEV_TIPS.md
@@ -1,4 +1,35 @@
-# DEV Tips
+# E2E: Start ボタンが有効にならない場合の切り分け（v1.12）
+
+症状: `e2e/test_i18n_a11y_live_region_smoke.mjs` が `start-btn` のクリックで 30s タイムアウト。
+
+原因: 本番では `requestIdleCallback` でデータセットを遅延ロードしているため、E2E/検証でも待ち続けて Start が `disabled` のままになることがある。
+
+対処（アプリ側・最小差分）: `public/app/app.js` にて、**`?test=1` または `?mock=1` の場合は即時 `loadDataset()`** する（本番は従来どおり idle）。
+
+---
+
+## 目視チェック（DevTools コンソール）
+
+以下を貼り付けて返り値を確認する。
+
+```js
+new URL(location).searchParams.toString();               // -> 'test=1&mock=1&...'
+document.querySelector('#feedback')?.textContent?.trim(); // -> '準備OK...' (ja) / 'Ready...' (en)
+document.querySelector('#start-btn')?.disabled;           // -> false が期待値
+performance.getEntriesByType('resource')
+  .map(e => e.name)
+  .filter(n => /mock|dataset/i.test(n));                  // -> mock/dataset.json が含まれる
+document.documentElement.lang;                            // -> 'ja' / 'en'
+```
+
+## 実装ポリシー
+
+- 本番挙動（ユーザー体験）は不変。E2E/検証モードでのみ即時ロードする。
+- Start の有効化は `datasetLoaded` を真にしてから `updateStartButton()` を呼ぶ従来経路を維持する。
+
+---
+
+# 既存の開発メモ
 
 ## Service Worker のキャッシュを無効化して確認したい
 1. DevTools → Application → Service Workers → **Unregister**。
@@ -9,8 +40,3 @@
 - Artifacts: `e2e/screenshots/footer.png` / `footer.html` を確認。
 - SW のキャッシュ影響が疑わしい場合は上記手順で解除。
 - バージョン文字列の形式: `Dataset: <ds> • commit: <abcdef0|local> [• updated: YYYY-MM-DD HH:MM]`。
-
-## E2E で Start ボタンが有効にならないとき
-- `?test=1` または `?mock=1` のときは **データセットの読み込みを即時実行** する（通常時は `requestIdleCallback` で後回し）。
-- これにより、`datasetLoaded` フラグが速やかに `true` になり、`#start-btn` が **enabled** になる。
-- 影響範囲は E2E/検証モードのみで、**本番挙動（遅延ロード）には影響しない**。

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -288,6 +288,8 @@ async function loadDataset() {
     const data = await parseJsonOffMainThread(txt);
     tracks = data.tracks || data; // 互換
     datasetLoaded = true;
+    try { window.__DATASET_READY__ = true; } catch(_) {}
+    try { console.info('[DATASET] ready (tracks=%s)', Array.isArray(tracks) ? tracks.length : 'n/a'); } catch(_) {}
     updateStartButton();
   } catch (err) {
     console.error('Failed to load dataset', err);
@@ -861,17 +863,21 @@ updateStartButton();
 console.log('features', { mode: questionMode === 'multiple-choice' ? 'MC' : 'Free', timer: useTimer ? '20s' : 'off' });
 
 checkOnLoad();
+// Dataset の読み込みタイミング：本番は idle、E2E/検証（?test=1 or ?mock=1）は即時
 {
   const ric = window.requestIdleCallback || (cb => setTimeout(cb, 1));
-  // In CI/E2E (test=1) or mock=1, load dataset immediately so Start becomes enabled promptly.
-  const __TEST_MODE__ = __SEARCH_PARAMS__.get('test') === '1';
-  const __MOCK_MODE__ = __SEARCH_PARAMS__.get('mock') === '1';
-  if (__TEST_MODE__ || __MOCK_MODE__) {
-    try { datasetPromise = loadDataset(); } catch(e){}
+  const isTest = (typeof __IS_TEST_MODE__ !== 'undefined') && __IS_TEST_MODE__ === true;
+  let isMock = false;
+  try { isMock = (new URLSearchParams(location.search).get('mock') === '1'); } catch(_) {}
+  const kick = () => { try { datasetPromise = loadDataset(); } catch(e){} };
+  if (isTest || isMock) {
+    // E2E/検証モード：Start を待たせないため即時ロード
+    kick();
   } else {
-    ric(() => { try { datasetPromise = loadDataset(); } catch(e){} });
+    // 本番：アイドル時にロード
+    ric(kick);
   }
-  // [perf] defer aliases: load after Start button (startQuiz)
+  // [perf] defer aliases: load after Start button (startQuiz) / keep as-is
   // ric(() => { try { ensureAliases(); } catch(e){} });
 }
 


### PR DESCRIPTION
## Summary
- expose `__DATASET_READY__` flag and log when dataset loads
- load dataset immediately in test/mock modes, otherwise wait for idle
- document troubleshooting steps when Start button stays disabled

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c265effcc08324af6eb5d8e44ef2b6