### PR TITLE
Log playable track count

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -293,6 +293,7 @@ async function loadDataset() {
     const playable = (Array.isArray(tracks) ? tracks : []).filter(t =>
       t && t.media && t.media.provider && t.answers
     ).length;
+    try { console.info('[PLAYABLE] count=%s', playable); } catch(_) {}
     // モック時(?mock=1)は“公開データに〜”の注意を出さない（紛らわしいため）
     const qs = new URLSearchParams(location.search || '');
     const hasMock = qs.get('mock') === '1' || qs.has('mock');


### PR DESCRIPTION
## Summary
- add console.info to log playable track count after dataset load

## Testing
- `npm test` (fails: clojure: not found)
- `apt-get update` (fails: repository 403, cannot install clojure)


------
https://chatgpt.com/codex/tasks/task_e_68c3d1c45bd883248738616b5c7c9f13