### PR TITLE
docs: note production i18n delay & footer fixes

### DIFF
--- a/docs/issues/v1_12.json
+++ b/docs/issues/v1_12.json
@@ -167,14 +167,27 @@
   {
     "id": "v112-prod-i18n-start-flicker",
     "title": "本番: 初期数秒の英語表示＆ボタン無効 → 数秒後に日本語＆有効",
-    "state": "open",
+    "state": "closed",
     "priority": "High",
     "notes": [
       "現象: 初期ロード直後は英語ラベル（例: Start）で、数秒間 Start/他ボタンが押せない。数秒後に日本語表示（スタート）かつ押下可能に変化。",
       "観測: i18n/resources と dataset の取得は ~200ms 程度だが、DevToolsで i18n.mjs / i18n-boot.mjs 周辺の Microtasks が長時間走り、メインスレッドを専有している。Startの無効化は属性（disabled）で制御。",
       "再現URL: https://nantes-rfli.github.io/vgm-quiz/app/",
       "対処: (1) playable≥1 到達時に Start の disabled を即解除（i18nに非依存）。(2) i18n MutationObserver を rAF デバウンスし、再入を防止。",
-      "DoD: 初期描画から主要ラベルがロケールに一致、Start 無効期間の短縮または明示的な準備中表示（a11y対応）。E2E影響なし。"
+      "2025-09-12: 本番で改善を確認（ハードリロード後 1〜2s で Start 押下可能・主要ラベルが日本語化）。",
+      "E2E への影響なし（テスト専用の堅牢化は不変）。"
+    ]
+  },
+  {
+    "id": "v112-prod-footer-empty",
+    "title": "本番: フッター要素は可視だがテキストが空",
+    "state": "closed",
+    "priority": "Medium",
+    "notes": [
+      "観測: footer#version は display:block で高さありだが textContent が空。",
+      "関連: build/version.json は fetch できている（~12ms）。dataset.json も取得済み。",
+      "対応: DOMContentLoaded で footer を常時 populate（build/version.json / dataset.json から生成、フェイルセーフ付き）。",
+      "2025-09-12: 本番で常時表示を確認（Start 解禁と同時期に表示）。"
     ]
   }
 ]

--- a/docs/prod-i18n-start-footer-result.md
+++ b/docs/prod-i18n-start-footer-result.md
@@ -1,0 +1,19 @@
+# 本番: 初期i18n遅延とフッター空表示の解消（結果）
+
+## 結果（2025-09-12）
+- ハードリロード後 **1〜2秒で Start 押下可能**、主要ラベルも同時期に日本語化。
+- フッターは **常時表示**（`Dataset • commit • updated`、フェイルセーフあり）。
+
+## 原因（事実）
+- DevTools 計測で **i18n-boot / i18n** 周辺の *Microtasks* がメインスレッドを占有し、+  **Start の `disabled` 解除・ラベル適用・フッター更新**が同じ解禁トリガーに束ねられて遅延。
+
+## 対処（最小差分・仕様不変）
+1. **Start 解禁を i18n と分離**：`playable≥1` 到達時点で `#start-btn` の `disabled` を即解除（`aria-disabled=false`）。+   仕様（Start ガード）は維持。
+2. **i18n MutationObserver を rAF デバウンス**：1フレーム1回＋再入防止で過剰適用を抑止。
+3. **フッターの常時 populate**：`build/version.json` / `build/dataset.json` から生成（失敗時は固定文言）。
+
+## 確認観点（回帰チェック）
+- `[PLAYABLE] count=` → `[DATASET] ready` → Start 押下可能までが **~1–2s** で収束。
+- `Performance` の「JavaScriptとイベント」における i18n 帯が **短時間で収束**。
+- E2E は **緑維持**（テスト専用の堅牢化ロジックに変更なし）。
+


### PR DESCRIPTION
## Summary
- Document resolution of production i18n start delay and empty footer
- Close tracking issues for start flicker and footer emptiness

## Testing
- `npm test` *(fails: clojure not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e4645a54832482d15b435762c2b6