### PR TITLE
Update daily publish for legacy map

### DIFF
--- a/public/daily/latest.html
+++ b/public/daily/latest.html
@@ -6,5 +6,5 @@
   <script>(function(){try{var p=new URLSearchParams(location.search||"");if(p.get("no-redirect")==="1")return;var delay=parseInt(p.get("redirectDelayMs")||"0",10);if(isNaN(delay)||delay<0)delay=0;setTimeout(function(){location.replace("./2025-09-13.html");},delay);}catch(e){}})();</script>
 </head><body>
   <p>Redirecting to <a href="./2025-09-13.html">2025-09-13</a> …</p>
-  <p><a id="cta-latest-app" href="../app/?daily=2025-09-13">アプリで今日の1問へ</a></p>
+  <p><a id="cta-latest-app" href="../app/?daily_auto=1&daily=2025-09-13">アプリで今日の1問へ</a></p>
 </body></html>

--- a/script/oneq_publish.mjs
+++ b/script/oneq_publish.mjs
@@ -5,7 +5,7 @@
  * - Does NOT commit here; workflow will open a PR with the changes.
  */
 import path from 'node:path';
-import { loadDataset, loadMediaMap, listTracks, resolveMedia, writeJSON, sha256, todayYMD, loadLock, addToLock } from './oneq_lib.mjs';
+import { loadDataset, loadMediaMap, listTracks, resolveMedia, writeJSON, sha256, todayYMD, loadLock, addToLock, readJSON } from './oneq_lib.mjs';
 
 const { ds, origin } = await loadDataset();
 if (!ds) {
@@ -72,5 +72,24 @@ writeJSON(outPath, obj);
 addToLock(lock, track['track/id']);
 writeJSON(lock.path, { used: lock.used });
 
-console.log('[oneq] publish staged:', outPath);
+console.log('[oneq] publish written:', outPath);
+
+// ---- Also append to legacy map: public/app/daily_auto.json (so the app can play it today)
+try {
+  const mapPath = path.resolve('public', 'app', 'daily_auto.json');
+  let j = readJSON(mapPath) || {};
+  if (!j.by_date) j.by_date = {};
+  j.by_date[date] = {
+    provider: prov,
+    id: mid,
+    title: track.title || '',
+    game: track.game || '',
+    composer: track.composer || '',
+    answers: { canonical: track.title || '' }
+  };
+  writeJSON(mapPath, j);
+  console.log('[oneq] daily_auto.json updated:', mapPath);
+} catch (e) {
+  console.warn('[oneq] WARN: failed to update daily_auto.json', e && e.message);
+}
 


### PR DESCRIPTION
## Summary
- Update daily publish script to also write today's track into `public/app/daily_auto.json`
- Adjust latest daily HTML link to flag `daily_auto=1`

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4facbdea083248c8622297af08c61