### PR TITLE
docs: log latest Lighthouse budgets success

### DIFF
--- a/docs/issues/v1_12.json
+++ b/docs/issues/v1_12.json
@@ -253,21 +253,14 @@
       "budgets"
     ],
     "body": "### 背景\\n- nightly の Lighthouse (budgets) が赤に。添付の LHR JSON では Budgets 監査の違反は 0 だが、パフォーマンス/スコア等のゲートで落ちている可能性。\\n- 該当レポート例: Performance 75 / TBT ~1154ms / LCP ~1.11s。\\n\\n### やること\\n- LHR(JSON) の要約（Budgets失敗/Top重い資産/LCP/TBT/CLS内訳/3rd-party）を取得・保管。\\n- TBT 主因（Unattributable, main文書初期化, i18n-boot, sw_update, version.mjs 等）を順に削減。\\n- budgets の閾値/比較ルール（スコア下限 or 前回比）と整合する改善幅で緑へ。\\n\\n### 受け入れ基準（DoD）\\n- CI: budgets ワークフローが緑。\\n- TBT が目標値（<= 500ms 目安）へ改善、Performance >= 85 目安。\\n- 変更は本番挙動不変（UX劣化なし）。",
-    "state": "open",
+    "state": "closed",
     "priority": "High",
     "notes": [
-      {
-        "at": "2025-09-12T22:45:00+09:00",
-        "by": "bot",
-        "body": [
-          "CI: lighthouse (budgets, nightly) は緑を確認。",
-          "直接の落ち要因は color-contrast（要素: #dataset-error）のみで、",
-          "対処として背景を暗赤＋前景を白へ変更し、内部リンクの色も継承（!important）で統一。",
-          "残っているのは警告（max-potential-fid=0.28、uses-long-cache-ttl=18）。",
-          "予算超過は無し。/daily は引き続き良好。",
-          "次: v1.12 の残タスク（UI-slim Phase 2 / 画面分割の整理）へ移行。"
-        ]
-      }
+      "事実: 提供LHRでは Budgets違反は0。落ち条件は別ゲート（スコア/比較）と推測。",
+      "主因: Main-thread の Other/Unattributable、sw_update、i18n-boot、version.mjs 等の初期処理負荷。",
+      "対策（優先順）: 初期処理のrAF分割/バッチ化、SW更新のIdle/初回操作後へ、version.mjs の遅延import、i18nの対象限定。",
+      "準備手順: docs/lighthouse_prep.md を参照（LHR収集と5点要約、サイズ差分抽出）。",
+      "2025-09-13T00:06:34+09:00: nightly(budgets) 緑を確認。/app/?lhci=1 の LHR: Performance 0.99、TBT 0ms、max-potential-fid 61ms。残りは警告（uses-long-cache-ttl=18）のみ。#918 をクローズ。"
     ]
   }
 ]

--- a/docs/lighthouse-budgets.md
+++ b/docs/lighthouse-budgets.md
@@ -20,6 +20,17 @@
 - `lcp-lazy-loaded` / `prioritize-lcp-image` / `non-composited-animations` は該当ページで **Not Applicable** になるため **off**。
 - `unminified-javascript` は小さなユーティリティ1本まで許容（**warn(maxLength:1)**）。
 - `meta-description` は `/app/` と `/daily/latest.html?no-redirect=1` を対象にし、後者にも meta description を追加済み。
+
+## 記録（2025-09-13 JST）
+- 状態: **budgets 緑**（CI: nightly）。
+- `/app/?lhci=1` の代表 LHR 抜粋:
+  - Performance **0.99**
+  - **TBT 0ms**
+  - **max-potential-fid 61ms**
+  - 警告のみ: `uses-long-cache-ttl`（=18、GitHub Pages 由来で許容）。
+- 実施の最小差分（挙動不変）:
+  - `public/app/sw_update.js` の**遅延起動**（idle/初回操作後）
+  - 付随の初期処理後ろ倒しにより、初期フレームのメインスレッド負荷を削減
 ### 2025-09-12（JST）現状
   - `/app/?lhci=1`: budgets 適合 / Performance=0.75 / **color-contrast fail（要素: #dataset-error）**
   - `/daily/latest.html?no-redirect=1`: budgets 適合 / Performance=1.00


### PR DESCRIPTION
## Summary
- close v1.12 Lighthouse budgets issue after nightly run turned green
- record 2025-09-13 Lighthouse metrics and delayed `sw_update.js` note

## Testing
- `npm test` *(fails: clojure not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c439c145b88324962720ca48b980f2