### PR TITLE
docs: add Lighthouse budgets regression issue

### DIFF
--- a/docs/issues/v1_12.json
+++ b/docs/issues/v1_12.json
@@ -193,5 +193,19 @@
       "対応: DOMContentLoaded で footer を常時 populate（build/version.json / dataset.json から生成、フェイルセーフ付き）。",
       "2025-09-12: 本番で常時表示を確認（Start 解禁と同時期に表示）。"
     ]
+  },
+  {
+    "id": "v112-lighthouse-budgets-regression",
+    "title": "Lighthouse(budgets, nightly): 赤判定の調査と改善（TBT高止まり/予算ゲート）",
+    "labels": ["roadmap:v1.12", "type:perf", "area:ci", "lighthouse", "budgets"],
+    "body": "### 背景\\n- nightly の Lighthouse (budgets) が赤に。添付の LHR JSON では Budgets 監査の違反は 0 だが、パフォーマンス/スコア等のゲートで落ちている可能性。\\n- 該当レポート例: Performance 75 / TBT ~1154ms / LCP ~1.11s。\\n\\n### やること\\n- LHR(JSON) の要約（Budgets失敗/Top重い資産/LCP/TBT/CLS内訳/3rd-party）を取得・保管。\\n- TBT 主因（Unattributable, main文書初期化, i18n-boot, sw_update, version.mjs 等）を順に削減。\\n- budgets の閾値/比較ルール（スコア下限 or 前回比）と整合する改善幅で緑へ。\\n\\n### 受け入れ基準（DoD）\\n- CI: budgets ワークフローが緑。\\n- TBT が目標値（<= 500ms 目安）へ改善、Performance >= 85 目安。\\n- 変更は本番挙動不変（UX劣化なし）。",
+    "state": "open",
+    "priority": "High",
+    "notes": [
+      "事実: 提供LHRでは Budgets違反は0。落ち条件は別ゲート（スコア/比較）と推測。",
+      "主因: Main-thread の Other/Unattributable、sw_update、i18n-boot、version.mjs 等の初期処理負荷。",
+      "対策（優先順）: 初期処理のrAF分割/バッチ化、SW更新のIdle/初回操作後へ、version.mjs の遅延import、i18nの対象限定。",
+      "準備手順: docs/lighthouse_prep.md を参照（LHR収集と5点要約、サイズ差分抽出）。"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- track nightly Lighthouse budgets regression with details and mitigation notes

## Testing
- `node scripts/docs_link_check.mjs`
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c40a6b55108324bbee0379d1dbed85