### PR TITLE
chore(daily-auto): update daily_auto.json

### DIFF
--- a/public/app/daily_auto.json
+++ b/public/app/daily_auto.json
@@ -111,14 +111,14 @@
       },
       "provenance": {
         "source": "dataset",
-        "collected_at": "2025-09-14T05:08:12.864Z",
+        "collected_at": "2025-09-14T05:59:15.173Z",
         "license_hint": "unknown",
         "hash": "sha1:0a13cf1663e1fcf0a4273ab2b27d0a9980ea227b"
       },
       "meta": {
         "provenance": {
           "source": "dataset",
-          "collected_at": "2025-09-14T05:08:12.864Z",
+          "collected_at": "2025-09-14T05:59:15.173Z",
           "license_hint": "unknown",
           "hash": "sha1:0a13cf1663e1fcf0a4273ab2b27d0a9980ea227b"
         }


### PR DESCRIPTION
Auto pipeline (harvest→score→generate) for (today JST).

- Writes `public/app/daily_auto.json` (separate from existing daily.json)
- 30-day dedup within the auto file

Default-off; merging does not affect current daily.json pipeline.