### PR TITLE
fix: ensure dataset-error links inherit error contrast

### DIFF
--- a/docs/lighthouse-budgets.md
+++ b/docs/lighthouse-budgets.md
@@ -20,4 +20,12 @@
 - `lcp-lazy-loaded` / `prioritize-lcp-image` / `non-composited-animations` は該当ページで **Not Applicable** になるため **off**。
 - `unminified-javascript` は小さなユーティリティ1本まで許容（**warn(maxLength:1)**）。
 - `meta-description` は `/app/` と `/daily/latest.html?no-redirect=1` を対象にし、後者にも meta description を追加済み。
+### 2025-09-12（JST）現状
+  - `/app/?lhci=1`: budgets 適合 / Performance=0.75 / **color-contrast fail（要素: #dataset-error）**
+  - `/daily/latest.html?no-redirect=1`: budgets 適合 / Performance=1.00
+
+#### フォローアップ（2025-09-12 夜）
+- `#dataset-error` について、背景/前景のコントラストは修正済み（赤背景+白文字）。
+- 追加で **内部リンクの配色が継承されず**、青リンクが暗赤背景と低コントラストになるケースを確認。
+- 対処: `#dataset-error a, #dataset-error a:visited { color: inherit !important; text-decoration: underline; }` を追加し、WCAG AA を満たすよう修正。
 

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -249,18 +249,25 @@
     color:var(--accent-fg);
     border-color:transparent;
   }
-  /* Accessible error alert styling (contrast-compliant) */
+  /* a11y: dataset-error must meet WCAG AA contrast even when links are present */
   #dataset-error{
-    color: var(--error-fg, #ffffff);
-    background: var(--error-bg, #991b1b);
-    padding: 10px 12px;
-    border-radius: 12px;
-    box-shadow: var(--shadow-1);
-    margin-top: 8px;
+    background:#991b1b; /* dark red (≈#B91C1C family but slightly darker) */
+    color:#ffffff;
+    padding:.75rem 1rem;
+    border-radius:.5rem;
+    line-height:1.5;
+    margin:.5rem 0;
   }
-  #dataset-error a{
-    color: inherit;
-    text-decoration: underline;
+  /* ensure anchors inside the alert inherit the high-contrast color */
+  #dataset-error a,
+  #dataset-error a:visited{
+    color:inherit !important;
+    text-decoration:underline;
+    font-weight:600;
+  }
+  #dataset-error a:focus-visible{
+    outline:2px dashed #ffffff;
+    outline-offset:2px;
   }
 
   #choices{


### PR DESCRIPTION
## Summary
- keep dataset-error alert text and links AA-compliant
- document follow up on color contrast issue in lighthouse notes

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c429f9792883249b554b6e3e54c606