### PR TITLE
docs: enrich v1.12 prod issue entries

### DIFF
--- a/docs/issues/v1_12.json
+++ b/docs/issues/v1_12.json
@@ -167,6 +167,8 @@
   {
     "id": "v112-prod-i18n-start-flicker",
     "title": "本番: 初期数秒の英語表示＆ボタン無効 → 数秒後に日本語＆有効",
+    "labels": ["roadmap:v1.12", "type:bug", "area:prod", "i18n", "a11y"],
+    "body": "### 背景\\n- 初期ロード直後、主要ラベルが英語表示のまま数秒間ボタンが無効。数秒後に日本語化・有効化。\\n- DevTools計測で i18n-boot / i18n 周辺の Microtasks がメインスレッドを占有し、Start解禁とラベル適用・フッター更新が同一トリガーに束ねられて遅延。\\n\\n### 対応\\n- playable≥1 到達時点で Start の disabled を即解除（i18nに非依存）。\\n- i18n MutationObserver を requestAnimationFrame デバウンス＋再入防止。\\n\\n### 受け入れ基準（DoD）\\n- ハードリロード後 1〜2s で Start 押下可能。主要ラベルが同時期に日本語化。\\n- E2E 緑維持（挙動不変・テスト専用堅牢化に影響なし）。",
     "state": "closed",
     "priority": "High",
     "notes": [
@@ -181,6 +183,8 @@
   {
     "id": "v112-prod-footer-empty",
     "title": "本番: フッター要素は可視だがテキストが空",
+    "labels": ["roadmap:v1.12", "type:bug", "area:prod", "area:ui"],
+    "body": "### 背景\\n- 本番で footer#version が可視だが文言が空のまま。\\n\\n### 対応\\n- DOMContentLoaded で build/version.json / build/dataset.json から常時 populate（失敗時はフェイルセーフ文言）。\\n\\n### 受け入れ基準（DoD）\\n- 本番で常時フッター文言が表示（`Dataset • commit • updated` のいずれか）。",
     "state": "closed",
     "priority": "Medium",
     "notes": [


### PR DESCRIPTION
## Summary
- add labels and description bodies for prod start flicker and footer empty issues

## Testing
- `jq '.' docs/issues/v1_12.json`
- `node scripts/docs_link_check.mjs docs/issues/v1_12.json`
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e9fd4d988324b2553ce129c79804