### PR TITLE
chore: compute ONEQ_DATE in UTC

### DIFF
--- a/.github/workflows/daily-oneq-publish.yml
+++ b/.github/workflows/daily-oneq-publish.yml
@@ -22,9 +22,9 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Compute date
+      - name: Compute date (UTC)
         id: date
-        run: echo "ONEQ_DATE=$(node -e \"console.log(new Date().toISOString().slice(0,10))\")" >> $GITHUB_ENV
+        run: echo "ONEQ_DATE=$(date -u +%F)" >> $GITHUB_ENV
 
       - name: Generate daily & update lock
         run: node script/oneq_publish.mjs


### PR DESCRIPTION
## Summary
- ensure daily-oneq-publish workflow computes ONEQ_DATE using UTC date command

## Testing
- `npm test` *(fails: clojure not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ed42db448324bc32ed3cfc34d88e