### PR TITLE
ci: enable auto-merge for daily oneq

### DIFF
--- a/.github/workflows/daily-oneq-publish.yml
+++ b/.github/workflows/daily-oneq-publish.yml
@@ -39,6 +39,7 @@ jobs:
             docs/data/daily_lock.json
 
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
           # Prefer DAILY_PR_PAT, fall back to CPR_PAT
@@ -55,4 +56,12 @@ jobs:
             docs/data/daily_lock.json
           signoff: true
           delete-branch: true
+
+      - name: Enable PR auto-merge (squash)
+        if: steps.cpr.outputs.pull-request-number != ''
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.DAILY_PR_PAT || secrets.CPR_PAT }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: SQUASH
 

--- a/docs/OPERATIONS_DAILY_ONEQ.md
+++ b/docs/OPERATIONS_DAILY_ONEQ.md
@@ -30,6 +30,11 @@
   - **FGT（細分化）**: 対象リポに対し *Contents: Read/Write*, *Pull requests: Read/Write*, *Actions: Read/Write*
 - 既に作成済みの PR は、`daily (oneq publish)` を**再実行**すると同ブランチへ新規コミットが積まれ、必須チェックが起動します。
 
+### 自動マージの有効化
+- 本ワークフローは PR 作成後に **auto-merge（squash）を自動で有効化**します。
+- リポジトリ設定で **Allow auto-merge** を ON にしてください（Settings → General）。
+- ブランチ保護で「レビュー必須」などの条件がある場合は、条件を満たした時点で自動的にマージされます。
+
 ## 失敗時の復旧
 - **A. 手動再実行**: フレーク要因の場合はリトライ。Artifacts を確認して原因を要約し、Issue に `notes` として残す。
 - **B. 強制 skip**: Apple/YouTube いずれも解決不可の場合は当日を skip。次回に繰越されることを Summary に明記。


### PR DESCRIPTION
## Summary
- enable auto-merge for daily oneq publish PRs
- document auto-merge behavior for daily oneq workflow

## Testing
- `npm test` *(fails: clojure not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f48d3e10832483d1789f34a5dd91