### PR TITLE
chore(ci): use fallback PAT for daily oneq

### DIFF
--- a/.github/workflows/daily-oneq-publish.yml
+++ b/.github/workflows/daily-oneq-publish.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,6 +41,8 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
+          # Prefer DAILY_PR_PAT, fall back to CPR_PAT
+          token: ${{ secrets.DAILY_PR_PAT || secrets.CPR_PAT }}
           commit-message: "chore(oneq): ${{ env.ONEQ_DATE }} daily question"
           title: "chore(oneq): ${{ env.ONEQ_DATE }} daily question"
           body: |

--- a/docs/OPERATIONS_DAILY_ONEQ.md
+++ b/docs/OPERATIONS_DAILY_ONEQ.md
@@ -22,6 +22,13 @@
 - Actions: **daily (oneq publish)** … 1件を pick し、`public/daily/YYYY-MM-DD.json` を生成、`docs/data/daily_lock.json` に追記し、**PR を自動作成**
 - PR をレビューしてマージすると、Pages に `public/daily/YYYY-MM-DD.json` が公開される
 
+### PR作成と必須チェックの起動（PAT設定）
+- `daily (oneq publish)` の PR で **必須チェック（ci-fast-pr-build / pages-pr-build / required-check）** が「Expected」のまま動かない場合、`GITHUB_TOKEN` では後続ワークフローが起動しない設定になっています。
+- 本ワークフローは **`DAILY_PR_PAT` を優先**し、未設定なら **`CPR_PAT`** をフォールバックして使います。
+  - 既存のどちらかを **Settings → Secrets and variables → Actions** に登録してあれば追加作業は不要です。
+  - **クラシックPAT**: `repo` + `workflow` スコープ（推奨: 期限付き）
+  - **FGT（細分化）**: 対象リポに対し *Contents: Read/Write*, *Pull requests: Read/Write*, *Actions: Read/Write*
+- 既に作成済みの PR は、`daily (oneq publish)` を**再実行**すると同ブランチへ新規コミットが積まれ、必須チェックが起動します。
 
 ## 失敗時の復旧
 - **A. 手動再実行**: フレーク要因の場合はリトライ。Artifacts を確認して原因を要約し、Issue に `notes` として残す。


### PR DESCRIPTION
## Summary
- allow daily oneq publish to fall back from `DAILY_PR_PAT` to `CPR_PAT`
- document PAT fallback for daily one question workflow

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f27085b8832498c89db1f5cf37b5