### PR TITLE
chore(workflow): add media guard and defaults

### DIFF
--- a/.github/workflows/daily-auto.yml
+++ b/.github/workflows/daily-auto.yml
@@ -11,10 +11,12 @@ on:
         description: 'Attach multiple-choice distractors (composer/game) to output'
         required: false
         type: boolean
+        default: false
       allow_heuristic_media:
         description: 'If no media exists, create heuristic media with guessed start (safe default = false)'
         required: false
         type: boolean
+        default: true
       apply_to_main:
         description: 'Create PR to update public/app/daily_auto.json'
         required: false
@@ -145,6 +147,32 @@ jobs:
             lines.push(`- pick: (no entry for this date)`);
           }
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n')+'\n');
+          NODE
+
+      - name: Guard: pick has media when heuristic enabled
+        if: ${{ github.event.inputs.allow_heuristic_media == 'true' }}
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const raw = fs.readFileSync('public/app/daily_auto.json','utf-8');
+          const j = JSON.parse(raw);
+          const by = j.by_date || {};
+          const inp = (process.env.INPUT_DATE||'').trim();
+          const resolved = (process.env.RESOLVED_DATE||'').trim();
+          const TZ = 'Asia/Tokyo';
+          function todayJST(){
+            try { return new Date(new Date().toLocaleString('en-US', { timeZone: TZ })).toISOString().slice(0,10); }
+            catch { const d = new Date(); return new Date(d.getTime()+9*3600*1000).toISOString().slice(0,10); }
+          }
+          const date = (/^\d{4}-\d{2}-\d{2}$/.test(resolved) ? resolved :
+                        (/^\d{4}-\d{2}-\d{2}$/.test(inp) ? inp : todayJST()));
+          const v = by[date];
+          if (!v) { console.error('no entry for date', date); process.exit(1); }
+          if (!v.media || !v.media.kind) {
+            console.error('media is missing for date', date, 'pick:', v.title, '/', v.game, '/', v.composer);
+            process.exit(1);
+          }
+          console.log('media present:', v.media);
           NODE
 
       - name: Summary (flags)


### PR DESCRIPTION
## Summary
- ensure daily auto workflow requires media when heuristic media is allowed
- add defaults for with_choices and allow_heuristic_media flags

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c634a9e5b083248d585f73b45a43d3