### PR TITLE
perf: defer noncritical app tasks until idle

### DIFF
--- a/docs/lighthouse-budgets.md
+++ b/docs/lighthouse-budgets.md
@@ -29,3 +29,11 @@
 - 追加で **内部リンクの配色が継承されず**、青リンクが暗赤背景と低コントラストになるケースを確認。
 - 対処: `#dataset-error a, #dataset-error a:visited { color: inherit !important; text-decoration: underline; }` を追加し、WCAG AA を満たすよう修正。
 
+### 2025-09-13（JST）MPFID/TBT 微改善（任意）
+- 目的: `max-potential-fid` の警告を抑制（初期フレームでの重い処理を後段へ移動）。
+- 変更（挙動不変）:
+  - `public/app/idle-init.mjs` を新設し、**`version.mjs` の読み込み**を Idle/初回操作後へ遅延。
+  - `public/app/sw_update.js` は **初回操作または idle まで SW 更新監視を遅延**（モジュール内で自動 arm）。
+  - `public/app/index.html` に `sw_update.js` と `idle-init.mjs` を読み込み。
+- 期待効果: 初期メインスレッドの処理量削減 → MPFID/TBT の低下。
+

--- a/public/app/idle-init.mjs
+++ b/public/app/idle-init.mjs
@@ -1,0 +1,35 @@
+// v1.12 perf: 非クリティカル初期処理をアイドル/初回操作後に遅延実行
+// 挙動不変（UI/文言/機能は変更しない）。LH の MPFID/TBT の圧縮を狙う。
+
+const idle = (cb) => {
+  if ('requestIdleCallback' in window) {
+    requestIdleCallback(cb, { timeout: 2500 });
+  } else {
+    // rAF 2 フレーム + setTimeout でほぼアイドル相当へ
+    requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(cb, 0)));
+  }
+};
+
+let armed = false;
+const arm = () => {
+  if (armed) return;
+  armed = true;
+  idle(async () => {
+    try {
+      // いずれも副作用が軽い順に評価
+      // 1) 版数フッターの埋め込み（UI 可用化後で十分）
+      await import('./version.mjs').catch(() => {});
+      // 2) Service Worker の更新確認は sw_update.js 側で遅延実行
+      // （ここでは何もしない）
+    } catch {
+      // no-op: 遅延系は失敗しても致命ではない
+    }
+  });
+};
+
+// 初回操作で確実に発火（キーボード/マウス/タッチ）
+['keydown','pointerdown','touchstart'].forEach(t =>
+  window.addEventListener(t, arm, { once: true, passive: true })
+);
+// 何も操作されない場合でも、起動から少し経てば実行
+arm();

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -29,6 +29,8 @@
     })();
   </script>
   <script defer src="./sw_update.js"></script>
+  <!-- v1.12 perf: 非クリティカル初期処理は idle に後ろ倒し -->
+  <script type="module" src="./idle-init.mjs" defer></script>
 <!-- Open Graph (optional but useful for previews) -->
 <meta property="og:title" content="VGM Quiz">
 <meta property="og:description" content="Play a fast, browser-based Video Game Music quiz with multiple modes and composers/titles matching.">

--- a/public/app/sw_update.js
+++ b/public/app/sw_update.js
@@ -132,15 +132,39 @@
     listenOnRegistration(reg);
   }
 
-  // Attach to any current registration
-  navigator.serviceWorker.getRegistration().then(attach).catch(() => {});
-  navigator.serviceWorker.ready.then(attach).catch(() => {});
-  waitForRegistration().then(attach);
-  window.addEventListener('sw-registered', (e) => attach(e.detail));
+  // Lazy attach: defer SW update wiring until idle or first interaction
+  function __vgmquiz_sw_init__(){
+    // Attach to any current registration
+    navigator.serviceWorker.getRegistration().then(attach).catch(() => {});
+    navigator.serviceWorker.ready.then(attach).catch(() => {});
+    waitForRegistration().then(attach);
+    window.addEventListener('sw-registered', (e) => attach(e.detail));
 
-  // Also watch future registrations
-  navigator.serviceWorker.addEventListener('controllerchange', () => {
-    // No-op here; reload is handled on button click path.
-  });
+    // Also watch future registrations
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      // No-op here; reload is handled on button click path.
+    });
+  }
+
+  const __idle__ = (cb) => {
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(cb, { timeout: 2500 });
+    } else {
+      requestAnimationFrame(() => setTimeout(cb, 0));
+    }
+  };
+
+  let __armed__ = false;
+  function __arm__(){
+    if (__armed__) return;
+    __armed__ = true;
+    __idle__(__vgmquiz_sw_init__);
+  }
+
+  // First meaningful user interaction triggers immediately; otherwise idle fallback
+  ['keydown','pointerdown','touchstart'].forEach(t =>
+    window.addEventListener(t, __arm__, { once: true, passive: true })
+  );
+  setTimeout(__arm__, 1500);
 })();
 


### PR DESCRIPTION
## Summary
- push SW update wiring off main thread until idle or first interaction
- simplify idle-init to only lazy-load the version footer
- load `sw_update.js` and `idle-init.mjs` in the HTML and update docs

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c430f1add48324ab2fd69dbbf66370