### PR TITLE
Allow heuristic media guard to continue on error

### DIFF
--- a/.github/workflows/daily-auto.yml
+++ b/.github/workflows/daily-auto.yml
@@ -210,6 +210,7 @@ jobs:
 
       - name: "Guard: pick has media when heuristic enabled"
         if: ${{ github.event.inputs.allow_heuristic_media == 'true' }}
+        continue-on-error: true
         run: |
           node - <<'NODE'
           const fs = require('fs');


### PR DESCRIPTION
## Summary
- allow heuristic media guard failure without failing workflow

## Testing
- `npm test` *(fails: sh: 1: clojure: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c64c61ec2c8324af085dd8c46d248f