### PR TITLE
Add oneq media map seed workflow and refine dry-run output

### DIFF
--- a/.github/workflows/oneq-seed.yml
+++ b/.github/workflows/oneq-seed.yml
@@ -1,0 +1,29 @@
+name: oneq (seed media_map todo)
+on:
+  workflow_dispatch: {}
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate media_map.todo.json
+        run: |
+          node script/oneq_media_map_seed.mjs
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: media_map.todo.json
+          path: docs/data/media_map.todo.json
+

--- a/script/oneq_dryrun.mjs
+++ b/script/oneq_dryrun.mjs
@@ -126,7 +126,8 @@ for (const x of [...apple, ...youtube]) {
   if (!uniq.has(k)) { uniq.add(k); uniqueCandidates.push(x); }
 }
 
-const pick = uniqueCandidates[0]?.t || null;
+const pickEntry = uniqueCandidates[0] || null;
+const pick = pickEntry ? pickEntry.t : null;
 
 const lines = [];
 lines.push(`# oneq dry-run（v1.13 MVP）`);
@@ -143,10 +144,13 @@ if (mediaMap?.mapPath) {
 lines.push(`- 一意化後の候補（単純ユニーク）: **${uniqueCandidates.length}**`);
 if (pick) {
   const p = pick;
-  const title = p?.track?.title || '(unknown title)';
-  const game = p?.game || '(unknown game)';
-  const comp = p?.track?.composer || '(unknown composer)';
-  lines.push(`- 代表候補（サンプル）: **${title}** / ${game} / ${comp} / ${p?.media?.provider}:${p?.media?.id}`);
+  const media = resolveMedia(p) || {};
+  const title = (p?.track?.title || p?.title || '').trim() || '(unknown title)';
+  const game = (p?.game || '').trim() || '(unknown game)';
+  const comp = (p?.track?.composer || p?.composer || '').trim() || '(unknown composer)';
+  const prov = (media.provider || '').trim() || '(no-provider)';
+  const mid = (media.id || '').trim() || '(no-id)';
+  lines.push(`- 代表候補（サンプル）: **${title}** / ${game} / ${comp} / ${prov}:${mid}`);
 } else {
   lines.push(`- 代表候補（サンプル）: なし`);
 }


### PR DESCRIPTION
## Summary
- Improve oneq dry-run sample output handling and media field resolution
- Add workflow to generate and upload media_map.todo.json artifacts

## Testing
- `clojure -M:test` *(fails: command not found)*
- `npm test` *(fails: clojure not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c4dfd2f36c8324bc664be0936a6e47