### PR TITLE
chore(daily-auto): update daily_auto.json

### DIFF
--- a/public/app/daily_auto.json
+++ b/public/app/daily_auto.json
@@ -91,6 +91,36 @@
         }
       },
       "difficulty": 5
+    },
+    "2025-09-14": {
+      "title": "クロノ・トリガー",
+      "game": "クロノ・トリガー",
+      "composer": "光田康典",
+      "platform": null,
+      "year": 1995,
+      "media": null,
+      "source": "dataset",
+      "norm": {
+        "title": "クロノトリガ",
+        "game": "クロノトリガ",
+        "composer": "光田康典",
+        "answer": "クロノトリガ"
+      },
+      "provenance": {
+        "source": "dataset",
+        "collected_at": "2025-09-13T15:29:29.010Z",
+        "license_hint": "unknown",
+        "hash": "sha1:49218369f03623dfef92d46ebf1828dcc1c0f0a2"
+      },
+      "meta": {
+        "provenance": {
+          "source": "dataset",
+          "collected_at": "2025-09-13T15:29:29.010Z",
+          "license_hint": "unknown",
+          "hash": "sha1:49218369f03623dfef92d46ebf1828dcc1c0f0a2"
+        }
+      },
+      "difficulty": 4
     }
   }
 }


### PR DESCRIPTION
Auto pipeline (harvest→score→generate) for (today JST).

- Writes `public/app/daily_auto.json` (separate from existing daily.json)
- 30-day dedup within the auto file

Default-off; merging does not affect current daily.json pipeline.