### PR TITLE
feat(oneq): add publish script and workflow

### DIFF
--- a/.github/workflows/daily-oneq-publish.yml
+++ b/.github/workflows/daily-oneq-publish.yml
@@ -1,0 +1,55 @@
+name: daily (oneq publish)
+on:
+  workflow_dispatch: {}
+  # schedule:
+  #   - cron: "5 15 * * *" # 00:05 JST (UTC+9)
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Compute date
+        id: date
+        run: echo "ONEQ_DATE=$(node -e \"console.log(new Date().toISOString().slice(0,10))\")" >> $GITHUB_ENV
+
+      - name: Generate daily & update lock
+        run: node script/oneq_publish.mjs
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-${{ env.ONEQ_DATE }}
+          path: |
+            public/daily/${{ env.ONEQ_DATE }}*.json
+            docs/data/daily_lock.json
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(oneq): ${{ env.ONEQ_DATE }} daily question"
+          title: "chore(oneq): ${{ env.ONEQ_DATE }} daily question"
+          body: |
+            Auto-generated daily question for ${{ env.ONEQ_DATE }}.
+            - Source: docs/data/media_map.json
+            - Embedding-only policy
+          branch: chore/oneq-${{ env.ONEQ_DATE }}
+          add-paths: |
+            public/daily/${{ env.ONEQ_DATE }}*.json
+            docs/data/daily_lock.json
+          signoff: true
+          delete-branch: true
+

--- a/docs/OPERATIONS_DAILY_ONEQ.md
+++ b/docs/OPERATIONS_DAILY_ONEQ.md
@@ -17,6 +17,12 @@
 - スキーマ: `{ "track_id": "<datasetの track/id>", "provider": "apple|youtube", "id": "<埋め込みID>" }`
 - 本番CIではネットワーク解決を行わない前提（法務と安定性のため）。`media_map.json` はPRで更新し、レビュー可能な形で履歴を残す。
 
+## 公開フロー（publish）
+- Actions: **daily (oneq preview)** … 1件を pick し、`out/daily-YYYY-MM-DD.json` をアーティファクトとして出力（コミットなし）
+- Actions: **daily (oneq publish)** … 1件を pick し、`public/daily/YYYY-MM-DD.json` を生成、`docs/data/daily_lock.json` に追記し、**PR を自動作成**
+- PR をレビューしてマージすると、Pages に `public/daily/YYYY-MM-DD.json` が公開される
+
+
 ## 失敗時の復旧
 - **A. 手動再実行**: フレーク要因の場合はリトライ。Artifacts を確認して原因を要約し、Issue に `notes` として残す。
 - **B. 強制 skip**: Apple/YouTube いずれも解決不可の場合は当日を skip。次回に繰越されることを Summary に明記。

--- a/script/oneq_publish.mjs
+++ b/script/oneq_publish.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * oneq publish: pick 1 track and write to public/daily/YYYY-MM-DD.json
+ * - Updates docs/data/daily_lock.json (append used track/id)
+ * - Does NOT commit here; workflow will open a PR with the changes.
+ */
+import path from 'node:path';
+import { loadDataset, loadMediaMap, listTracks, resolveMedia, writeJSON, sha256, todayYMD, loadLock, addToLock } from './oneq_lib.mjs';
+
+const { ds, origin } = await loadDataset();
+if (!ds) {
+  console.log('[oneq] dataset not found (origin=%s)', origin);
+  process.exit(0);
+}
+const mediaMap = loadMediaMap();
+const tracks = listTracks(ds);
+const lock = loadLock();
+
+function isUsed(t){ const tid = t['track/id'] || ''; return Array.isArray(lock.used) && lock.used.includes(tid); }
+
+const enriched = tracks.map(t => ({ t, m: resolveMedia(t, mediaMap) }))
+  .filter(x => !!x.m && (x.m.provider === 'apple' || x.m.provider === 'youtube'))
+  .filter(x => !isUsed(x.t));
+
+// Apple first, deterministic
+enriched.sort((a,b) => {
+  const pa = a.m.provider === 'apple' ? 0 : 1;
+  const pb = b.m.provider === 'apple' ? 0 : 1;
+  if (pa !== pb) return pa - pb;
+  return String(a.t['track/id']).localeCompare(String(b.t['track/id']));
+});
+
+if (!enriched.length) {
+  console.log('[oneq] no candidate to publish (all used or no media). dataset:', origin);
+  process.exit(0);
+}
+
+const pick = enriched[0];
+const date = todayYMD();
+const prov = pick.m.provider;
+const mid = pick.m.id;
+const track = pick.t;
+
+const obj = {
+  date,
+  question: {
+    type: "guess-track",
+    locale: "ja",
+    title: track.title || null,
+    game: track.game || null,
+    composer: track.composer || null,
+    "track/id": track['track/id']
+  },
+  media: {
+    provider: prov,
+    id: mid
+  },
+  provenance: {
+    source: "docs/data/media_map.json",
+    provider: prov,
+    id: mid,
+    collected_at: new Date().toISOString(),
+    hash: sha256([track['track/id'], prov, mid].join('::')),
+    license_hint: "embed-only; see provider terms"
+  }
+};
+
+const outPath = path.resolve('public/daily', `${date}.json`);
+writeJSON(outPath, obj);
+
+// update lock
+addToLock(lock, track['track/id']);
+writeJSON(lock.path, { used: lock.used });
+
+console.log('[oneq] publish staged:', outPath);
+


### PR DESCRIPTION
## Summary
- add `oneq_publish.mjs` to stage daily question and update lock
- wire up `daily (oneq publish)` workflow to open PRs with the daily JSON
- document publish flow in `OPERATIONS_DAILY_ONEQ`

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e9c72e1483248387ed3486bce6b1