### PR TITLE
feat: seed media map and skip placeholders

### DIFF
--- a/docs/data/media_map.json
+++ b/docs/data/media_map.json
@@ -1,1 +1,19 @@
-[]
+[
+  {
+    "track_id": "2a78a753-5f45-39e7-b04c-4e7718aaeab5",
+    "title": "Megalovania",
+    "game": "UNDERTALE",
+    "composer": "Toby Fox",
+    "provider": "apple",
+    "id": "FILL_ME"
+  },
+  {
+    "track_id": "d18f04f2-7c53-3baf-af77-09952dee1658",
+    "title": "序曲",
+    "game": "ドラゴンクエスト",
+    "composer": "すぎやまこういち",
+    "provider": "apple",
+    "id": "FILL_ME"
+  }
+]
+

--- a/script/oneq_dryrun.mjs
+++ b/script/oneq_dryrun.mjs
@@ -49,6 +49,7 @@ function buildMediaMap() {
       const prov = String(r.provider || '').toLowerCase().trim();
       const mid = String(r.id || '').trim();
       if (!k || !prov || !mid) continue;
+      if (mid === 'FILL_ME' || /^FILL_ME/i.test(mid)) continue; // placeholderは除外
       byId.set(k, { provider: prov, id: mid });
     }
     return { byId, mapPath };
@@ -114,6 +115,7 @@ const resolved = all.map(t => ({ t, m: resolveMedia(t) }));
 const apple = resolved.filter(x => x.m?.provider === 'apple');
 const youtube = resolved.filter(x => x.m?.provider === 'youtube');
 const covered = resolved.filter(x => !!x.m);
+const missing = all.length - covered.length;
 
 // 簡易ユニーク性（将来は直近N日の一意性ロックと統合）
 const key = t => [t?.game || t.game, t?.track?.title || t.title, t?.track?.composer || t.composer, (resolveMedia(t)||{}).provider || '', (resolveMedia(t)||{}).id || ''].map(x=>String(x||'')).join('｜');
@@ -130,7 +132,7 @@ const lines = [];
 lines.push(`# oneq dry-run（v1.13 MVP）`);
 lines.push(`- dataset: ${datasetOrigin}`);
 lines.push(`- 全トラック数: **${all.length}**`);
-lines.push(`- メディア情報の被覆: **${covered.length} / ${all.length}**`);
+lines.push(`- メディア情報の被覆: **${covered.length} / ${all.length}**（未解決: ${missing}）`);
 lines.push(`  - Apple: **${apple.length}**`);
 lines.push(`  - YouTube: **${youtube.length}**`);
 if (mediaMap?.mapPath) {

--- a/script/oneq_media_map_seed.mjs
+++ b/script/oneq_media_map_seed.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Seed file for docs/data/media_map.todo.json from dataset (local or Pages)
+ * - Non-destructive: writes a TODO file (does not touch media_map.json)
+ * - Default provider is "apple"; adjust as needed.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+function readJSON(p){ try{ return JSON.parse(fs.readFileSync(p,'utf8')); }catch{ return null; } }
+
+const local = path.resolve('public/build/dataset.json');
+let ds = readJSON(local);
+let origin = `local:${local}`;
+
+async function fetchJSON(url){
+  try{
+    const ctrl = new AbortController();
+    const t = setTimeout(()=>ctrl.abort(), 8000);
+    const r = await fetch(url, { signal: ctrl.signal, headers: { 'accept':'application/json' } });
+    clearTimeout(t);
+    if(!r.ok) return null;
+    return await r.json();
+  }catch{ return null; }
+}
+
+if(!ds){
+  const repo = process.env.GITHUB_REPOSITORY || 'nantes-rfli/vgm-quiz';
+  const [owner, name] = repo.split('/');
+  const base = process.env.ONEQ_DATASET_BASE || `https://${owner}.github.io/${name}`;
+  const url = process.env.ONEQ_DATASET_URL || `${base}/build/dataset.json`;
+  ds = await fetchJSON(url);
+  origin = `remote:${url}`;
+}
+
+if(!ds || !Array.isArray(ds.tracks)){
+  console.error('[seed] dataset not found or invalid');
+  process.exit(1);
+}
+
+const rows = ds.tracks.map(t => ({
+  "track_id": t['track/id'],
+  "title": t.title,
+  "game": t.game,
+  "composer": t.composer,
+  "provider": "apple",
+  "id": "FILL_ME"
+}));
+
+const outPath = path.resolve('docs/data/media_map.todo.json');
+fs.writeFileSync(outPath, JSON.stringify(rows, null, 2));
+console.log('[seed] wrote', outPath, 'from', origin, 'rows=', rows.length);
+


### PR DESCRIPTION
## Summary
- Seed docs/data/media_map.todo.json from dataset with placeholder IDs
- Ignore `FILL_ME` placeholders in dry-run and report unresolved count
- Add sample entries to media_map.json

## Testing
- `npm test` *(fails: clojure not found)*
- `node script/oneq_dryrun.mjs`
- `node script/oneq_media_map_seed.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68c4daddec68832495e15d7d25075d98