### PR TITLE
ci: guard daily-oneq dependency install

### DIFF
--- a/.github/workflows/daily-oneq.yml
+++ b/.github/workflows/daily-oneq.yml
@@ -17,10 +17,14 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install deps (if any)
+      - name: Install deps (guarded, dry-run needs none)
         run: |
-          if [ -f package.json ]; then
+          if [ -f package-lock.json ]; then
             npm ci --no-audit --no-fund
+          elif [ -f package.json ]; then
+            echo "[oneq] skip install: package-lock.json not found (dry-run does not require deps)"
+          else
+            echo "[oneq] skip install: no package.json"
           fi
 
       - name: Run oneq dry-run


### PR DESCRIPTION
## Summary
- guard dependency install in the daily-oneq workflow, skipping when lock file or package.json absent

## Testing
- `npm test` (fails: `clojure` not found)
- `apt-get update` (fails: repository InRelease not signed)

------
https://chatgpt.com/codex/tasks/task_e_68c4d2d6a4d4832496983ab3e2ea10bd