### PR TITLE
Wait for start button enable in live region test

### DIFF
--- a/e2e/test_i18n_a11y_live_region_smoke.mjs
+++ b/e2e/test_i18n_a11y_live_region_smoke.mjs
@@ -38,6 +38,8 @@ import { chromium } from 'playwright';
   }
   // Start the quiz (ensure the button is visible before clicking)
   await page.waitForSelector('[data-testid="start-btn"]', { state: 'visible', timeout: TIMEOUT });
+  // Start が disabled のままなら、最大30sまで有効化を待ってからクリック
+  await page.waitForSelector('#start-btn:not([disabled])', { timeout: 30000 });
   await page.click('[data-testid="start-btn"]');
 
   // Choices can exist immediately but be mid-transition / off-visibility.


### PR DESCRIPTION
## Summary
- ensure live region E2E waits for Start button to become enabled before click

## Testing
- `npm test` *(fails: clojure: not found)*
- `node e2e/test_i18n_a11y_live_region_smoke.mjs` *(fails: Cannot find package 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68c2681796d0832495c1f0e3dbbd9362