### PR TITLE
Accept 'mc' shorthand for multiple-choice mode

### DIFF
--- a/public/app/version.mjs
+++ b/public/app/version.mjs
@@ -60,7 +60,9 @@ const SETTINGS_KEY = 'quiz-options';
 function loadSettings() {
   try {
     const s = JSON.parse(localStorage.getItem(SETTINGS_KEY)) || {};
-    const q = new URLSearchParams(location.search).get('mode');
+    let q = new URLSearchParams(location.search).get('mode');
+    // URLの省略表記を許可：mode=mc → multiple-choice（後方互換・本番挙動は不変）
+    if (q === 'mc') q = 'multiple-choice';
     if (q === 'multiple-choice' || q === 'free') {
       s.mode = q;
     }


### PR DESCRIPTION
## Summary
- Allow query parameter `mode=mc` as shorthand for `multiple-choice`

## Testing
- `npm test` *(fails: `clojure: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68c372816b60832489dbf108b187a2e5