### PR TITLE
Skip dataset error warning during mock mode

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -293,13 +293,14 @@ async function loadDataset() {
     const playable = (Array.isArray(tracks) ? tracks : []).filter(t =>
       t && t.media && t.media.provider && t.answers
     ).length;
-    if (!playable) {
-      const qs = new URLSearchParams(location.search || '');
-      const hasMock = qs.get('mock') === '1' || qs.has('mock');
+    // モック時(?mock=1)は“公開データに〜”の注意を出さない（紛らわしいため）
+    const qs = new URLSearchParams(location.search || '');
+    const hasMock = qs.get('mock') === '1' || qs.has('mock');
+    if (!playable && !hasMock) {
       const msg = document.getElementById('dataset-error');
       if (msg) {
         msg.innerHTML = '公開データに再生可能な問題がありません（media/provider/answers が不足）。' +
-          (hasMock ? '' : ' <a href="?mock=1">テストデータで起動する</a>');
+          ' <a href="?mock=1">テストデータで起動する</a>';
         msg.style.display = 'block';
       }
       // Start ボタンに理由を付記（UIスリムの契約は維持：Start は無効のまま）


### PR DESCRIPTION
## Summary
- avoid showing dataset error when `?mock=1` is present to reduce confusion

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: The repository is not signed; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c28d2ab47483249f950014573a41f5