### PR TITLE
fix: avoid duplicate export

### DIFF
--- a/public/app/result-dialog.mjs
+++ b/public/app/result-dialog.mjs
@@ -8,7 +8,7 @@
  * @param {Object} TYPE_LABELS - タイプごとの表示ラベル
  * @param {HTMLElement} [listEl=document.getElementById('summary-list')]
  */
-export function renderResultSummary(questions, TYPE_LABELS, listEl = document.getElementById('summary-list')) {
+function renderResultSummary(questions, TYPE_LABELS, listEl = document.getElementById('summary-list')) {
   if (!Array.isArray(questions)) return;
   if (!listEl) return;
   listEl.innerHTML = '';
@@ -216,5 +216,5 @@ function closeResultDialogA11y(goStart = false) {
   _resultDialogPrevFocus = null;
 }
 
-export { copyToClipboard, canonicalAppUrl, setupResultShare, openResultDialogA11y, closeResultDialogA11y, renderResultSummary };
+export { renderResultSummary, copyToClipboard, canonicalAppUrl, setupResultShare, openResultDialogA11y, closeResultDialogA11y };
 


### PR DESCRIPTION
## Summary
- avoid duplicate exports by exporting result summary helper once with others

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2841145ac8324834f5c6a3c2886aa