### PR TITLE
Enable early start button activation and i18n mutation observer

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -310,7 +310,15 @@ async function loadDataset() {
     }
 
     try { window.__DATASET_READY__ = true; } catch(_) {}
-    try { console.info('[DATASET] ready (tracks=%s)', Array.isArray(tracks) ? tracks.length : 'n/a'); } catch(_) {}
+    try { console.info('[DATASET] ready (tracks=%s)', playable); } catch(_) {}
+    // ★ Start 有効化を i18n とは独立に前倒し（仕様: playable≥1 を維持）
+    try {
+      const startBtn = document.getElementById('start-btn');
+      if (startBtn && playable >= 1) {
+        startBtn.removeAttribute('disabled');
+        startBtn.setAttribute('aria-disabled', 'false');
+      }
+    } catch {}
     updateStartButton();
   } catch (err) {
     console.error('Failed to load dataset', err);

--- a/public/app/i18n-boot.mjs
+++ b/public/app/i18n-boot.mjs
@@ -22,16 +22,29 @@ if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', __applyStaticAll, { once: true });
 }
 
-// Short bootstrap observation window: if components mount after init,
-// localize them using the canonical locales/*.json via applyStaticLabels.
-(function __i18nBootstrapObserve(){
-  try {
-    const stopAt = Date.now() + 3000;
-    const mo = new MutationObserver(() => {
+// DOMの変化を監視して i18n を適用（rAFデバウンス＋再入防止）
+let __i18nApplying = false;
+let __i18nScheduled = false;
+function scheduleI18nApply() {
+  if (__i18nScheduled) return;
+  __i18nScheduled = true;
+  const raf = window.requestAnimationFrame || (cb => setTimeout(cb, 16));
+  raf(() => {
+    __i18nScheduled = false;
+    if (__i18nApplying) return; // すでに実行中なら次フレームへ委譲
+    __i18nApplying = true;
+    try {
       __applyStaticAll();
-      if (Date.now() > stopAt) { try { mo.disconnect(); } catch {} }
-    });
-    mo.observe(document.documentElement, { childList: true, subtree: true });
-    setTimeout(() => { try { mo.disconnect(); } catch {} }, 3500);
-  } catch {}
-})();
+    } finally {
+      __i18nApplying = false;
+    }
+  });
+}
+const mo = new MutationObserver(muts => {
+  // 無関係な属性変更は無視して負荷を下げる
+  const interesting = muts.some(m => m.type === 'childList' || (m.type === 'attributes' && /^(lang|dir|data-i18n)/.test(m.attributeName || '')));
+  if (interesting) scheduleI18nApply();
+});
+mo.observe(document.documentElement, { subtree:true, childList:true, attributes:true, attributeFilter:['lang','dir'] });
+// 初回適用も同一経路で
+scheduleI18nApply();


### PR DESCRIPTION
## Summary
- Unlock Start button as soon as dataset loads and log playable counts
- Debounce i18n updates with rAF and MutationObserver for DOM changes

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ddf2ed648324ad6e00658b5398b7