### PR TITLE
feat: add oneq publish summary

### DIFF
--- a/.github/workflows/daily-oneq-publish.yml
+++ b/.github/workflows/daily-oneq-publish.yml
@@ -1,8 +1,8 @@
 name: daily (oneq publish)
 on:
   workflow_dispatch: {}
-  # schedule:
-  #   - cron: "5 15 * * *" # 00:05 JST (UTC+9)
+  schedule:
+    - cron: "5 0 * * *" # 09:05 JST (UTC+9)
 
 jobs:
   publish:
@@ -30,13 +30,17 @@ jobs:
       - name: Generate daily & update lock
         run: node script/oneq_publish.mjs
 
-      - name: Upload artifact
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: daily-${{ env.ONEQ_DATE }}
+          name: oneq-publish-${{ env.ONEQ_DATE }}
           path: |
-            public/daily/${{ env.ONEQ_DATE }}*.json
+            public/daily/
             docs/data/daily_lock.json
+
+      - name: Write KPI summary
+        run: |
+          node script/oneq_summary.mjs
 
       - name: Create Pull Request
         id: cpr

--- a/docs/issues/v1_13.json
+++ b/docs/issues/v1_13.json
@@ -6,7 +6,19 @@
     "state": "open",
     "labels": ["v1.13", "feature", "daily", "pipeline", "embedding-only", "legal-safe"],
     "body": "目的: 無人で毎日1問を安定配信。法務安全性を担保し埋め込みに統一。\n\n- 要件: Apple優先→YouTube埋め込み、クリップ開始秒選定、難易度、誤答肢、正規化、一意性ロック、budgets/E2E緑\n- 生成物: Daily JSON / OGP / Feeds（既存dailyの拡張・互換）\n- DoD: 下位Issues（運用・KPI）含めて緑",
-    "notes": []
+    "notes": [
+      {
+        "at": "2025-09-13T13:35:00+09:00",
+        "by": "bot",
+        "body": [
+          "dry-run 実装: dataset から埋め込み候補をKPI出力（Apple優先→YouTube、media_map 参照）。",
+          "preview 実装: 1件pickして out/daily-YYYY-MM-DD.json を生成（provenance 6項目）。",
+          "publish 実装: public/daily/YYYY-MM-DD.json 生成＋daily_lock更新＋PR自動作成（auto-merge有効化）。",
+          "PAT: DAILY_PR_PAT 優先、CPR_PAT フォールバック。",
+          "現状: PR #998 の自動マージを確認。"
+        ]
+      }
+    ]
   },
   {
     "id": "v1-13-operations-daily-oneq-md",
@@ -15,7 +27,16 @@
     "state": "open",
     "labels": ["v1.13", "docs", "operations", "runbook"],
     "body": "手順: 失敗時の手動再実行、強制skip、PRロールバック、Secrets確認。\n\n- 確認: Step Summaryの各KPIとArtifactsの整合\n- 対象: daily（1問）ジョブ、OGP/Feedsジョブ、ids assign→sync→export の整合",
-    "notes": []
+    "notes": [
+      {
+        "at": "2025-09-13T13:35:00+09:00",
+        "by": "bot",
+        "body": [
+          "OPERATIONS_DAILY_ONEQ.md に PAT/auto-merge、media_map、seedワークフローを追記。",
+          "運用: Actions から seed → dry-run → preview → publish の段階実行が可能。"
+        ]
+      }
+    ]
   },
   {
     "id": "v1-13-kpi-step-summary",
@@ -24,6 +45,15 @@
     "state": "open",
     "labels": ["v1.13", "quality", "kpi", "ci"],
     "body": "KPI: 成功率、生成リードタイム、メディア解決率、重複拒否件数、ゲート余裕度。\n\n- 出力: Actions Summary とログ（スキーマ固定、破壊的変更はNG）\n- 運用: 失敗時はKPIを含めてSummaryに原因要約を必ず残す",
-    "notes": []
+    "notes": [
+      {
+        "at": "2025-09-13T13:35:00+09:00",
+        "by": "bot",
+        "body": [
+          "publish ワークフローに Step Summary を追加（タイトル/ゲーム/作曲/track-id/メディア）。",
+          "将来: 候補母数・被覆率・ロック更新件数なども出力候補。"
+        ]
+      }
+    ]
   }
 ]

--- a/script/oneq_summary.mjs
+++ b/script/oneq_summary.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// Append KPI summary for oneq publish to $GITHUB_STEP_SUMMARY
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SUMMARY = process.env.GITHUB_STEP_SUMMARY;
+const DATE = process.env.ONEQ_DATE || new Date().toISOString().slice(0,10);
+const p = path.resolve('public/daily', `${DATE}.json`);
+
+function readJSON(file){ try{ return JSON.parse(fs.readFileSync(file,'utf8')); }catch{ return null; } }
+const data = readJSON(p);
+
+let out = [];
+out.push(`# oneq publish summary (${DATE})`);
+if (!data) {
+  out.push(`- 状態: 失敗（ファイル未生成）`);
+  out.push(`- パス: \`${p}\``);
+} else {
+  const q = data.question || {};
+  const m = data.media || {};
+  out.push(`- 状態: 成功`);
+  out.push(`- タイトル: **${(q.title||'(unknown)')}**`);
+  out.push(`- ゲーム: ${q.game || '(unknown)'}`);
+  out.push(`- 作曲: ${q.composer || '(unknown)'}`);
+  out.push(`- track/id: \`${q['track/id'] || '(none)'}\``);
+  out.push(`- メディア: \`${m.provider || '(none)'}:${m.id || '(none)'}\``);
+}
+
+const text = out.join('\n') + '\n';
+console.log(text);
+if (SUMMARY) fs.appendFileSync(SUMMARY, '\n' + text);


### PR DESCRIPTION
## Summary
- schedule daily oneq publish workflow
- capture KPI summary and attach to step summary
- document daily oneq progress notes

## Testing
- `npm test` *(fails: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f73ef25883249e791cbd61ac1469