### PR TITLE
chore: quote guard step name

### DIFF
--- a/.github/workflows/daily-auto.yml
+++ b/.github/workflows/daily-auto.yml
@@ -208,7 +208,7 @@ jobs:
             echo "- with_choices: ${WITH_CHOICES}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Guard: pick has media when heuristic enabled
+      - name: "Guard: pick has media when heuristic enabled"
         if: ${{ github.event.inputs.allow_heuristic_media == 'true' }}
         run: |
           node - <<'NODE'


### PR DESCRIPTION
## Summary
- quote guard step name in daily-auto workflow

## Testing
- `npm test` *(fails: clojure: not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c64126e5b8832499ff3adbdf37cd91