### PR TITLE
feat: add simple answer sets

### DIFF
--- a/script/oneq_publish.mjs
+++ b/script/oneq_publish.mjs
@@ -85,7 +85,12 @@ try {
     title: track.title || '',
     game: track.game || '',
     composer: track.composer || '',
-    answers: { canonical: track.title || '' }
+    // 現行UIが期待する簡易回答セット（title/game/composer それぞれの正解候補）
+    answers: {
+      title: [track.title || ''].filter(Boolean),
+      game: [track.game || ''].filter(Boolean),
+      composer: [track.composer || ''].filter(Boolean)
+    }
   };
   writeJSON(mapPath, j);
   console.log('[oneq] daily_auto.json updated:', mapPath);


### PR DESCRIPTION
## Summary
- enrich daily_auto entries with arrays of title, game, and composer answers

## Testing
- `npm test` *(fails: `clojure` not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y clojure` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c501a2b0b88324840234f11d5fae4d