### PR TITLE
chore(e2e): bridge console logs for i18n smoke

### DIFF
--- a/e2e/test_i18n_a11y_live_region_smoke.mjs
+++ b/e2e/test_i18n_a11y_live_region_smoke.mjs
@@ -31,6 +31,17 @@ import { chromium } from 'playwright';
 
   // ---- JA ----
   await page.goto(urlWith(base, 'ja'));
+  // Bridge page console to CI logs for deeper diagnostics
+  page.on('console', msg => {
+    try {
+      console.log(`[APP:${msg.type()}] ${msg.text()}`);
+    } catch {}
+  });
+  console.log(`[E2E] url(ja)=${page.url()}`);
+  // Ensure app shell is present before proceeding
+  try {
+    await page.waitForSelector('#feedback, #start-view, #app, #app-root', { timeout: 20000 });
+  } catch {}
   await page.waitForFunction(() => document.documentElement.lang === 'ja', null, { timeout: TIMEOUT });
   const liveStartJa = await page.textContent('#feedback');
   if (!liveStartJa || !/準備OK/.test(liveStartJa)) {


### PR DESCRIPTION
## Summary
- log page console output to aid diagnostics in i18n live-region smoke test
- wait for app shell before language assertion

## Testing
- `npm test` *(fails: clojure: not found)*
- `node e2e/test_i18n_a11y_live_region_smoke.mjs` *(fails: Cannot find package 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68c2cce2d3a48324a99bf4fb0eb497ec