### PR TITLE
docs: close E2E on-demand/nightly issue

### DIFF
--- a/docs/e2e-on-demand-and-nightly-result.md
+++ b/docs/e2e-on-demand-and-nightly-result.md
@@ -1,0 +1,23 @@
+# E2E: On-demand / Nightly（#811）結果
+
+## 結果（2025-09-12）
+- **緑化**：on-demand / nightly ともにパス。
+
+## 主な修正（E2E専用・本番不変）
+1. Start ボタンの **visible 依存を撤廃**。presence+enabled を満たせば、可視なら通常クリック、不可視でも **programmatic click** を許可。
+2. 開始後の **UI差（MC/Free）に非依存**とするため、`#choices button` と `#free-answer, #answer-input, #answer, [data-testid="answer"]` をいずれも待機対象に。
+3. **結果クローズ後の復帰**は寛容に判定：
+   - A) `#result-view` 非表示 かつ `#feedback` が `準備OK|Ready` を含む、または
+   - B) `#start-view` 可視 & `#question-view` 非可視。
+   - 満たさない場合は**診断のみ**で非致命（本テストの主目的は結果モーダルの a11y 検証）。
+
+## ログ例（一部）
+```
+[E2E URL] https://.../app/?test=1&mock=1&seed=e2e&autostart=0
+[OK] free-mode A11y structure checks passed
+[footer-version] Dataset: v1 • commit: …
+```
+
+## 備考
+- すべて **E2Eの堅牢化**であり、アプリ本番挙動には影響しない。
+

--- a/docs/issues/v1_12.json
+++ b/docs/issues/v1_12.json
@@ -59,13 +59,13 @@
     "title": "v1.12: E2E(on-demand + nightly) を修正",
     "labels": ["roadmap:v1.12", "type:ci", "area:workflow", "area:e2e"],
     "body": "### 背景\n- on-demand と nightly の統合ジョブで、期待アーティファクト/前提の差異により失敗。\n\n### DoD\n- E2E `on-demand + nightly` が緑\n- 期待アーティファクト（URL/パス/生成物）と事前ステップ（build/prepare）の整合を明文化\n",
-    "state": "open",
+    "state": "closed",
     "notes": [
-      "2025-09-12: nightly-prod で test_results_modal_a11y.mjs が start-btn の visible 待ちで 30s timeout。",
-      "実ログ: locator('[data-testid=\"start-btn\"]').visible を待機 → hidden のまま。ボタン自体は存在し enabled。",
-      "原因仮説: レイアウト/レスポンシブによる可視条件の相違、または autostart=0 の状態で free/MC可視差。",
-      "対応方針（E2E専用・本番不変）: start の可視依存を排し、presence + enabled を条件に可視なら通常クリック、不可視なら programmatic click のフェイルセーフを適用。",
-      "結果モーダルのa11y検証（role=dialog/aria-*）が本テストの主目的のため、開始までの可視条件には依存しない設計に改める。"
+      "2025-09-12: nightly / on-demand とも緑化を確認。",
+      "原因：Start ボタンの visible 依存で 30s timeout（存在・enabled でも hidden だと待ち続ける）。",
+      "対応（E2E専用・本番不変）：presence+enabled を条件に、可視なら通常クリック／不可視なら programmatic click にフォールバック。",
+      "開始後は MC/Free いずれのUIでも先へ進めるよう、選択肢と自由入力セレクタを網羅。",
+      "結果クローズ後は“開始状態”のサイン（準備OK or start-view可視 & question-view非可視）で寛容に判定。"
     ]
   },
   {


### PR DESCRIPTION
## Summary
- mark `v112-e2e-on-demand-and-nightly` issue as closed with notes
- document the on-demand/nightly E2E result

## Testing
- `npm test` *(fails: clojure not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a703a870832489e4f83eb98ec2f2