### PR TITLE
docs: document mode query param

### DIFF
--- a/docs/urls-and-params.md
+++ b/docs/urls-and-params.md
@@ -45,6 +45,7 @@
 | `lhci` | `?lhci=1` | Stub media for Lighthouse |
 | `nomedia` | `?nomedia=1` | Manually stub media |
 | `lives` | `?lives=on` / `?lives=5` | End immediately when misses reach limit |
+| `mode` | `?mode=multiple-choice` / `?mode=free` | 回答モードの強制切替（MC/Free）。**省略表記** `mode=mc` も受理（`multiple-choice` と同義）。 |
 
 
 #### provider（dev）


### PR DESCRIPTION
## Summary
- document mode query flag for switching between multiple-choice and free answer modes

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3736e1dbc83249bec58971e0c1072